### PR TITLE
Honor Engine.autoescape in render_to_string (swev-id: django__django-11119)

### DIFF
--- a/django/template/engine.py
+++ b/django/template/engine.py
@@ -160,7 +160,7 @@ class Engine:
         if isinstance(context, Context):
             return t.render(context)
         else:
-            return t.render(Context(context))
+            return t.render(Context(context, autoescape=self.autoescape))
 
     def select_template(self, template_name_list):
         """

--- a/tests/template_tests/test_engine.py
+++ b/tests/template_tests/test_engine.py
@@ -21,6 +21,31 @@ class RenderToStringTest(SimpleTestCase):
             'obj:test\n',
         )
 
+    def test_render_to_string_respects_autoescape_false(self):
+        engine = Engine(
+            autoescape=False,
+            loaders=[(
+                'django.template.loaders.locmem.Loader',
+                {'t': '{{ x }}'},
+            )],
+        )
+        self.assertEqual(
+            engine.render_to_string('t', {'x': '<b>a</b>'}),
+            '<b>a</b>',
+        )
+
+    def test_render_to_string_default_autoescape_true(self):
+        engine = Engine(
+            loaders=[(
+                'django.template.loaders.locmem.Loader',
+                {'t': '{{ x }}'},
+            )],
+        )
+        self.assertEqual(
+            engine.render_to_string('t', {'x': '<b>a</b>'}),
+            '&lt;b&gt;a&lt;/b&gt;',
+        )
+
 
 class GetDefaultTests(SimpleTestCase):
 


### PR DESCRIPTION
Refer to Issue #97.

Observed failure:
- Using Engine(autoescape=False), render_to_string still escapes variables.
- Repro:
```python
from django.template.engine import Engine

engine = Engine(autoescape=False, loaders=[('django.template.loaders.locmem.Loader', {'t': '{{ x }}'})])
print(engine.render_to_string('t', {'x': '<b>bold</b>'}))
```
Expected: <b>bold</b>
Actual: &lt;b&gt;bold&lt;/b&gt;

Call path (per Issue #97):
- Engine.render_to_string() constructs a Context without passing autoescape (django/template/engine.py line ~163).
- Context defaults to autoescape=True (django/template/context.py line ~137).
- Template.render() therefore escapes the variable before returning.

Fix:
- Pass autoescape=self.autoescape when constructing Context inside Engine.render_to_string().

Tests:
- Added template tests in tests/template_tests/test_engine.py covering both autoescape=False and default behavior.
- PYTHONPATH=/workspace/django python tests/runtests.py template_tests.test_engine.RenderToStringTest --parallel=1 --verbosity=1
- flake8 django/template/engine.py tests/template_tests/test_engine.py