### PR TITLE
swev-id: django__django-11095 Add ModelAdmin.get_inlines() for dynamic inlines

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -580,9 +580,35 @@ class ModelAdmin(BaseModelAdmin):
     def __str__(self):
         return "%s.%s" % (self.model._meta.app_label, self.__class__.__name__)
 
+    def get_inlines(self, request, obj=None):
+        """Return the inline classes displayed on the add/change views."""
+        return self.inlines
+
     def get_inline_instances(self, request, obj=None):
         inline_instances = []
-        for inline_class in self.inlines:
+        inline_classes = self.get_inlines(request, obj)
+        if inline_classes is None:
+            raise TypeError(
+                "ModelAdmin.get_inlines() must return an iterable of InlineModelAdmin "
+                "classes, not None."
+            )
+
+        for inline_class in inline_classes:
+            if isinstance(inline_class, InlineModelAdmin):
+                raise TypeError(
+                    "ModelAdmin.get_inlines() must return InlineModelAdmin classes, "
+                    "not instances of %s." % inline_class.__class__.__name__
+                )
+            if not isinstance(inline_class, type):
+                raise TypeError(
+                    "ModelAdmin.get_inlines() must return InlineModelAdmin classes, got %r."
+                    % (inline_class,)
+                )
+            if not issubclass(inline_class, InlineModelAdmin):
+                raise TypeError(
+                    "ModelAdmin.get_inlines() must return subclasses of InlineModelAdmin. "
+                    "Got %s." % inline_class.__name__
+                )
             inline = inline_class(self.model, self.admin_site)
             if request:
                 if not (inline.has_view_or_change_permission(request, obj) or

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -1608,24 +1608,41 @@ templates used by the :class:`ModelAdmin` views:
             def get_sortable_by(self, request):
                 return {*self.get_list_display(request)} - {'rank'}
 
+.. method:: ModelAdmin.get_inlines(request, obj=None)
+
+    The ``get_inlines()`` method is given the ``HttpRequest`` and the ``obj``
+    being edited (or ``None`` on an add form). It must return an iterable of
+    :class:`~django.contrib.admin.InlineModelAdmin` subclasses to display on the
+    add or change form. The default implementation returns the classes defined
+    in :attr:`ModelAdmin.inlines <django.contrib.admin.ModelAdmin.inlines>`.
+
+    This hook allows you to vary the inlines shown depending on the current
+    request or object. For example, the following ``ModelAdmin`` only shows the
+    ``RestrictedInline`` for non-superusers::
+
+        class BandAdmin(admin.ModelAdmin):
+            inlines = (PublicInline, RestrictedInline)
+
+            def get_inlines(self, request, obj=None):
+                if request.user.is_superuser:
+                    return self.inlines
+                return (PublicInline,)
+
+    Returning ``None``, inline instances, or objects that aren't subclasses of
+    :class:`~django.contrib.admin.InlineModelAdmin` raises ``TypeError``.
+
 .. method:: ModelAdmin.get_inline_instances(request, obj=None)
 
     The ``get_inline_instances`` method is given the ``HttpRequest`` and the
-    ``obj`` being edited (or ``None`` on an add form) and is expected to return
-    a ``list`` or ``tuple`` of :class:`~django.contrib.admin.InlineModelAdmin`
-    objects, as described below in the :class:`~django.contrib.admin.InlineModelAdmin`
-    section. For example, the following would return inlines without the default
-    filtering based on add, change, delete, and view permissions::
+    ``obj`` being edited (or ``None`` on an add form) and returns a list of
+    :class:`~django.contrib.admin.InlineModelAdmin` objects, as described below
+    in the :class:`~django.contrib.admin.InlineModelAdmin` section. The default
+    implementation instantiates and permission-filters the classes returned by
+    :meth:`~django.contrib.admin.ModelAdmin.get_inlines`.
 
-        class MyModelAdmin(admin.ModelAdmin):
-            inlines = (MyInline,)
-
-            def get_inline_instances(self, request, obj=None):
-                return [inline(self.model, self.admin_site) for inline in self.inlines]
-
-    If you override this method, make sure that the returned inlines are
-    instances of the classes defined in :attr:`inlines` or you might encounter
-    a "Bad Request" error when adding related objects.
+    Overriding this method is rarely necessary. If you do, you are responsible
+    for instantiating each inline class and applying any permission checks you
+    require.
 
 .. method:: ModelAdmin.get_urls()
 

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -46,6 +46,8 @@ Minor features
 
 * Added support for the ``admin_order_field`` attribute on properties in
   :attr:`.ModelAdmin.list_display`.
+* Added :meth:`~django.contrib.admin.ModelAdmin.get_inlines` to allow dynamic
+  selection and validation of inline admin classes.
 
 :mod:`django.contrib.admindocs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -1,4 +1,5 @@
 from datetime import date
+from types import SimpleNamespace
 
 from django import forms
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
@@ -42,6 +43,12 @@ class ModelAdminTests(TestCase):
             sign_date=date(1965, 1, 1),
         )
         self.site = AdminSite()
+
+    def _request_with_user(self, **attrs):
+        attrs.setdefault('has_perm', lambda perm: True)
+        request = MockRequest()
+        request.user = SimpleNamespace(**attrs)
+        return request
 
     def test_modeladmin_str(self):
         ma = ModelAdmin(Band, self.site)
@@ -718,6 +725,134 @@ class ModelAdminTests(TestCase):
         self.assertEqual(model_count, {'bands': 1})
         self.assertEqual(perms_needed, {'band'})
         self.assertEqual(protected, [])
+
+    def test_get_inlines_default_returns_inlines(self):
+        class ConcertInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class BandAdmin(ModelAdmin):
+            inlines = [ConcertInline]
+
+        ma = BandAdmin(Band, self.site)
+        request = self._request_with_user()
+        self.assertEqual(ma.get_inlines(request), [ConcertInline])
+        inline_instances = ma.get_inline_instances(request)
+        self.assertEqual([type(inline) for inline in inline_instances], [ConcertInline])
+
+    def test_get_inline_instances_dynamic_user(self):
+        class SuperuserInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class StaffInline(TabularInline):
+            model = Concert
+            fk_name = 'opening_band'
+
+        class BandAdmin(ModelAdmin):
+            def get_inlines(self, request, obj=None):
+                if getattr(request.user, 'is_superuser', False):
+                    return [SuperuserInline, StaffInline]
+                return [StaffInline]
+
+        ma = BandAdmin(Band, self.site)
+        superuser_request = self._request_with_user(is_superuser=True)
+        staff_request = self._request_with_user(is_superuser=False)
+        superuser_inlines = ma.get_inline_instances(superuser_request)
+        self.assertEqual([type(inline) for inline in superuser_inlines], [SuperuserInline, StaffInline])
+        staff_inlines = ma.get_inline_instances(staff_request)
+        self.assertEqual([type(inline) for inline in staff_inlines], [StaffInline])
+
+    def test_get_inline_instances_dynamic_obj(self):
+        class AddInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class ChangeInline(TabularInline):
+            model = Concert
+            fk_name = 'opening_band'
+
+        class BandAdmin(ModelAdmin):
+            def get_inlines(self, request, obj=None):
+                if obj is None or not getattr(obj, 'bio', ''):
+                    return [AddInline]
+                return [ChangeInline]
+
+        ma = BandAdmin(Band, self.site)
+        request = self._request_with_user()
+        add_inlines = ma.get_inline_instances(request)
+        self.assertEqual([type(inline) for inline in add_inlines], [AddInline])
+        self.band.bio = 'With support'
+        self.band.save(update_fields=['bio'])
+        change_inlines = ma.get_inline_instances(request, self.band)
+        self.assertEqual([type(inline) for inline in change_inlines], [ChangeInline])
+
+    def test_get_inline_instances_rejects_inline_instances(self):
+        class ConcertInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class BandAdmin(ModelAdmin):
+            def get_inlines(self, request, obj=None):
+                return [ConcertInline(self.model, self.admin_site)]
+
+        ma = BandAdmin(Band, self.site)
+        request = self._request_with_user()
+        message = (
+            "ModelAdmin.get_inlines() must return InlineModelAdmin classes, "
+            "not instances of ConcertInline."
+        )
+        with self.assertRaisesMessage(TypeError, message):
+            ma.get_inline_instances(request)
+
+    def test_get_inline_instances_rejects_non_inline_class(self):
+        class BandAdmin(ModelAdmin):
+            def get_inlines(self, request, obj=None):
+                return [ModelAdmin]
+
+        ma = BandAdmin(Band, self.site)
+        request = self._request_with_user()
+        message = (
+            "ModelAdmin.get_inlines() must return subclasses of InlineModelAdmin. "
+            "Got ModelAdmin."
+        )
+        with self.assertRaisesMessage(TypeError, message):
+            ma.get_inline_instances(request)
+
+    def test_get_inline_instances_rejects_none(self):
+        class BandAdmin(ModelAdmin):
+            def get_inlines(self, request, obj=None):
+                return None
+
+        ma = BandAdmin(Band, self.site)
+        request = self._request_with_user()
+        message = (
+            "ModelAdmin.get_inlines() must return an iterable of InlineModelAdmin classes, "
+            "not None."
+        )
+        with self.assertRaisesMessage(TypeError, message):
+            ma.get_inline_instances(request)
+
+    def test_get_inline_instances_preserves_order(self):
+        class FirstInline(TabularInline):
+            model = Concert
+            fk_name = 'main_band'
+
+        class SecondInline(TabularInline):
+            model = Concert
+            fk_name = 'opening_band'
+
+        class BandAdmin(ModelAdmin):
+            def get_inlines(self, request, obj=None):
+                return [SecondInline, FirstInline]
+
+        ma = BandAdmin(Band, self.site)
+        request = self._request_with_user()
+        inline_instances = ma.get_inline_instances(request)
+        self.assertEqual(
+            [type(inline) for inline in inline_instances],
+            [SecondInline, FirstInline],
+        )
 
 
 class ModelAdminPermissionTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- add ModelAdmin.get_inlines() so admins can choose inline classes per request/object
- validate get_inlines() output and preserve permission filtering when instantiating inlines
- cover the hook with modeladmin tests, admin docs, and a 3.0 release note

## Observed Failures
- PYTHONPATH=/workspace/django ./runtests.py modeladmin.tests.ModelAdminTests *(fails before the fix)*
  ```
  AttributeError: 'BandAdmin' object has no attribute 'get_inlines'
  FAIL: test_get_inline_instances_dynamic_user ... Lists differ: [] != [...]
  FAIL: test_get_inline_instances_rejects_none ... TypeError not raised
  ```

## Testing
- PYTHONPATH=/workspace/django ./runtests.py modeladmin.tests.ModelAdminTests
- PYTHONPATH=/workspace/django ./runtests.py admin_inlines
- flake8 django/contrib/admin/options.py --extend-ignore=E741
- flake8 tests/modeladmin/tests.py

Fixes #84