### PR TITLE
swev-id: django__django-11206 fix tiny decimal formatting

### DIFF
--- a/django/utils/numberformat.py
+++ b/django/utils/numberformat.py
@@ -29,8 +29,14 @@ def format(number, decimal_sep, decimal_pos=None, grouping=0, thousand_sep='',
     if isinstance(number, Decimal):
         # Format values with more than 200 digits (an arbitrary cutoff) using
         # scientific notation to avoid high memory usage in {:f}'.format().
-        _, digits, exponent = number.as_tuple()
+        sign_flag, digits, exponent = number.as_tuple()
         if abs(exponent) + len(digits) > 200:
+            if decimal_pos is not None and number.adjusted() < -decimal_pos:
+                zero = format(
+                    '0', decimal_sep, decimal_pos, grouping,
+                    thousand_sep, force_grouping, use_l10n,
+                )
+                return ('-' if sign_flag else '') + zero
             number = '{:e}'.format(number)
             coefficient, exponent = number.split('e')
             # Format the coefficient.

--- a/tests/utils_tests/test_numberformat.py
+++ b/tests/utils_tests/test_numberformat.py
@@ -70,6 +70,17 @@ class TestNumberFormat(SimpleTestCase):
         self.assertEqual(nformat(Decimal('0.00000001'), '.', decimal_pos=8), '0.00000001')
         self.assertEqual(nformat(Decimal('9e-19'), '.', decimal_pos=2), '0.00')
         self.assertEqual(nformat(Decimal('.00000000000099'), '.', decimal_pos=0), '0')
+        self.assertEqual(nformat(Decimal('1e-199'), '.', decimal_pos=2), '0.00')
+        self.assertEqual(nformat(Decimal('1e-200'), '.', decimal_pos=2), '0.00')
+        self.assertEqual(nformat(Decimal('-1e-200'), '.', decimal_pos=2), '-0.00')
+        self.assertEqual(nformat(Decimal('1e-200'), '.', decimal_pos=0), '0')
+        self.assertEqual(
+            nformat(
+                Decimal('1e-200'), '.', decimal_pos=2,
+                thousand_sep=',', grouping=3, force_grouping=True,
+            ),
+            '0.00'
+        )
         self.assertEqual(
             nformat(Decimal('1e16'), '.', thousand_sep=',', grouping=3, force_grouping=True),
             '10,000,000,000,000,000'
@@ -94,7 +105,7 @@ class TestNumberFormat(SimpleTestCase):
             ('1e-10', 8, '0.00000000'),
             ('1e-11', 8, '0.00000000'),
             ('1' + ('0' * 300), 3, '1.000e+300'),
-            ('0.{}1234'.format('0' * 299), 3, '1.234e-300'),
+            ('0.{}1234'.format('0' * 299), 3, '0.000'),
         ]
         for value, decimal_pos, expected_value in tests:
             with self.subTest(value=value):


### PR DESCRIPTION
$Fix django.utils.numberformat.format to avoid scientific notation for extreme tiny Decimals when decimal_pos is set.

Observed failure and reproduction:
>>> from decimal import Decimal
>>> from django.utils.numberformat import format as nformat
>>> nformat(Decimal("1e-199"), ".", decimal_pos=2)
"0.00"
>>> nformat(Decimal("1e-200"), ".", decimal_pos=2)
"1.00e-200"  # incorrect; should be fixed-point zero with given precision.

Change:
- In Decimal cutoff branch, when decimal_pos is provided and the most significant digit lies beyond the requested decimal places, return fixed-point zeros (preserving sign) instead of scientific notation.

Tests:
- Added cases for tiny positive/negative values, decimal_pos=0, and grouping.

Notes:
- Commit message includes [skip ci]; no CI run.
- References issue #55.