### PR TITLE
Fix combinator query cloning (swev-id: django__django-10554)

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -931,7 +931,9 @@ class QuerySet:
         # Clear limits and ordering so they can be reapplied
         clone.query.clear_ordering(True)
         clone.query.clear_limits()
-        clone.query.combined_queries = (self.query,) + tuple(qs.query for qs in other_qs)
+        subqueries = [self.query.clone()]
+        subqueries.extend(qs.query.clone() for qs in other_qs)
+        clone.query.combined_queries = tuple(subqueries)
         clone.query.combinator = combinator
         clone.query.combinator_all = all
         return clone

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -153,6 +153,28 @@ class QuerySetSetOperationTests(TestCase):
         qs2 = Number.objects.filter(num=9)
         self.assertCountEqual(qs1.union(qs2).values_list('num', flat=True), [1, 9])
 
+    @skipUnlessDBFeature('supports_slicing_ordering_in_compound')
+    def test_union_reuse_after_values_list_evaluation(self):
+        qs = Number.objects.filter(num__lte=4).union(
+            Number.objects.filter(num__gte=5).order_by('id')
+        )
+        baseline = list(qs)
+        baseline_pks = {obj.pk for obj in baseline}
+        qs._result_cache = None  # Force fresh evaluation after derived queryset.
+        list(qs.order_by().values_list('pk', flat=True))
+        self.assertSetEqual({obj.pk for obj in qs}, baseline_pks)
+
+    @skipUnlessDBFeature('supports_slicing_ordering_in_compound')
+    def test_union_reuse_after_values_evaluation(self):
+        qs = Number.objects.filter(num__lte=4).union(
+            Number.objects.filter(num__gte=5).order_by('id')
+        )
+        baseline = list(qs)
+        baseline_pks = {obj.pk for obj in baseline}
+        qs._result_cache = None  # Force fresh evaluation after derived queryset.
+        list(qs.order_by().values('pk'))
+        self.assertSetEqual({obj.pk for obj in qs}, baseline_pks)
+
     def test_count_union(self):
         qs1 = Number.objects.filter(num__lte=1).values('num')
         qs2 = Number.objects.filter(num__gte=2, num__lte=3).values('num')
@@ -168,11 +190,35 @@ class QuerySetSetOperationTests(TestCase):
         qs2 = Number.objects.filter(num__lt=9)
         self.assertEqual(qs1.difference(qs2).count(), 1)
 
+    @skipUnlessDBFeature('supports_select_difference')
+    @skipUnlessDBFeature('supports_slicing_ordering_in_compound')
+    def test_difference_reuse_after_values_list_evaluation(self):
+        qs = Number.objects.filter(num__lt=7).difference(
+            Number.objects.filter(num__lt=5).order_by('id')
+        )
+        baseline = list(qs)
+        baseline_pks = {obj.pk for obj in baseline}
+        qs._result_cache = None  # Force fresh evaluation after derived queryset.
+        list(qs.order_by().values_list('pk', flat=True))
+        self.assertSetEqual({obj.pk for obj in qs}, baseline_pks)
+
     @skipUnlessDBFeature('supports_select_intersection')
     def test_count_intersection(self):
         qs1 = Number.objects.filter(num__gte=5)
         qs2 = Number.objects.filter(num__lte=5)
         self.assertEqual(qs1.intersection(qs2).count(), 1)
+
+    @skipUnlessDBFeature('supports_select_intersection')
+    @skipUnlessDBFeature('supports_slicing_ordering_in_compound')
+    def test_intersection_reuse_after_values_list_evaluation(self):
+        qs = Number.objects.filter(num__gte=3).intersection(
+            Number.objects.filter(num__lte=6).order_by('id')
+        )
+        baseline = list(qs)
+        baseline_pks = {obj.pk for obj in baseline}
+        qs._result_cache = None  # Force fresh evaluation after derived queryset.
+        list(qs.order_by().values_list('pk', flat=True))
+        self.assertSetEqual({obj.pk for obj in qs}, baseline_pks)
 
     @skipUnlessDBFeature('supports_slicing_ordering_in_compound')
     def test_ordering_subqueries(self):


### PR DESCRIPTION
## Summary
- Clone each combined subquery (Query.clone()) before building compound queries to avoid shared-state leakage across derived querysets.
- Add regression tests for UNION/INTERSECT/EXCEPT re-use after derived evaluation (skipped where compound ORDER BY unsupported).

## Issue
Fixes #82

## Reproduction and observed failure (from Issue #82)

>>> Dimension.objects.values_list('id', flat=True)
<QuerySet [10, 11, 12, 13, 14, 15, 16, 17, 18]>
>>> qs = (
    Dimension.objects.filter(pk__in=[10, 11])
    .union(Dimension.objects.filter(pk__in=[16, 17])
    .order_by('order')
)
>>> qs
<QuerySet [<Dimension: boeksoort>, <Dimension: grootboek>, <Dimension: kenteken>, <Dimension: activa>]>
# this causes re-evaluation of the original qs to break
>>> qs.order_by().values_list('pk', flat=True)
<QuerySet [16, 11, 10, 17]>
>>> qs
[breaks]

Traceback (PostgreSQL):

django.db.utils.ProgrammingError: ORDER BY position 4 is not in select list
LINE 1: ...dimensions_dimension"."id" IN (16, 17)) ORDER BY (4) ASC LIM...
                                             ^

## Root cause
Combined querysets stored sub-queries by reference. During compilation of a derived queryset (e.g., qs.order_by().values_list(...)), ORDER BY normalization for compound queries converts orderings to positional indices. Because the same Query instances were referenced, this normalization leaked back to the original queryset state, causing later evaluations to use mismatched ORDER BY against a different select list.

## Fix
In django/db/models/query.py, _combinator_query() now stores clones of sub-queries in query.combined_queries to isolate state.

## Testing
- ./runtests.py queries.test_qs_combinators
- ./runtests.py queries
- flake8 django/db/models/query.py tests/queries/test_qs_combinators.py

## Notes
- This PR targets base branch: django__django-10554.