### PR TITLE
Allow migrations directories without __init__.py (swev-id: django__django-11141)

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -84,12 +84,11 @@ class MigrationLoader:
                     continue
                 raise
             else:
-                # Empty directories are namespaces.
-                # getattr() needed on PY36 and older (replace w/attribute access).
-                if getattr(module, '__file__', None) is None:
-                    self.unmigrated_apps.add(app_config.label)
-                    continue
-                # Module is not a package (e.g. migrations.py).
+                # Allow implicit namespace packages for the migrations module.
+                # Migration discovery relies on pkgutil.iter_modules() which
+                # uses the module's __path__, available on both regular and
+                # namespace packages. Reject only non-packages (e.g. a
+                # single migrations.py module) which won't have __path__.
                 if not hasattr(module, '__path__'):
                     self.unmigrated_apps.add(app_config.label)
                     continue


### PR DESCRIPTION
Allow migrations directories without __init__.py files

Background
- In Python 3, a package directory without an __init__.py is an implicit namespace package and has no __file__ attribute.
- Django's migration discovery previously guarded against empty directories by checking for module.__file__. That guard became unnecessary after migration discovery switched to pkgutil.iter_modules(), which uses the module's __path__ (available for both regular and namespace packages).
- The __file__ check prevents Django from recognizing migrations packages implemented as implicit namespace packages.

What changed
- In django/db/migrations/loader.py, remove the check that rejected migrations modules lacking __file__.
- Keep the guard that rejects non-packages (e.g., a single migrations.py module) by checking for the presence of __path__.

Rationale
- pkgutil.iter_modules(module.__path__) correctly discovers migration modules for both regular and namespace packages. Requiring __file__ blocks valid Python 3 namespace packages.

Observed failure before this change
- Behavior: migrations in an app are silently ignored when the app's migrations directory lacks __init__.py, resulting in "No migrations to apply" even though migration files exist.
- Root cause: MigrationLoader.load_disk() rejects the app's migrations module because getattr(module, "__file__", None) is None for implicit namespace packages, adding the app to unmigrated_apps.

Reproduction steps (before fix)
1. Ensure Python 3.4+ (implicit namespace packages supported) and use the Django branch without this fix.
2. Create a minimal project and app:
   - app1/__init__.py (empty)
   - app1/apps.py:
     from django.apps import AppConfig
     class App1Config(AppConfig):
         name = 'app1'
   - app1/migrations/ (no __init__.py)
   - app1/migrations/0001_initial.py containing a basic Migration with a CreateModel operation.
   - settings.py with INSTALLED_APPS = ['django.contrib.contenttypes','django.contrib.auth','app1.apps.App1Config'] and SQLite DB.
3. Run: python manage.py migrate app1 -v 2
4. Actual result (before fix): Output reports "No migrations to apply" for app1; app1 is treated as unmigrated because its migrations module lacks __file__.
5. Expected result: The migration 0001_initial should be discovered and applied.

Stack trace
- None. This is a functional issue where migration discovery incorrectly excludes the app; no exception is raised.

After this change
- Running the same steps discovers app1.migrations.0001_initial via pkgutil.iter_modules(module.__path__) and applies it as expected.

Related
- Follow-up to the migration discovery change in #23406; removes the stale guard added in #21015. Related to #29091.

Notes
- This PR targets branch django__django-11141.
- CI should not be manually triggered as per task instructions; opening the PR may still trigger CI automatically.
