### PR TITLE
fix: ensure DISTINCT CASE spacing (swev-id: django__django-10880)

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -68,7 +68,7 @@ class Aggregate(Func):
         return []
 
     def as_sql(self, compiler, connection, **extra_context):
-        extra_context['distinct'] = 'DISTINCT' if self.distinct else ''
+        extra_context['distinct'] = 'DISTINCT ' if self.distinct else ''
         if self.filter:
             if connection.features.supports_aggregate_filter_clause:
                 filter_sql, filter_params = self.filter.as_sql(compiler, connection)

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -149,6 +149,21 @@ class AggregateTestCase(TestCase):
         vals = Store.objects.filter(name="Amazon.com").aggregate(amazon_mean=Avg("books__rating"))
         self.assertEqual(vals, {'amazon_mean': Approximate(4.08, places=2)})
 
+    def test_count_distinct_case_spacing(self):
+        from django.db.models import Case, Count, IntegerField, When
+        from .models import Author
+
+        qs = Author.objects.annotate(
+            c=Count(
+                Case(
+                    When(age__gte=0, then=1),
+                    output_field=IntegerField(),
+                ),
+                distinct=True,
+            )
+        )
+        self.assertIn('DISTINCT CASE', str(qs.query))
+
     def test_annotate_basic(self):
         self.assertQuerysetEqual(
             Book.objects.annotate().order_by('pk'), [


### PR DESCRIPTION
## Summary
- add trailing space to DISTINCT context in `Aggregate.as_sql()`
- add regression test ensuring COUNT(DISTINCT CASE ...) renders correctly

## Testing
- PYTHONPATH=/workspace . /workspace/.venv/bin/activate && ./tests/runtests.py aggregation.tests.AggregateTestCase.test_count_distinct_case_spacing --parallel=1
- PYTHONPATH=/workspace . /workspace/.venv/bin/activate && ./tests/runtests.py aggregation --parallel=1
- . /workspace/.venv/bin/activate && flake8 django/db/models/aggregates.py tests/aggregation/tests.py

Fixes #83