### PR TITLE
swev-id: django__django-11087 Optimize queryset deletion selection

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -76,6 +76,72 @@ class Collector:
         # database tables; proxy models are represented here by their concrete
         # parent.
         self.dependencies = {}  # {model: {models}}
+        self._required_fields_cache = {}
+
+    def _required_fields_for_model(self, model):
+        fields = self._required_fields_cache.get(model)
+        if fields is not None:
+            return fields
+
+        opts = model._meta
+        required = {opts.pk.name}
+        for parent_link in opts.parents.values():
+            if parent_link:
+                required.add(parent_link.name)
+        for related in get_candidate_relations_to_delete(opts):
+            for target_field in related.field.foreign_related_fields:
+                required.add(target_field.name)
+        fields = tuple(sorted(required))
+        self._required_fields_cache[model] = fields
+        return fields
+
+    def _optimization_allowed_for_model(self, model):
+        if (signals.pre_delete.has_listeners(model) or
+                signals.post_delete.has_listeners(model) or
+                signals.m2m_changed.has_listeners(model)):
+            return False
+        for m2m in model._meta.many_to_many:
+            through = m2m.remote_field.through
+            if signals.m2m_changed.has_listeners(through):
+                return False
+        return True
+
+    def _optimize_queryset(self, objs):
+        if not hasattr(objs, 'query') or not hasattr(objs, 'model'):
+            return objs
+
+        model = objs.model
+        if not self._optimization_allowed_for_model(model):
+            return objs
+
+        required_fields = self._required_fields_for_model(model)
+        if not required_fields:
+            return objs
+
+        query = objs.query
+        existing, defer = query.deferred_loading
+        required = set(required_fields)
+
+        if defer:
+            if not existing:
+                return objs.only(*required_fields)
+            missing = required.intersection(existing)
+            if not missing:
+                return objs
+            clone = objs._chain()
+            clone.query.deferred_loading = (frozenset(existing.difference(missing)), True)
+            return clone
+
+        # Immediate loading is in use. Ensure required fields are present.
+        if not existing:
+            query.add_immediate_loading(required_fields)
+            return objs
+
+        if required.difference(existing):
+            clone = objs._chain()
+            clone.query.deferred_loading = (frozenset(set(existing).union(required)), False)
+            return clone
+        return objs
 
     def add(self, objs, source=None, nullable=False, reverse_dependency=False):
         """
@@ -188,6 +254,7 @@ class Collector:
         if self.can_fast_delete(objs):
             self.fast_deletes.append(objs)
             return
+        objs = self._optimize_queryset(objs)
         new_objs = self.add(objs, source, nullable,
                             reverse_dependency=reverse_dependency)
         if not new_objs:
@@ -220,8 +287,10 @@ class Collector:
                     sub_objs = self.related_objects(related, batch)
                     if self.can_fast_delete(sub_objs, from_field=field):
                         self.fast_deletes.append(sub_objs)
-                    elif sub_objs:
-                        field.remote_field.on_delete(self, field, sub_objs, self.using)
+                    else:
+                        sub_objs = self._optimize_queryset(sub_objs)
+                        if sub_objs:
+                            field.remote_field.on_delete(self, field, sub_objs, self.using)
             for field in model._meta.private_fields:
                 if hasattr(field, 'bulk_related_objects'):
                     # It's something like generic foreign key.

--- a/tests/delete/models.py
+++ b/tests/delete/models.py
@@ -126,3 +126,58 @@ class Base(models.Model):
 
 class RelToBase(models.Model):
     base = models.ForeignKey(Base, models.DO_NOTHING)
+
+
+class ExplodingTextField(models.TextField):
+    def from_db_value(self, value, expression, connection):
+        raise RuntimeError('ExplodingTextField evaluated')
+
+
+class DeleteCollectorTag(models.Model):
+    name = models.CharField(max_length=16)
+
+
+class DeleteCollectorRoot(models.Model):
+    code = models.CharField(max_length=32, unique=True)
+    payload = ExplodingTextField()
+    tags = models.ManyToManyField(
+        DeleteCollectorTag,
+        through='DeleteCollectorRootTag',
+        related_name='collector_roots',
+    )
+
+
+class DeleteCollectorRootTag(models.Model):
+    root = models.ForeignKey(DeleteCollectorRoot, models.CASCADE)
+    tag = models.ForeignKey(DeleteCollectorTag, models.CASCADE)
+
+
+class DeleteCollectorCascadeChild(models.Model):
+    root = models.ForeignKey(DeleteCollectorRoot, models.CASCADE, related_name='cascade_children')
+
+
+class DeleteCollectorSetNullChild(models.Model):
+    root = models.ForeignKey(DeleteCollectorRoot, models.SET_NULL, null=True, related_name='setnull_children')
+
+
+class DeleteCollectorProtectedChild(models.Model):
+    root = models.ForeignKey(DeleteCollectorRoot, models.PROTECT, related_name='protect_children')
+
+
+class DeleteCollectorCodeTarget(models.Model):
+    code = models.CharField(max_length=32, unique=True)
+    payload = ExplodingTextField()
+
+
+class DeleteCollectorCodeChild(models.Model):
+    target = models.ForeignKey(
+        DeleteCollectorCodeTarget,
+        models.CASCADE,
+        to_field='code',
+        db_column='target_code',
+        related_name='code_children',
+    )
+
+
+class DeleteCollectorFast(models.Model):
+    payload = ExplodingTextField()

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -1,13 +1,16 @@
 from math import ceil
 
 from django.db import IntegrityError, connection, models
-from django.db.models.deletion import Collector
+from django.db.models.deletion import Collector, ProtectedError
 from django.db.models.sql.constants import GET_ITERATOR_CHUNK_SIZE
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
 from .models import (
     MR, A, Avatar, Base, Child, HiddenUser, HiddenUserProfile, M, M2MFrom,
     M2MTo, MRNull, Parent, R, RChild, S, T, User, create_a, get_default_r,
+    DeleteCollectorCascadeChild, DeleteCollectorCodeChild, DeleteCollectorCodeTarget,
+    DeleteCollectorFast, DeleteCollectorProtectedChild, DeleteCollectorRoot,
+    DeleteCollectorSetNullChild, DeleteCollectorTag,
 )
 
 
@@ -531,3 +534,67 @@ class FastDeleteTests(TestCase):
                 User.objects.filter(avatar__desc='missing').delete(),
                 (0, {'delete.User': 0})
             )
+
+
+class CollectorOptimizationTests(TestCase):
+
+    def test_queryset_delete_skips_unrelated_fields_without_signals(self):
+        root = DeleteCollectorRoot.objects.create(code='root-no-signal', payload='payload')
+        DeleteCollectorCascadeChild.objects.create(root=root)
+        DeleteCollectorRoot.objects.filter(pk=root.pk).delete()
+        self.assertFalse(DeleteCollectorRoot.objects.filter(pk=root.pk).exists())
+        self.assertFalse(DeleteCollectorCascadeChild.objects.filter(root=root).exists())
+
+    def test_queryset_delete_handles_to_field_target(self):
+        target = DeleteCollectorCodeTarget.objects.create(code='code-target', payload='payload')
+        DeleteCollectorCodeChild.objects.create(target=target)
+        DeleteCollectorCodeTarget.objects.filter(pk=target.pk).delete()
+        self.assertFalse(DeleteCollectorCodeTarget.objects.filter(pk=target.pk).exists())
+        self.assertFalse(DeleteCollectorCodeChild.objects.exists())
+
+    def test_queryset_delete_with_signals_fetches_all_fields(self):
+        root = DeleteCollectorRoot.objects.create(code='root-with-signal', payload='payload')
+        DeleteCollectorCascadeChild.objects.create(root=root)
+
+        def receiver(sender, instance, using, **kwargs):
+            pass
+
+        models.signals.pre_delete.connect(receiver, sender=DeleteCollectorRoot)
+        try:
+            with self.assertRaises(RuntimeError):
+                DeleteCollectorRoot.objects.filter(pk=root.pk).delete()
+        finally:
+            models.signals.pre_delete.disconnect(receiver, sender=DeleteCollectorRoot)
+
+    def test_fast_delete_skips_selects(self):
+        DeleteCollectorFast.objects.create(payload='payload')
+        self.assertNumQueries(1, DeleteCollectorFast.objects.all().delete)
+        self.assertFalse(DeleteCollectorFast.objects.exists())
+
+    def test_set_null_and_protect_behaviors_with_restricted_selection(self):
+        protected_root = DeleteCollectorRoot.objects.create(code='root-protect', payload='payload')
+        DeleteCollectorProtectedChild.objects.create(root=protected_root)
+        with self.assertRaises(ProtectedError):
+            DeleteCollectorRoot.objects.filter(pk=protected_root.pk).delete()
+
+        nullable_root = DeleteCollectorRoot.objects.create(code='root-set-null', payload='payload')
+        child = DeleteCollectorSetNullChild.objects.create(root=nullable_root)
+        DeleteCollectorRoot.objects.filter(pk=nullable_root.pk).delete()
+        child.refresh_from_db()
+        self.assertIsNone(child.root)
+
+    def test_m2m_changed_listener_disables_optimization(self):
+        root = DeleteCollectorRoot.objects.create(code='root-m2m', payload='payload')
+        tag = DeleteCollectorTag.objects.create(name='tag')
+        root.tags.add(tag)
+
+        def listener(sender, **kwargs):
+            pass
+
+        through = DeleteCollectorRoot.tags.through
+        models.signals.m2m_changed.connect(listener, sender=through)
+        try:
+            with self.assertRaises(RuntimeError):
+                DeleteCollectorRoot.objects.filter(pk=root.pk).delete()
+        finally:
+            models.signals.m2m_changed.disconnect(listener, sender=through)


### PR DESCRIPTION
## Summary
- optimize Collector queryset deletions by selecting only required fields and handling deferred loading
- skip optimization when signals or m2m listeners are active and reuse the selection for cascaded queries
- add regression coverage for signals, to_field cascades, fast delete, set null/protect, and m2m listeners (#85)

## Testing
- PYTHONPATH=/workspace/django ./runtests.py delete --parallel=1
- flake8 django/db/models/deletion.py tests/delete/models.py tests/delete/tests.py