### PR TITLE
fix: swev-id: django__django-10973 set postgres client password via env

### DIFF
--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -30,6 +30,7 @@ class DatabaseClient(BaseDatabaseClient):
         try:
             custom_env = os.environ.copy()
             if passwd is not None:
+                custom_env.pop('PGPASSFILE', None)
                 custom_env['PGPASSWORD'] = passwd
             # Allow SIGINT to pass to psql to abort queries.
             signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -2,15 +2,7 @@ import os
 import signal
 import subprocess
 
-from django.core.files.temp import NamedTemporaryFile
 from django.db.backends.base.client import BaseDatabaseClient
-
-
-def _escape_pgpass(txt):
-    """
-    Escape a fragment of a PostgreSQL .pgpass file.
-    """
-    return txt.replace('\\', '\\\\').replace(':', '\\:')
 
 
 class DatabaseClient(BaseDatabaseClient):
@@ -24,7 +16,7 @@ class DatabaseClient(BaseDatabaseClient):
         port = conn_params.get('port', '')
         dbname = conn_params.get('database', '')
         user = conn_params.get('user', '')
-        passwd = conn_params.get('password', '')
+        passwd = conn_params.get('password')
 
         if user:
             args += ['-U', user]
@@ -34,38 +26,17 @@ class DatabaseClient(BaseDatabaseClient):
             args += ['-p', str(port)]
         args += [dbname]
 
-        temp_pgpass = None
         sigint_handler = signal.getsignal(signal.SIGINT)
         try:
-            if passwd:
-                # Create temporary .pgpass file.
-                temp_pgpass = NamedTemporaryFile(mode='w+')
-                try:
-                    print(
-                        _escape_pgpass(host) or '*',
-                        str(port) or '*',
-                        _escape_pgpass(dbname) or '*',
-                        _escape_pgpass(user) or '*',
-                        _escape_pgpass(passwd),
-                        file=temp_pgpass,
-                        sep=':',
-                        flush=True,
-                    )
-                    os.environ['PGPASSFILE'] = temp_pgpass.name
-                except UnicodeEncodeError:
-                    # If the current locale can't encode the data, let the
-                    # user input the password manually.
-                    pass
+            custom_env = os.environ.copy()
+            if passwd is not None:
+                custom_env['PGPASSWORD'] = passwd
             # Allow SIGINT to pass to psql to abort queries.
             signal.signal(signal.SIGINT, signal.SIG_IGN)
-            subprocess.check_call(args)
+            subprocess.run(args, check=True, env=custom_env)
         finally:
             # Restore the original SIGINT handler.
             signal.signal(signal.SIGINT, sigint_handler)
-            if temp_pgpass:
-                temp_pgpass.close()
-                if 'PGPASSFILE' in os.environ:  # unit tests need cleanup
-                    del os.environ['PGPASSFILE']
 
     def runshell(self):
         DatabaseClient.runshell_db(self.connection.get_connection_params())

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -143,6 +143,20 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
         self.assertEqual(original, 'from-env')
         self.assertEqual(current, 'from-env')
 
+    def test_password_prefer_pgpassword_without_pgpassfile(self):
+        pgpassfile_path = '/tmp/.pgpass-test'
+        with mock.patch.dict(os.environ, {'PGPASSFILE': pgpassfile_path}, clear=True):
+            args, env, original, current = self._run_it({
+                'database': 'dbname',
+                'password': 'pw-value',
+            })
+
+            self.assertEqual(args, ['psql', 'dbname'])
+            self.assertEqual(env['PGPASSWORD'], 'pw-value')
+            self.assertNotIn('PGPASSFILE', env)
+            self.assertEqual(os.environ['PGPASSFILE'], pgpassfile_path)
+            self.assertIs(original, current)
+
     def test_sigint_handler(self):
         """SIGINT is ignored in Python and passed to psql to abort queries."""
 

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -10,107 +10,151 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
 
     def _run_it(self, dbinfo):
         """
-        That function invokes the runshell command, while mocking
-        subprocess.call. It returns a 2-tuple with:
-        - The command line list
-        - The content of the file pointed by environment PGPASSFILE, or None.
+        Invoke the runshell command while mocking subprocess.run.
+        Returns a 4-tuple containing:
+        - The command arguments list
+        - The environment dict passed to subprocess.run
+        - The pre-call value of os.environ['PGPASSWORD'] (or a sentinel)
+        - The post-call value of os.environ['PGPASSWORD'] (or a sentinel)
         """
-        def _mock_subprocess_call(*args):
-            self.subprocess_args = list(*args)
-            if 'PGPASSFILE' in os.environ:
-                with open(os.environ['PGPASSFILE']) as f:
-                    self.pgpass = f.read().strip()  # ignore line endings
-            else:
-                self.pgpass = None
-            return 0
+
+        sentinel = object()
+        original_pgpassword = os.environ.get('PGPASSWORD', sentinel)
+
+        def _mock_subprocess_run(*args, **kwargs):
+            self.subprocess_args = list(args[0])
+            self.subprocess_env = kwargs['env']
+            self.subprocess_kwargs = kwargs
+            return mock.Mock(returncode=0)
+
         self.subprocess_args = None
-        self.pgpass = None
-        with mock.patch('subprocess.call', new=_mock_subprocess_call):
+        self.subprocess_env = None
+        self.subprocess_kwargs = None
+
+        with mock.patch('subprocess.run', side_effect=_mock_subprocess_run):
             DatabaseClient.runshell_db(dbinfo)
-        return self.subprocess_args, self.pgpass
+
+        current_pgpassword = os.environ.get('PGPASSWORD', sentinel)
+        return (
+            self.subprocess_args,
+            self.subprocess_env,
+            original_pgpassword,
+            current_pgpassword,
+        )
 
     def test_basic(self):
-        self.assertEqual(
-            self._run_it({
+        with mock.patch.dict(os.environ, {}, clear=True):
+            args, env, original, current = self._run_it({
                 'database': 'dbname',
                 'user': 'someuser',
                 'password': 'somepassword',
                 'host': 'somehost',
                 'port': '444',
-            }), (
-                ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
-                'somehost:444:dbname:someuser:somepassword',
-            )
+            })
+
+        self.assertEqual(
+            args,
+            ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
         )
+        self.assertIn('PGPASSWORD', env)
+        self.assertEqual(env['PGPASSWORD'], 'somepassword')
+        self.assertNotIn('PGPASSFILE', env)
+        self.assertIs(original, current)
+        self.assertIsNot(env, os.environ)
+        self.assertTrue(self.subprocess_kwargs['check'])
 
     def test_nopass(self):
-        self.assertEqual(
-            self._run_it({
+        with mock.patch.dict(os.environ, {}, clear=True):
+            args, env, original, current = self._run_it({
                 'database': 'dbname',
                 'user': 'someuser',
                 'host': 'somehost',
                 'port': '444',
-            }), (
-                ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
-                None,
-            )
+            })
+
+        self.assertEqual(
+            args,
+            ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
         )
+        self.assertNotIn('PGPASSWORD', env)
+        self.assertIs(original, current)
 
     def test_column(self):
-        self.assertEqual(
-            self._run_it({
+        with mock.patch.dict(os.environ, {}, clear=True):
+            args, env, original, current = self._run_it({
                 'database': 'dbname',
                 'user': 'some:user',
                 'password': 'some:password',
                 'host': '::1',
                 'port': '444',
-            }), (
-                ['psql', '-U', 'some:user', '-h', '::1', '-p', '444', 'dbname'],
-                '\\:\\:1:444:dbname:some\\:user:some\\:password',
-            )
+            })
+
+        self.assertEqual(
+            args,
+            ['psql', '-U', 'some:user', '-h', '::1', '-p', '444', 'dbname'],
         )
+        self.assertEqual(env['PGPASSWORD'], 'some:password')
+        self.assertIs(original, current)
 
     def test_escape_characters(self):
-        self.assertEqual(
-            self._run_it({
+        with mock.patch.dict(os.environ, {}, clear=True):
+            args, env, original, current = self._run_it({
                 'database': 'dbname',
                 'user': 'some\\user',
                 'password': 'some\\password',
                 'host': 'somehost',
                 'port': '444',
-            }), (
-                ['psql', '-U', 'some\\user', '-h', 'somehost', '-p', '444', 'dbname'],
-                'somehost:444:dbname:some\\\\user:some\\\\password',
-            )
+            })
+
+        self.assertEqual(
+            args,
+            ['psql', '-U', 'some\\user', '-h', 'somehost', '-p', '444', 'dbname'],
         )
+        self.assertEqual(env['PGPASSWORD'], 'some\\password')
+        self.assertIs(original, current)
 
     def test_accent(self):
         username = 'rôle'
         password = 'sésame'
-        pgpass_string = 'somehost:444:dbname:%s:%s' % (username, password)
-        self.assertEqual(
-            self._run_it({
+        with mock.patch.dict(os.environ, {}, clear=True):
+            args, env, original, current = self._run_it({
                 'database': 'dbname',
                 'user': username,
                 'password': password,
                 'host': 'somehost',
                 'port': '444',
-            }), (
-                ['psql', '-U', username, '-h', 'somehost', '-p', '444', 'dbname'],
-                pgpass_string,
-            )
+            })
+
+        self.assertEqual(
+            args,
+            ['psql', '-U', username, '-h', 'somehost', '-p', '444', 'dbname'],
         )
+        self.assertEqual(env['PGPASSWORD'], password)
+        self.assertIs(original, current)
+
+    def test_preserve_existing_pgpassword_when_missing(self):
+        with mock.patch.dict(os.environ, {'PGPASSWORD': 'from-env'}, clear=True):
+            args, env, original, current = self._run_it({
+                'database': 'dbname',
+            })
+
+        self.assertEqual(args, ['psql', 'dbname'])
+        self.assertEqual(env['PGPASSWORD'], 'from-env')
+        self.assertEqual(original, 'from-env')
+        self.assertEqual(current, 'from-env')
 
     def test_sigint_handler(self):
-        """SIGINT is ignored in Python and passed to psql to abort quries."""
-        def _mock_subprocess_call(*args):
+        """SIGINT is ignored in Python and passed to psql to abort queries."""
+
+        def _mock_subprocess_run(*args, **kwargs):
             handler = signal.getsignal(signal.SIGINT)
             self.assertEqual(handler, signal.SIG_IGN)
+            return mock.Mock(returncode=0)
 
         sigint_handler = signal.getsignal(signal.SIGINT)
         # The default handler isn't SIG_IGN.
         self.assertNotEqual(sigint_handler, signal.SIG_IGN)
-        with mock.patch('subprocess.check_call', new=_mock_subprocess_call):
+        with mock.patch('subprocess.run', new=_mock_subprocess_run):
             DatabaseClient.runshell_db({})
         # dbshell restores the original handler.
         self.assertEqual(sigint_handler, signal.getsignal(signal.SIGINT))


### PR DESCRIPTION
## Summary
- set PostgreSQL dbshell to pass passwords via subprocess.run env instead of .pgpass
- update dbshell tests to validate env handling and SIGINT behavior with mocks
- ensure external PGPASSWORD values propagate when no explicit password is provided

## Testing
- /workspace/.venv/bin/flake8 django/db/backends/postgresql/client.py tests/dbshell/test_postgresql.py
- PYTHONPATH=/workspace/django /workspace/.venv/bin/python ./runtests.py dbshell.test_postgresql

## Reproduction
- Configure a non-UTF-8 locale and supply a non-ASCII database password
- Original dbshell writes to a NamedTemporaryFile-based .pgpass path that can't encode the password
- psql is invoked without PGPASSFILE and terminates with `psql: error: fe_sendauth: no password supplied` (subprocess.CalledProcessError exit status 2)

## Rationale
- subprocess.run with an env copy avoids locale-dependent .pgpass encoding and sets PGPASSWORD explicitly while preserving existing error semantics

Fixes #80