### PR TITLE
Fix parse_duration negatives and ISO 8601 sign (Issue #24)

### DIFF
--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -146,11 +146,10 @@ def parse_duration(value):
         minutes_s = kw.get('minutes')
         seconds_s = kw.get('seconds') or ''
 
-        # Reject mixed-sign forms like "1 days, -2:03:04" (positive days, negative time).
+        # Reject mixed-sign forms like "1 days, -2:03:04" (positive days with negative time).
         if days_str is not None and not str(days_str).startswith('-'):
-            if (hours_s and str(hours_s).startswith('-')) or (
-                minutes_s and str(minutes_s).startswith('-')
-            ) or str(seconds_s).startswith('-'):
+            time_parts = [p for p in (hours_s, minutes_s, seconds_s) if p]
+            if any(str(p).startswith('-') for p in time_parts):
                 return None
 
         # Reject minus signs in components after any colon.

--- a/django/utils/dateparse.py
+++ b/django/utils/dateparse.py
@@ -130,33 +130,45 @@ def parse_duration(value):
     format.
     """
     # Prefer standard duration handling first to implement stricter minus rules.
+    def _normalize_time_parts(parts):
+        """Normalize microseconds padding and sign based on seconds sign."""
+        d = dict(parts)
+        if d.get('microseconds'):
+            d['microseconds'] = d['microseconds'].ljust(6, '0')
+        if d.get('seconds') and d.get('microseconds') and str(d['seconds']).startswith('-'):
+            d['microseconds'] = '-' + d['microseconds']
+        return {k: float(v) for k, v in d.items() if v is not None}
     std_match = standard_duration_re.match(value)
     if std_match:
-        # Reject any minus sign appearing after a colon.
-        if ':-' in value:
-            return None
-        # Reject double leading minus.
-        if value.startswith('--'):
-            return None
-
         kw = std_match.groupdict()
         days_str = kw.get('days')
+        hours_s = kw.get('hours')
+        minutes_s = kw.get('minutes')
+        seconds_s = kw.get('seconds') or ''
 
         # Reject mixed-sign forms like "1 days, -2:03:04" (positive days, negative time).
-        if days_str is not None and not days_str.startswith('-'):
-            hours_s = kw.get('hours') or ''
-            minutes_s = kw.get('minutes') or ''
-            seconds_s = kw.get('seconds') or ''
-            if hours_s.startswith('-') or minutes_s.startswith('-') or seconds_s.startswith('-'):
+        if days_str is not None and not str(days_str).startswith('-'):
+            if (hours_s and str(hours_s).startswith('-')) or (
+                minutes_s and str(minutes_s).startswith('-')
+            ) or str(seconds_s).startswith('-'):
                 return None
 
-        # Apply a single leading minus to negate entire time-only duration.
+        # Reject minus signs in components after any colon.
+        # - For H:M:S, minutes and seconds cannot be negative.
+        # - For M:S (no hours), seconds cannot be negative.
+        if hours_s is not None:
+            if (minutes_s and str(minutes_s).startswith('-')) or str(seconds_s).startswith('-'):
+                return None
+        elif minutes_s is not None:
+            if str(seconds_s).startswith('-'):
+                return None
+
+        # Apply a single leading minus to negate entire time-only duration
+        # only for HH:MM:SS where hours == '00'. For MM:SS, preserve legacy
+        # behavior where only minutes may be negative.
         apply_global_sign = False
-        if days_str is None and value.startswith('-'):
-            colon_count = value.count(':')
-            # For SS or MM:SS always apply global sign; for HH:MM:SS apply it
-            # only when hours are zero-padded (e.g., "-00:01:01").
-            if colon_count <= 1 or (colon_count == 2 and value.startswith('-0')):
+        if days_str is None and value.startswith('-') and hours_s is not None:
+            if str(hours_s).lstrip('-') == '00':
                 apply_global_sign = True
 
         if apply_global_sign:
@@ -166,22 +178,13 @@ def parse_duration(value):
                 return None
             ukw = unsigned_match.groupdict()
             days = datetime.timedelta(float(ukw.pop('days', 0) or 0))
-            if ukw.get('microseconds'):
-                ukw['microseconds'] = ukw['microseconds'].ljust(6, '0')
-            if ukw.get('seconds') and ukw.get('microseconds') and ukw['seconds'].startswith('-'):
-                ukw['microseconds'] = '-' + ukw['microseconds']
-            ukw = {k: float(v) for k, v in ukw.items() if v is not None}
+            ukw = _normalize_time_parts(ukw)
             return -(days + datetime.timedelta(**ukw))
 
         # Default behavior preserves existing per-component signs.
         days = datetime.timedelta(float(kw.pop('days', 0) or 0))
-        # 'sign' only applies to ISO 8601/postgres formats.
         kw.pop('sign', None)
-        if kw.get('microseconds'):
-            kw['microseconds'] = kw['microseconds'].ljust(6, '0')
-        if kw.get('seconds') and kw.get('microseconds') and kw['seconds'].startswith('-'):
-            kw['microseconds'] = '-' + kw['microseconds']
-        kw = {k: float(v) for k, v in kw.items() if v is not None}
+        kw = _normalize_time_parts(kw)
         return days + datetime.timedelta(**kw)
 
     # ISO 8601: apply leading sign uniformly to all components including days.
@@ -190,11 +193,7 @@ def parse_duration(value):
         kw = iso_match.groupdict()
         sign = -1 if kw.pop('sign', '+') == '-' else 1
         days = float(kw.pop('days', 0) or 0)
-        if kw.get('microseconds'):
-            kw['microseconds'] = kw['microseconds'].ljust(6, '0')
-        if kw.get('seconds') and kw.get('microseconds') and kw['seconds'].startswith('-'):
-            kw['microseconds'] = '-' + kw['microseconds']
-        kw = {k: float(v) for k, v in kw.items() if v is not None}
+        kw = _normalize_time_parts(kw)
         total = datetime.timedelta(days=days, **kw)
         return sign * total
 
@@ -204,11 +203,7 @@ def parse_duration(value):
         kw = pg_match.groupdict()
         days = datetime.timedelta(float(kw.pop('days', 0) or 0))
         sign = -1 if kw.pop('sign', '+') == '-' else 1
-        if kw.get('microseconds'):
-            kw['microseconds'] = kw['microseconds'].ljust(6, '0')
-        if kw.get('seconds') and kw.get('microseconds') and kw['seconds'].startswith('-'):
-            kw['microseconds'] = '-' + kw['microseconds']
-        kw = {k: float(v) for k, v in kw.items() if v is not None}
+        kw = _normalize_time_parts(kw)
         return days + sign * datetime.timedelta(**kw)
 
     return None

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -145,8 +145,9 @@ The functions defined in this module share the following properties:
 
     Minus sign semantics:
     - A single leading minus may be used to negate the entire time-only value
-      (``SS`` or zero-padded ``HH:MM:SS`` such as ``-00:01:01``). For example,
-      ``-01:01`` equals ``-61`` seconds.
+      (``SS`` or zero-padded ``HH:MM:SS`` such as ``-00:01:01``). Global
+      negation does not apply to ``-MM:SS``; in that case, only the minutes
+      component is negative.
     - A minus sign is not allowed in components after a colon (e.g. ``00:-01``)
       and mixed-sign inputs like ``"1 days, -2:03:04"`` are rejected.
     - When no global leading minus is present, existing semantics are preserved:

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -143,6 +143,19 @@ The functions defined in this module share the following properties:
     8601 (e.g. ``P4DT1H15M20S`` which is equivalent to ``4 1:15:20``) or
     PostgreSQL's day-time interval format (e.g. ``3 days 04:05:06``).
 
+    Minus sign semantics:
+    - A single leading minus may be used to negate the entire time-only value
+      (``SS``, ``MM:SS``, or zero-padded ``HH:MM:SS`` such as ``-00:01:01``).
+      For example, ``-01:01`` equals ``-61`` seconds.
+    - A minus sign is not allowed in components after a colon (e.g. ``00:-01``)
+      and mixed-sign inputs like ``"1 days, -2:03:04"`` are rejected.
+    - When no global leading minus is present, existing semantics are preserved:
+      a leading minus on the first time component (e.g. ``-1:15:30``) denotes
+      a negative value for that component only, and negative days with positive
+      time (e.g. ``-4 15:30``) are accepted.
+    - For ISO 8601 durations, a leading sign applies uniformly to all
+      components including days (e.g. ``-P1D`` is ``-1`` day).
+
 ``django.utils.decorators``
 ===========================
 

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -145,14 +145,14 @@ The functions defined in this module share the following properties:
 
     Minus sign semantics:
     - A single leading minus may be used to negate the entire time-only value
-      (``SS``, ``MM:SS``, or zero-padded ``HH:MM:SS`` such as ``-00:01:01``).
-      For example, ``-01:01`` equals ``-61`` seconds.
+      (``SS`` or zero-padded ``HH:MM:SS`` such as ``-00:01:01``). For example,
+      ``-01:01`` equals ``-61`` seconds.
     - A minus sign is not allowed in components after a colon (e.g. ``00:-01``)
       and mixed-sign inputs like ``"1 days, -2:03:04"`` are rejected.
     - When no global leading minus is present, existing semantics are preserved:
-      a leading minus on the first time component (e.g. ``-1:15:30``) denotes
-      a negative value for that component only, and negative days with positive
-      time (e.g. ``-4 15:30``) are accepted.
+      a leading minus on the first time component (e.g. ``-1:15:30`` or
+      ``-15:30``) denotes a negative value for that component only, and
+      negative days with positive time (e.g. ``-4 15:30``) are accepted.
     - For ISO 8601 durations, a leading sign applies uniformly to all
       components including days (e.g. ``-P1D`` is ``-1`` day).
 

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -91,6 +91,8 @@ class DurationParseTests(unittest.TestCase):
         self.assertEqual(parse_duration('10:15:30'), timedelta(hours=10, minutes=15, seconds=30))
         self.assertEqual(parse_duration('1:15:30'), timedelta(hours=1, minutes=15, seconds=30))
         self.assertEqual(parse_duration('100:200:300'), timedelta(hours=100, minutes=200, seconds=300))
+        # Explicitly lock per-component behavior for '-HH:MM:SS' (negative hours only).
+        self.assertEqual(parse_duration('-01:02:03'), timedelta(hours=-1, minutes=2, seconds=3))
 
     def test_days(self):
         self.assertEqual(parse_duration('4 15:30'), timedelta(days=4, minutes=15, seconds=30))

--- a/tests/utils_tests/test_dateparse.py
+++ b/tests/utils_tests/test_dateparse.py
@@ -113,14 +113,15 @@ class DurationParseTests(unittest.TestCase):
         test_values = (
             ('-4 15:30', timedelta(days=-4, minutes=15, seconds=30)),
             ('-172800', timedelta(days=-2)),
-            # Leading minus negates entire MM:SS or SS.
-            ('-15:30', timedelta(seconds=-930)),
+            # Preserve legacy semantics for -MM:SS (minutes negative only).
+            ('-15:30', timedelta(minutes=-15, seconds=30)),
             # Preserve existing behavior for -H:MM:SS (no global sign).
             ('-1:15:30', timedelta(hours=-1, minutes=15, seconds=30)),
             ('-30.1', timedelta(seconds=-30, milliseconds=-100)),
             # Global sign on zero-padded hours for HH:MM:SS.
             ('-00:01:01', timedelta(seconds=-61)),
-            ('-01:01', timedelta(seconds=-61)),
+            # Legacy semantics for -MM:SS: minutes negative only.
+            ('-01:01', timedelta(minutes=-1, seconds=1)),
         )
         for source, expected in test_values:
             with self.subTest(source=source):

--- a/tests/utils_tests/test_duration.py
+++ b/tests/utils_tests/test_duration.py
@@ -87,6 +87,9 @@ class TestParseISODurationRoundtrip(unittest.TestCase):
             parse_duration('-P1DT01H03M05S'),
             -datetime.timedelta(days=1, hours=1, minutes=3, seconds=5),
         )
+        # Additional ISO cases
+        self.assertEqual(parse_duration('-P2DT03H'), -datetime.timedelta(days=2, hours=3))
+        self.assertEqual(parse_duration('-PT0.5S'), -datetime.timedelta(seconds=0.5))
 
 
 class TestDurationMicroseconds(unittest.TestCase):

--- a/tests/utils_tests/test_duration.py
+++ b/tests/utils_tests/test_duration.py
@@ -81,6 +81,12 @@ class TestParseISODurationRoundtrip(unittest.TestCase):
     def test_negative(self):
         duration = datetime.timedelta(days=-1, hours=1, minutes=3, seconds=5)
         self.assertEqual(parse_duration(duration_iso_string(duration)).total_seconds(), duration.total_seconds())
+        # Leading sign applies to entire ISO duration including days.
+        self.assertEqual(parse_duration('-P1D'), datetime.timedelta(days=-1))
+        self.assertEqual(
+            parse_duration('-P1DT01H03M05S'),
+            -datetime.timedelta(days=1, hours=1, minutes=3, seconds=5),
+        )
 
 
 class TestDurationMicroseconds(unittest.TestCase):


### PR DESCRIPTION
Recreating PR after resetting base branch per request. This PR implements Issue #24: fixes parse_duration() handling for negative durations in standard format (global minus for time-only where applicable; reject inner minus/mixed signs) and applies ISO 8601 leading sign uniformly to all components. Includes tests and docs updates. Do not merge until explicitly approved.