### PR TITLE
swev-id: django__django-10914 — Set default FILE_UPLOAD_PERMISSIONS to 0o644

### DIFF
--- a/django/conf/global_settings.py
+++ b/django/conf/global_settings.py
@@ -304,7 +304,7 @@ FILE_UPLOAD_TEMP_DIR = None
 
 # The numeric mode to set newly-uploaded files to. The value should be a mode
 # you'd pass directly to os.chmod; see https://docs.python.org/library/os.html#files-and-directories.
-FILE_UPLOAD_PERMISSIONS = None
+FILE_UPLOAD_PERMISSIONS = 0o644
 
 # The numeric mode to assign to newly-created directories, when uploading files.
 # The value should be a mode as you'd pass to os.chmod;

--- a/docs/howto/deployment/checklist.txt
+++ b/docs/howto/deployment/checklist.txt
@@ -157,12 +157,13 @@ Now is a good time to check your backup strategy for these files.
 :setting:`FILE_UPLOAD_PERMISSIONS`
 ----------------------------------
 
-With the default file upload settings, files smaller than
-:setting:`FILE_UPLOAD_MAX_MEMORY_SIZE` may be stored with a different mode
-than larger files as described in :setting:`FILE_UPLOAD_PERMISSIONS`.
+With the default file upload settings, Django applies ``0o644`` to all newly
+uploaded files, regardless of whether they're streamed to disk or handled in
+memory.
 
-Setting :setting:`FILE_UPLOAD_PERMISSIONS` ensures all files are uploaded with
-the same permissions.
+Adjust :setting:`FILE_UPLOAD_PERMISSIONS` if your deployment requires a
+different mode, or set it to ``None`` to restore the operating
+system-dependent behavior described in :setting:`FILE_UPLOAD_PERMISSIONS`.
 
 HTTPS
 =====

--- a/docs/ref/contrib/staticfiles.txt
+++ b/docs/ref/contrib/staticfiles.txt
@@ -66,8 +66,9 @@ by the :class:`~django.contrib.staticfiles.storage.ManifestStaticFilesStorage`
 by default.
 
 By default, collected files receive permissions from
-:setting:`FILE_UPLOAD_PERMISSIONS` and collected directories receive permissions
-from :setting:`FILE_UPLOAD_DIRECTORY_PERMISSIONS`. If you would like different
+:setting:`FILE_UPLOAD_PERMISSIONS` (``0o644`` by default) and collected
+directories receive permissions from :setting:`FILE_UPLOAD_DIRECTORY_PERMISSIONS`.
+If you would like different
 permissions for these files and/or directories, you can subclass either of the
 :ref:`static files storage classes <staticfiles-storages>` and specify the
 ``file_permissions_mode`` and/or ``directory_permissions_mode`` parameters,

--- a/docs/ref/settings.txt
+++ b/docs/ref/settings.txt
@@ -1484,16 +1484,17 @@ This value mirrors the functionality and caveats of the
 ``FILE_UPLOAD_PERMISSIONS``
 ---------------------------
 
-Default: ``None``
+Default: ``0o644``
 
 The numeric mode (i.e. ``0o644``) to set newly uploaded files to. For
 more information about what these modes mean, see the documentation for
 :func:`os.chmod`.
 
-If this isn't given or is ``None``, you'll get operating-system
-dependent behavior. On most platforms, temporary files will have a mode
-of ``0o600``, and files saved from memory will be saved using the
-system's standard umask.
+Uploads handled in memory or via temporary files now use consistent
+permissions that match this setting. Set this to ``None`` to restore the
+previous, operating system-dependent behavior. On most platforms, that
+behavior yields ``0o600`` for temporary files and uses the process
+umask for in-memory uploads.
 
 For security reasons, these permissions aren't applied to the temporary files
 that are stored in :setting:`FILE_UPLOAD_TEMP_DIR`.

--- a/docs/releases/3.0.txt
+++ b/docs/releases/3.0.txt
@@ -284,6 +284,18 @@ Django 3.0, we're removing these APIs at this time.
 
 * ``django.utils.safestring.SafeBytes`` - Unused since Django 2.0.
 
+File uploads
+------------
+
+* :setting:`FILE_UPLOAD_PERMISSIONS` now defaults to ``0o644`` instead of
+  ``None``. This change ensures that uploads handled in memory and those
+  streamed to temporary files end up with consistent permissions, and that
+  collected static files inherit the same default. Deployments that relied on
+  the previous operating system-dependent behavior can restore it by setting
+  :setting:`FILE_UPLOAD_PERMISSIONS` to ``None``. Directory permissions are
+  unchanged; :setting:`FILE_UPLOAD_DIRECTORY_PERMISSIONS` remains ``None`` by
+  default.
+
 Miscellaneous
 -------------
 

--- a/docs/topics/http/file-uploads.txt
+++ b/docs/topics/http/file-uploads.txt
@@ -184,6 +184,15 @@ Together :class:`MemoryFileUploadHandler` and
 :class:`TemporaryFileUploadHandler` provide Django's default file upload
 behavior of reading small files into memory and large ones onto disk.
 
+.. note::
+
+    Prior to :setting:`FILE_UPLOAD_PERMISSIONS` defaulting to ``0o644``,
+    uploads handled in memory and those written to temporary files could
+    land on disk with different permissions when the setting was ``None``.
+    The ``0o644`` default ensures consistent permissions regardless of the
+    upload handler. Set :setting:`FILE_UPLOAD_PERMISSIONS` to ``None`` to
+    restore the historical, operating system-dependent behavior if needed.
+
 You can write custom handlers that customize how Django handles files. You
 could, for example, use custom handlers to enforce user-level quotas, compress
 data on the fly, render progress bars, and even send data to another storage

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -885,6 +885,12 @@ class FileStoragePermissions(unittest.TestCase):
         shutil.rmtree(self.storage_dir)
         os.umask(self.old_umask)
 
+    def test_file_upload_default_permissions(self):
+        self.storage = FileSystemStorage(self.storage_dir)
+        name = self.storage.save("the_file", ContentFile("data"))
+        mode = os.stat(self.storage.path(name))[0] & 0o777
+        self.assertEqual(mode, 0o644)
+
     @override_settings(FILE_UPLOAD_PERMISSIONS=0o654)
     def test_file_upload_permissions(self):
         self.storage = FileSystemStorage(self.storage_dir)
@@ -892,12 +898,31 @@ class FileStoragePermissions(unittest.TestCase):
         actual_mode = os.stat(self.storage.path(name))[0] & 0o777
         self.assertEqual(actual_mode, 0o654)
 
+    def test_temporary_upload_default_permissions(self):
+        self.storage = FileSystemStorage(self.storage_dir)
+        with TemporaryUploadedFile("the_file", 'text/plain', 4, 'utf8') as upload:
+            upload.write(b"data")
+            upload.seek(0)
+            name = self.storage.save("the_file", upload)
+        mode = os.stat(self.storage.path(name))[0] & 0o777
+        self.assertEqual(mode, 0o644)
+
     @override_settings(FILE_UPLOAD_PERMISSIONS=None)
-    def test_file_upload_default_permissions(self):
+    def test_file_upload_permissions_none_uses_umask(self):
         self.storage = FileSystemStorage(self.storage_dir)
         fname = self.storage.save("some_file", ContentFile("data"))
         mode = os.stat(self.storage.path(fname))[0] & 0o777
         self.assertEqual(mode, 0o666 & ~self.umask)
+
+    @override_settings(FILE_UPLOAD_PERMISSIONS=None)
+    def test_temporary_upload_permissions_none(self):
+        self.storage = FileSystemStorage(self.storage_dir)
+        with TemporaryUploadedFile("the_file", 'text/plain', 4, 'utf8') as upload:
+            upload.write(b"data")
+            upload.seek(0)
+            name = self.storage.save("the_file", upload)
+        mode = os.stat(self.storage.path(name))[0] & 0o777
+        self.assertEqual(mode, 0o600)
 
     @override_settings(FILE_UPLOAD_DIRECTORY_PERMISSIONS=0o765)
     def test_file_upload_directory_permissions(self):

--- a/tests/test_utils/tests.py
+++ b/tests/test_utils/tests.py
@@ -1099,7 +1099,7 @@ class OverrideSettingsTests(SimpleTestCase):
         the file_permissions_mode attribute of
         django.core.files.storage.default_storage.
         """
-        self.assertIsNone(default_storage.file_permissions_mode)
+        self.assertEqual(default_storage.file_permissions_mode, 0o644)
         with self.settings(FILE_UPLOAD_PERMISSIONS=0o777):
             self.assertEqual(default_storage.file_permissions_mode, 0o777)
 


### PR DESCRIPTION
## Summary
- set FILE_UPLOAD_PERMISSIONS default to 0o644 so FileSystemStorage chmods every saved upload consistently
- update docs and release notes to call out the new default and how to opt back into OS-dependent behavior
- expand tests to cover both ContentFile and TemporaryUploadedFile flows under the new default and when the setting is None

## Breaking change
- Uploaded files saved via FileSystemStorage now default to mode 0o644 even when produced by TemporaryUploadedFile; deployments depending on umask-driven modes must set FILE_UPLOAD_PERMISSIONS explicitly or to None.

## Reproduction
The snippet from #87 demonstrates the historical mismatch when FILE_UPLOAD_PERMISSIONS is None:

```python
import os
from django.core.files.base import ContentFile
from django.core.files.uploadedfile import TemporaryUploadedFile
from django.core.files.storage import FileSystemStorage
import tempfile, shutil

tmpdir = tempfile.mkdtemp()
try:
    st = FileSystemStorage(tmpdir)

    name1 = st.save("small.txt", ContentFile(b"data"))
    mode1 = os.stat(st.path(name1)).st_mode & 0o777

    tuf = TemporaryUploadedFile('large.txt', 'text/plain', 0, 'utf-8')
    tuf.write(b'x' * 1024)
    tuf.seek(0, os.SEEK_END); tuf.size = tuf.tell(); tuf.seek(0)
    name2 = st.save("large.txt", tuf)
    mode2 = os.stat(st.path(name2)).st_mode & 0o777

    print("small.txt mode:", oct(mode1))
    print("large.txt mode:", oct(mode2))
finally:
    shutil.rmtree(tmpdir)
```

With this patch the two modes both resolve to 0o644 by default, while setting FILE_UPLOAD_PERMISSIONS=None reproduces the prior 0o600 vs umask-driven behavior.

## Restoring previous behavior
- Set FILE_UPLOAD_PERMISSIONS=None to return to OS-dependent modes (umask for in-memory, often 0o600 for TemporaryUploadedFile) as documented.

## Testing
- PYTHONPATH=/workspace/django ./runtests.py file_storage.tests
- PYTHONPATH=/workspace/django ./runtests.py test_utils.tests.OverrideSettingsTests.test_override_file_upload_permissions
- flake8 tests/file_storage/tests.py tests/test_utils/tests.py

Fixes #87.