### PR TITLE
Add ModelAdmin.get_inlines(request, obj=None) hook and use it in get_inline_instances (swev-id: django__django-11095)

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -580,9 +580,19 @@ class ModelAdmin(BaseModelAdmin):
     def __str__(self):
         return "%s.%s" % (self.model._meta.app_label, self.__class__.__name__)
 
+    def get_inlines(self, request, obj=None):
+        """
+        Return a sequence of InlineModelAdmin classes that will be used.
+
+        By default, this returns the ``inlines`` attribute. Subclasses may
+        override this to compute the inlines dynamically based on the
+        ``request`` and/or the ``obj`` being edited (``None`` on add forms).
+        """
+        return self.inlines
+
     def get_inline_instances(self, request, obj=None):
         inline_instances = []
-        for inline_class in self.inlines:
+        for inline_class in self.get_inlines(request, obj):
             inline = inline_class(self.model, self.admin_site)
             if request:
                 if not (inline.has_view_or_change_permission(request, obj) or

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1608,14 +1608,35 @@ templates used by the :class:`ModelAdmin` views:
             def get_sortable_by(self, request):
                 return {*self.get_list_display(request)} - {'rank'}
 
+.. method:: ModelAdmin.get_inlines(request, obj=None)
+
+    The ``get_inlines`` method is given the ``HttpRequest`` and the ``obj``
+    being edited (or ``None`` on an add form) and is expected to return an
+    iterable of :class:`~django.contrib.admin.InlineModelAdmin` **classes**
+    that should be used. The default implementation returns the classes listed
+    in :attr:`inlines`.
+
+    Override this method when the set of inline classes should be determined
+    dynamically based on the current user or object. The instances returned by
+    :meth:`get_inline_instances` will be created from these classes, and the
+    usual permission-based filtering still applies there.
+
 .. method:: ModelAdmin.get_inline_instances(request, obj=None)
 
-    The ``get_inline_instances`` method is given the ``HttpRequest`` and the
-    ``obj`` being edited (or ``None`` on an add form) and is expected to return
-    a ``list`` or ``tuple`` of :class:`~django.contrib.admin.InlineModelAdmin`
-    objects, as described below in the :class:`~django.contrib.admin.InlineModelAdmin`
-    section. For example, the following would return inlines without the default
-    filtering based on add, change, delete, and view permissions::
+    The ``get_inline_instances`` method instantiates each inline class returned
+    by :meth:`get_inlines` and applies the default filtering based on add,
+    change, delete, and view permissions. It returns a ``list`` or ``tuple`` of
+    :class:`~django.contrib.admin.InlineModelAdmin` objects, as described below
+    in the :class:`~django.contrib.admin.InlineModelAdmin` section.
+
+    Overriding this method is rarely required now that you can customize the
+    set of inline classes in :meth:`get_inlines`. If you do override it, make
+    sure that the returned inlines are instances of the classes defined in
+    :attr:`inlines` (or those returned by :meth:`get_inlines`) or you might
+    encounter a "Bad Request" error when adding related objects.
+
+    For example, the following would return inlines without the default
+    permission filtering::
 
         class MyModelAdmin(admin.ModelAdmin):
             inlines = (MyInline,)

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -46,6 +46,9 @@ Minor features
 
 * Added support for the ``admin_order_field`` attribute on properties in
   :attr:`.ModelAdmin.list_display`.
+* Added the :meth:`~django.contrib.admin.ModelAdmin.get_inlines` hook for
+  selecting inline classes dynamically while preserving default permission
+  filtering in :meth:`~django.contrib.admin.ModelAdmin.get_inline_instances`.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -719,6 +719,116 @@ class ModelAdminTests(TestCase):
         self.assertEqual(perms_needed, {'band'})
         self.assertEqual(protected, [])
 
+    def test_get_inlines_default_returns_attribute(self):
+        class ConcertInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class BandAdmin(ModelAdmin):
+            inlines = [ConcertInline]
+
+        ma = BandAdmin(Band, self.site)
+        mock_request = MockRequest()
+        self.assertEqual(ma.get_inlines(mock_request), [ConcertInline])
+
+    def test_dynamic_inlines_based_on_request_and_obj(self):
+        class SongInline(TabularInline):
+            model = Song
+
+        class ConcertInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class DynamicBandAdmin(ModelAdmin):
+            # Default inlines contain both, but get_inlines will filter dynamically.
+            inlines = [SongInline, ConcertInline]
+
+            def get_inlines(self, request, obj=None):
+                inlines = []
+                if getattr(request.user, 'is_superuser', False):
+                    inlines.append(ConcertInline)
+                if obj is not None:
+                    inlines.append(SongInline)
+                return inlines
+
+        class InlineUser:
+            def __init__(self, *, is_superuser=False):
+                self.is_superuser = is_superuser
+
+            def has_perm(self, perm):
+                return True
+
+        ma = DynamicBandAdmin(Band, self.site)
+        mock_request = MockRequest()
+        mock_request.user = InlineUser()
+
+        # Not superuser and no obj: no inlines.
+        self.assertEqual(ma.get_inline_instances(mock_request), [])
+
+        # Not superuser but with obj: SongInline only.
+        inline_instances = ma.get_inline_instances(mock_request, self.band)
+        self.assertEqual(len(inline_instances), 1)
+        self.assertIsInstance(inline_instances[0], SongInline)
+
+        # Superuser and no obj: ConcertInline only.
+        mock_request.user = InlineUser(is_superuser=True)
+        inline_instances = ma.get_inline_instances(mock_request)
+        self.assertEqual(len(inline_instances), 1)
+        self.assertIsInstance(inline_instances[0], ConcertInline)
+
+        # Superuser and obj present: both inlines.
+        inline_instances = ma.get_inline_instances(mock_request, self.band)
+        self.assertEqual({type(i) for i in inline_instances}, {SongInline, ConcertInline})
+
+    def test_get_inline_instances_filters_inlines_without_permissions(self):
+        class RestrictedSongInline(TabularInline):
+            model = Song
+            max_num = 1
+
+            def has_view_or_change_permission(self, request, obj=None):
+                return getattr(request.user, 'can_view_song_inline', False)
+
+            def has_add_permission(self, request, obj=None):
+                return getattr(request.user, 'can_add_song_inline', False)
+
+            def has_delete_permission(self, request, obj=None):
+                return getattr(request.user, 'can_delete_song_inline', False)
+
+        class DynamicBandAdmin(ModelAdmin):
+            inlines = [RestrictedSongInline]
+
+            def get_inlines(self, request, obj=None):
+                return [RestrictedSongInline]
+
+        ma = DynamicBandAdmin(Band, self.site)
+        mock_request = MockRequest()
+
+        class NoInlinePermissions:
+            can_view_song_inline = False
+            can_add_song_inline = False
+            can_delete_song_inline = False
+
+        mock_request.user = NoInlinePermissions()
+        self.assertEqual(ma.get_inline_instances(mock_request, self.band), [])
+
+        class ViewInlinePermissions(NoInlinePermissions):
+            can_view_song_inline = True
+
+        mock_request.user = ViewInlinePermissions()
+        inline_instances = ma.get_inline_instances(mock_request, self.band)
+        self.assertEqual(len(inline_instances), 1)
+        inline = inline_instances[0]
+        self.assertIsInstance(inline, RestrictedSongInline)
+        self.assertEqual(inline.max_num, 0)
+
+        class AddInlinePermissions(ViewInlinePermissions):
+            can_add_song_inline = True
+
+        mock_request.user = AddInlinePermissions()
+        inline_instances = ma.get_inline_instances(mock_request, self.band)
+        self.assertEqual(len(inline_instances), 1)
+        self.assertEqual(inline_instances[0].max_num, RestrictedSongInline.max_num)
+
 
 class ModelAdminPermissionTests(SimpleTestCase):
 
@@ -854,55 +964,3 @@ class ModelAdminPermissionTests(SimpleTestCase):
             self.assertFalse(ma.has_module_permission(request))
         finally:
             ma.opts.app_label = original_app_label
-
-    def test_get_inlines_default_returns_attribute(self):
-        class ConcertInline(TabularInline):
-            model = Concert
-            fk_name = 'main_band'
-
-        class BandAdmin(ModelAdmin):
-            inlines = [ConcertInline]
-
-        ma = BandAdmin(Band, self.site)
-        self.assertEqual(ma.get_inlines(request), [ConcertInline])
-
-    def test_dynamic_inlines_based_on_request_and_obj(self):
-        class SongInline(TabularInline):
-            model = Song
-
-        class ConcertInline(TabularInline):
-            model = Concert
-            fk_name = 'main_band'
-
-        class DynamicBandAdmin(ModelAdmin):
-            # Default inlines contain both, but get_inlines will filter dynamically.
-            inlines = [SongInline, ConcertInline]
-
-            def get_inlines(self, request, obj=None):
-                inlines = []
-                if getattr(request.user, 'is_superuser', False):
-                    inlines.append(ConcertInline)
-                if obj is not None:
-                    inlines.append(SongInline)
-                return inlines
-
-        ma = DynamicBandAdmin(Band, self.site)
-        # Not superuser and no obj: no inlines.
-        mock_request = MockRequest()
-        mock_request.user = User.objects.create(username='regular')
-        self.assertEqual(ma.get_inline_instances(mock_request), [])
-
-        # Not superuser but with obj: SongInline only.
-        inline_instances = ma.get_inline_instances(mock_request, self.band)
-        self.assertEqual(len(inline_instances), 1)
-        self.assertIsInstance(inline_instances[0], SongInline)
-
-        # Superuser and no obj: ConcertInline only.
-        mock_request.user = User.objects.create_superuser('admin', 'a@example.com', 'x')
-        inline_instances = ma.get_inline_instances(mock_request)
-        self.assertEqual(len(inline_instances), 1)
-        self.assertIsInstance(inline_instances[0], ConcertInline)
-
-        # Superuser and obj present: both inlines.
-        inline_instances = ma.get_inline_instances(mock_request, self.band)
-        self.assertEqual({type(i) for i in inline_instances}, {SongInline, ConcertInline})

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -854,3 +854,55 @@ class ModelAdminPermissionTests(SimpleTestCase):
             self.assertFalse(ma.has_module_permission(request))
         finally:
             ma.opts.app_label = original_app_label
+
+    def test_get_inlines_default_returns_attribute(self):
+        class ConcertInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class BandAdmin(ModelAdmin):
+            inlines = [ConcertInline]
+
+        ma = BandAdmin(Band, self.site)
+        self.assertEqual(ma.get_inlines(request), [ConcertInline])
+
+    def test_dynamic_inlines_based_on_request_and_obj(self):
+        class SongInline(TabularInline):
+            model = Song
+
+        class ConcertInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class DynamicBandAdmin(ModelAdmin):
+            # Default inlines contain both, but get_inlines will filter dynamically.
+            inlines = [SongInline, ConcertInline]
+
+            def get_inlines(self, request, obj=None):
+                inlines = []
+                if getattr(request.user, 'is_superuser', False):
+                    inlines.append(ConcertInline)
+                if obj is not None:
+                    inlines.append(SongInline)
+                return inlines
+
+        ma = DynamicBandAdmin(Band, self.site)
+        # Not superuser and no obj: no inlines.
+        mock_request = MockRequest()
+        mock_request.user = User.objects.create(username='regular')
+        self.assertEqual(ma.get_inline_instances(mock_request), [])
+
+        # Not superuser but with obj: SongInline only.
+        inline_instances = ma.get_inline_instances(mock_request, self.band)
+        self.assertEqual(len(inline_instances), 1)
+        self.assertIsInstance(inline_instances[0], SongInline)
+
+        # Superuser and no obj: ConcertInline only.
+        mock_request.user = User.objects.create_superuser('admin', 'a@example.com', 'x')
+        inline_instances = ma.get_inline_instances(mock_request)
+        self.assertEqual(len(inline_instances), 1)
+        self.assertIsInstance(inline_instances[0], ConcertInline)
+
+        # Superuser and obj present: both inlines.
+        inline_instances = ma.get_inline_instances(mock_request, self.band)
+        self.assertEqual({type(i) for i in inline_instances}, {SongInline, ConcertInline})


### PR DESCRIPTION
Implements a new ModelAdmin.get_inlines(request, obj=None) hook to determine inline classes dynamically based on the request or object. Refactors get_inline_instances() to call get_inlines(). Adds unit tests for dynamic inlines behavior. No backward-incompatible changes; default behavior remains unchanged.