### PR TITLE
swev-id: django__django-11141 Allow migrations directories without __init__.py files

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -84,11 +84,6 @@ class MigrationLoader:
                     continue
                 raise
             else:
-                # Empty directories are namespaces.
-                # getattr() needed on PY36 and older (replace w/attribute access).
-                if getattr(module, '__file__', None) is None:
-                    self.unmigrated_apps.add(app_config.label)
-                    continue
                 # Module is not a package (e.g. migrations.py).
                 if not hasattr(module, '__path__'):
                     self.unmigrated_apps.add(app_config.label)

--- a/tests/migrations/namespace_migrations/0001_initial.py
+++ b/tests/migrations/namespace_migrations/0001_initial.py
@@ -1,0 +1,6 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    initial = True
+    dependencies = []
+    operations = []

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -189,6 +189,17 @@ class LoaderTests(TestCase):
                 "App with migrations module file not in unmigrated apps."
             )
 
+    def test_namespace_package_with_migration(self):
+        """
+        A migrations module that's a namespace package (no __init__.py)
+        with actual migration files should be loaded by the MigrationLoader.
+        """
+        with override_settings(MIGRATION_MODULES={"migrations": "migrations.namespace_migrations"}):
+            loader = MigrationLoader(connection)
+            self.assertNotIn("migrations", loader.unmigrated_apps)
+            # The graph should contain the namespace migration.
+            self.assertIn(("migrations", "0001_initial"), loader.graph.nodes)
+
     def test_load_empty_dir(self):
         with override_settings(MIGRATION_MODULES={"migrations": "migrations.faulty_migrations.namespace"}):
             loader = MigrationLoader(connection)

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -192,9 +192,9 @@ class LoaderTests(TestCase):
     def test_load_empty_dir(self):
         with override_settings(MIGRATION_MODULES={"migrations": "migrations.faulty_migrations.namespace"}):
             loader = MigrationLoader(connection)
-            self.assertIn(
+            self.assertNotIn(
                 "migrations", loader.unmigrated_apps,
-                "App missing __init__.py in migrations module not in unmigrated apps."
+                "Namespace package migrations module incorrectly marked as unmigrated."
             )
 
     @override_settings(


### PR DESCRIPTION
Summary
- Remove a legacy __file__ check in MigrationLoader that incorrectly marks namespace package migrations modules (no __init__.py) as unmigrated.
- pkgutil.iter_modules() relies on the module's __path__, which exists for implicit namespace packages in Python 3, so the __file__ guard is no longer needed.

Changes
- django/db/migrations/loader.py: drop getattr(module, '__file__', None) is None check; retain the "not a package" guard (no __path__).
- tests/migrations/test_loader.py:
  - Update empty dir (namespace) expectation to be considered valid (not in unmigrated_apps).
  - Add test_namespace_package_with_migration to ensure a migration in a namespace package is discovered and loaded.
- tests/migrations/namespace_migrations/0001_initial.py: new minimal migration placed in a namespace package (no __init__.py).

Observed failure (before fix)
Reproduction steps (run in repo root, Python 3.12+; ensure local path includes this django checkout and tests):

1) Create a minimal script (or use the one below) to initialize Django apps registry with the tests 'migrations' app and point MIGRATION_MODULES to a namespace package containing a migration:

from pathlib import Path
import sys
sys.path.insert(0, str(Path.cwd()))
sys.path.insert(0, str(Path.cwd() / 'tests'))
from django.conf import settings
settings.configure(SECRET_KEY='x', INSTALLED_APPS=['migrations'])
import django; django.setup()
from django.test.utils import override_settings
from django.db.migrations.loader import MigrationLoader
with override_settings(MIGRATION_MODULES={'migrations': 'migrations.namespace_migrations'}):
    loader = MigrationLoader(connection=None)
    assert ('migrations', '0001_initial') in loader.graph.nodes

2) On the original branch (before this fix), running this script fails as the loader marks the app as unmigrated due to the __file__ check and doesn't load the migration.

Actual captured output before fix:

unmigrated: {'migrations'}
migrations nodes: []
Traceback (most recent call last):
  File "<stdin>", line 20, in <module>
AssertionError: Expected 0001_initial to be loaded

After fix
- The same script reports:
  unmigrated: set()
  migrations nodes: [('migrations', '0001_initial')]
  and the assertion passes.

Notes
- This aligns migration discovery with Python 3 implicit namespace packages and removes an obsolete guard introduced when discovery depended on __file__ (pre-#23406).

Related tickets: #21015, #23406, #29091.
