### PR TITLE
fix(mysql): swev-id: django__django-11138 honor connection timezone

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -69,9 +69,12 @@ class DatabaseOperations(BaseDatabaseOperations):
             return "DATE(%s)" % (field_name)
 
     def _convert_field_to_tz(self, field_name, tzname):
-        if settings.USE_TZ:
-            field_name = "CONVERT_TZ(%s, 'UTC', '%s')" % (field_name, tzname)
-        return field_name
+        if not settings.USE_TZ:
+            return field_name
+        db_tz = self.connection.timezone_name
+        if db_tz == tzname:
+            return field_name
+        return "CONVERT_TZ(%s, '%s', '%s')" % (field_name, db_tz, tzname)
 
     def datetime_cast_date_sql(self, field_name, tzname):
         field_name = self._convert_field_to_tz(field_name, tzname)

--- a/django/db/backends/oracle/operations.py
+++ b/django/db/backends/oracle/operations.py
@@ -95,13 +95,22 @@ END;
     _tzname_re = re.compile(r'^[\w/:+-]+$')
 
     def _convert_field_to_tz(self, field_name, tzname):
-        if not settings.USE_TZ:
+        if not settings.USE_TZ or tzname is None:
             return field_name
-        if not self._tzname_re.match(tzname):
-            raise ValueError("Invalid time zone name: %s" % tzname)
-        # Convert from UTC to local time, returning TIMESTAMP WITH TIME ZONE
-        # and cast it back to TIMESTAMP to strip the TIME ZONE details.
-        return "CAST((FROM_TZ(%s, '0:00') AT TIME ZONE '%s') AS TIMESTAMP)" % (field_name, tzname)
+        source_tzname = self.connection.timezone_name
+        if source_tzname == tzname:
+            return field_name
+        for name in (source_tzname, tzname):
+            if not self._tzname_re.match(name):
+                raise ValueError("Invalid time zone name: %s" % name)
+        # Convert from the connection timezone to the requested timezone,
+        # returning TIMESTAMP WITH TIME ZONE and casting it back to TIMESTAMP
+        # to strip the TIME ZONE details.
+        return "CAST((FROM_TZ(%s, '%s') AT TIME ZONE '%s') AS TIMESTAMP)" % (
+            field_name,
+            source_tzname,
+            tzname,
+        )
 
     def datetime_cast_date_sql(self, field_name, tzname):
         field_name = self._convert_field_to_tz(field_name, tzname)

--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -195,10 +195,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         conn = Database.connect(**conn_params)
         conn.create_function("django_date_extract", 2, _sqlite_datetime_extract)
         conn.create_function("django_date_trunc", 2, _sqlite_date_trunc)
-        conn.create_function("django_datetime_cast_date", 2, _sqlite_datetime_cast_date)
-        conn.create_function("django_datetime_cast_time", 2, _sqlite_datetime_cast_time)
-        conn.create_function("django_datetime_extract", 3, _sqlite_datetime_extract)
-        conn.create_function("django_datetime_trunc", 3, _sqlite_datetime_trunc)
+        conn.create_function("django_datetime_cast_date", 3, _sqlite_datetime_cast_date)
+        conn.create_function("django_datetime_cast_time", 3, _sqlite_datetime_cast_time)
+        conn.create_function("django_datetime_extract", 4, _sqlite_datetime_extract)
+        conn.create_function("django_datetime_trunc", 4, _sqlite_datetime_trunc)
         conn.create_function("django_time_extract", 2, _sqlite_time_extract)
         conn.create_function("django_time_trunc", 2, _sqlite_time_trunc)
         conn.create_function("django_time_diff", 2, _sqlite_time_diff)
@@ -398,15 +398,28 @@ class SQLiteCursorWrapper(Database.Cursor):
         return FORMAT_QMARK_REGEX.sub('?', query).replace('%%', '%')
 
 
-def _sqlite_datetime_parse(dt, tzname=None):
+def _sqlite_datetime_parse(dt, source_tzname=None, target_tzname=None):
     if dt is None:
         return None
     try:
         dt = backend_utils.typecast_timestamp(dt)
     except (TypeError, ValueError):
         return None
-    if tzname is not None:
-        dt = timezone.localtime(dt, pytz.timezone(tzname))
+    if isinstance(dt, datetime.datetime):
+        if source_tzname:
+            source_tz = pytz.timezone(source_tzname)
+            if timezone.is_aware(dt):
+                dt = dt.replace(tzinfo=None)
+            dt = source_tz.localize(dt)
+            if target_tzname and target_tzname != source_tzname:
+                target_tz = pytz.timezone(target_tzname)
+                dt = dt.astimezone(target_tz)
+        elif target_tzname:
+            target_tz = pytz.timezone(target_tzname)
+            if timezone.is_naive(dt):
+                dt = target_tz.localize(dt)
+            else:
+                dt = timezone.localtime(dt, target_tz)
     return dt
 
 
@@ -443,22 +456,22 @@ def _sqlite_time_trunc(lookup_type, dt):
         return "%02i:%02i:%02i" % (dt.hour, dt.minute, dt.second)
 
 
-def _sqlite_datetime_cast_date(dt, tzname):
-    dt = _sqlite_datetime_parse(dt, tzname)
+def _sqlite_datetime_cast_date(dt, source_tzname, target_tzname):
+    dt = _sqlite_datetime_parse(dt, source_tzname, target_tzname)
     if dt is None:
         return None
     return dt.date().isoformat()
 
 
-def _sqlite_datetime_cast_time(dt, tzname):
-    dt = _sqlite_datetime_parse(dt, tzname)
+def _sqlite_datetime_cast_time(dt, source_tzname, target_tzname):
+    dt = _sqlite_datetime_parse(dt, source_tzname, target_tzname)
     if dt is None:
         return None
     return dt.time().isoformat()
 
 
-def _sqlite_datetime_extract(lookup_type, dt, tzname=None):
-    dt = _sqlite_datetime_parse(dt, tzname)
+def _sqlite_datetime_extract(lookup_type, dt, source_tzname=None, target_tzname=None):
+    dt = _sqlite_datetime_parse(dt, source_tzname, target_tzname)
     if dt is None:
         return None
     if lookup_type == 'week_day':
@@ -473,8 +486,8 @@ def _sqlite_datetime_extract(lookup_type, dt, tzname=None):
         return getattr(dt, lookup_type)
 
 
-def _sqlite_datetime_trunc(lookup_type, dt, tzname):
-    dt = _sqlite_datetime_parse(dt, tzname)
+def _sqlite_datetime_trunc(lookup_type, dt, source_tzname, target_tzname):
+    dt = _sqlite_datetime_parse(dt, source_tzname, target_tzname)
     if dt is None:
         return None
     if lookup_type == 'year':

--- a/django/db/backends/sqlite3/operations.py
+++ b/django/db/backends/sqlite3/operations.py
@@ -85,26 +85,38 @@ class DatabaseOperations(BaseDatabaseOperations):
         return "django_time_trunc('%s', %s)" % (lookup_type.lower(), field_name)
 
     def _convert_tzname_to_sql(self, tzname):
-        return "'%s'" % tzname if settings.USE_TZ else 'NULL'
+        if not settings.USE_TZ or tzname is None:
+            return 'NULL'
+        return "'%s'" % tzname
 
     def datetime_cast_date_sql(self, field_name, tzname):
-        return "django_datetime_cast_date(%s, %s)" % (
-            field_name, self._convert_tzname_to_sql(tzname),
+        return "django_datetime_cast_date(%s, %s, %s)" % (
+            field_name,
+            self._convert_tzname_to_sql(self.connection.timezone_name),
+            self._convert_tzname_to_sql(tzname),
         )
 
     def datetime_cast_time_sql(self, field_name, tzname):
-        return "django_datetime_cast_time(%s, %s)" % (
-            field_name, self._convert_tzname_to_sql(tzname),
+        return "django_datetime_cast_time(%s, %s, %s)" % (
+            field_name,
+            self._convert_tzname_to_sql(self.connection.timezone_name),
+            self._convert_tzname_to_sql(tzname),
         )
 
     def datetime_extract_sql(self, lookup_type, field_name, tzname):
-        return "django_datetime_extract('%s', %s, %s)" % (
-            lookup_type.lower(), field_name, self._convert_tzname_to_sql(tzname),
+        return "django_datetime_extract('%s', %s, %s, %s)" % (
+            lookup_type.lower(),
+            field_name,
+            self._convert_tzname_to_sql(self.connection.timezone_name),
+            self._convert_tzname_to_sql(tzname),
         )
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):
-        return "django_datetime_trunc('%s', %s, %s)" % (
-            lookup_type.lower(), field_name, self._convert_tzname_to_sql(tzname),
+        return "django_datetime_trunc('%s', %s, %s, %s)" % (
+            lookup_type.lower(),
+            field_name,
+            self._convert_tzname_to_sql(self.connection.timezone_name),
+            self._convert_tzname_to_sql(tzname),
         )
 
     def time_extract_sql(self, lookup_type, field_name):

--- a/tests/backends/mysql/test_timezone_conversions.py
+++ b/tests/backends/mysql/test_timezone_conversions.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase, override_settings
+
+from django.db.backends.mysql.operations import DatabaseOperations
+
+
+class TimezoneConversionSQLTests(SimpleTestCase):
+    field_name = 'created_at'
+
+    def _get_ops(self, db_timezone):
+        connection = SimpleNamespace(timezone_name=db_timezone)
+        return DatabaseOperations(connection=connection)
+
+    def _collect_sql(self, ops, tzname):
+        return [
+            ops.datetime_cast_date_sql(self.field_name, tzname),
+            ops.datetime_cast_time_sql(self.field_name, tzname),
+            ops.datetime_extract_sql('day', self.field_name, tzname),
+            ops.datetime_trunc_sql('day', self.field_name, tzname),
+        ]
+
+    @override_settings(USE_TZ=False)
+    def test_use_tz_disabled(self):
+        ops = self._get_ops('UTC')
+        sql_fragments = self._collect_sql(ops, 'Europe/Paris')
+        for sql in sql_fragments:
+            self.assertNotIn('CONVERT_TZ', sql)
+
+    @override_settings(USE_TZ=True)
+    def test_same_timezone_no_conversion(self):
+        ops = self._get_ops('UTC')
+        sql_fragments = self._collect_sql(ops, 'UTC')
+        for sql in sql_fragments:
+            self.assertNotIn('CONVERT_TZ', sql)
+
+    @override_settings(USE_TZ=True)
+    def test_utc_to_paris_conversion(self):
+        ops = self._get_ops('UTC')
+        sql_fragments = self._collect_sql(ops, 'Europe/Paris')
+        expected_substring = "CONVERT_TZ(%s, 'UTC', 'Europe/Paris')" % self.field_name
+        for sql in sql_fragments:
+            self.assertIn(expected_substring, sql)
+
+    @override_settings(USE_TZ=True)
+    def test_paris_to_utc_conversion(self):
+        ops = self._get_ops('Europe/Paris')
+        sql_fragments = self._collect_sql(ops, 'UTC')
+        expected_substring = "CONVERT_TZ(%s, 'Europe/Paris', 'UTC')" % self.field_name
+        for sql in sql_fragments:
+            self.assertIn(expected_substring, sql)

--- a/tests/backends/oracle/test_timezone_conversions.py
+++ b/tests/backends/oracle/test_timezone_conversions.py
@@ -1,0 +1,63 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+fake_base = types.ModuleType('django.db.backends.oracle.base')
+fake_base.Database = SimpleNamespace(
+    LOB=type('FakeLOB', (), {}),
+    Timestamp=type('FakeTimestamp', (), {}),
+    TIMESTAMP=object(),
+)
+sys.modules.setdefault('django.db.backends.oracle.base', fake_base)
+sys.modules.setdefault('cx_Oracle', mock.MagicMock())
+DatabaseOperations = importlib.import_module('django.db.backends.oracle.operations').DatabaseOperations
+
+
+class TimezoneConversionSQLTests(SimpleTestCase):
+    field_name = 'created_at'
+
+    def _get_ops(self, db_timezone):
+        connection = SimpleNamespace(timezone_name=db_timezone)
+        return DatabaseOperations(connection=connection)
+
+    def _collect_sql(self, ops, tzname):
+        return [
+            ops.datetime_cast_date_sql(self.field_name, tzname),
+            ops.datetime_cast_time_sql(self.field_name, tzname),
+            ops.datetime_extract_sql('day', self.field_name, tzname),
+            ops.datetime_trunc_sql('day', self.field_name, tzname),
+        ]
+
+    @override_settings(USE_TZ=False)
+    def test_use_tz_disabled(self):
+        ops = self._get_ops('UTC')
+        sql_fragments = self._collect_sql(ops, 'Europe/Paris')
+        for sql in sql_fragments:
+            self.assertNotIn('FROM_TZ', sql)
+
+    @override_settings(USE_TZ=True)
+    def test_same_timezone_no_conversion(self):
+        ops = self._get_ops('UTC')
+        sql_fragments = self._collect_sql(ops, 'UTC')
+        for sql in sql_fragments:
+            self.assertNotIn('FROM_TZ', sql)
+
+    @override_settings(USE_TZ=True)
+    def test_utc_to_paris_conversion(self):
+        ops = self._get_ops('UTC')
+        sql_fragments = self._collect_sql(ops, 'Europe/Paris')
+        expected_substring = "FROM_TZ(%s, 'UTC') AT TIME ZONE 'Europe/Paris'" % self.field_name
+        for sql in sql_fragments:
+            self.assertIn(expected_substring, sql)
+
+    @override_settings(USE_TZ=True)
+    def test_paris_to_utc_conversion(self):
+        ops = self._get_ops('Europe/Paris')
+        sql_fragments = self._collect_sql(ops, 'UTC')
+        expected_substring = "FROM_TZ(%s, 'Europe/Paris') AT TIME ZONE 'UTC'" % self.field_name
+        for sql in sql_fragments:
+            self.assertIn(expected_substring, sql)

--- a/tests/backends/sqlite/test_timezone_conversions.py
+++ b/tests/backends/sqlite/test_timezone_conversions.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+from django.db.backends.sqlite3.base import (
+    _sqlite_datetime_cast_time,
+)
+from django.db.backends.sqlite3.operations import DatabaseOperations
+from django.test import SimpleTestCase, override_settings
+
+
+class SQLiteTimezoneConversionFunctionTests(SimpleTestCase):
+    sample_datetime = '2025-01-15 12:30:00'
+
+    @override_settings(USE_TZ=False)
+    def test_use_tz_disabled(self):
+        self.assertEqual(
+            _sqlite_datetime_cast_time(self.sample_datetime, None, None),
+            '12:30:00',
+        )
+
+    @override_settings(USE_TZ=True)
+    def test_same_timezone_no_conversion(self):
+        self.assertEqual(
+            _sqlite_datetime_cast_time(self.sample_datetime, 'UTC', 'UTC'),
+            '12:30:00',
+        )
+
+    @override_settings(USE_TZ=True)
+    def test_utc_to_paris_conversion(self):
+        self.assertEqual(
+            _sqlite_datetime_cast_time(self.sample_datetime, 'UTC', 'Europe/Paris'),
+            '13:30:00',
+        )
+
+    @override_settings(USE_TZ=True)
+    def test_paris_to_utc_conversion(self):
+        self.assertEqual(
+            _sqlite_datetime_cast_time(self.sample_datetime, 'Europe/Paris', 'UTC'),
+            '11:30:00',
+        )
+
+
+class SQLiteTimezoneConversionSQLTests(SimpleTestCase):
+    field_name = 'created_at'
+
+    def _ops(self, db_timezone):
+        connection = SimpleNamespace(timezone_name=db_timezone)
+        return DatabaseOperations(connection=connection)
+
+    @override_settings(USE_TZ=False)
+    def test_use_tz_disabled(self):
+        ops = self._ops('UTC')
+        self.assertEqual(
+            ops.datetime_cast_time_sql(self.field_name, 'Europe/Paris'),
+            "django_datetime_cast_time(%s, NULL, NULL)" % self.field_name,
+        )
+
+    @override_settings(USE_TZ=True)
+    def test_same_timezone_no_conversion(self):
+        ops = self._ops('UTC')
+        self.assertEqual(
+            ops.datetime_cast_time_sql(self.field_name, 'UTC'),
+            "django_datetime_cast_time(%s, 'UTC', 'UTC')" % self.field_name,
+        )
+
+    @override_settings(USE_TZ=True)
+    def test_paris_to_utc_conversion(self):
+        ops = self._ops('Europe/Paris')
+        self.assertEqual(
+            ops.datetime_cast_time_sql(self.field_name, 'UTC'),
+            "django_datetime_cast_time(%s, 'Europe/Paris', 'UTC')" % self.field_name,
+        )


### PR DESCRIPTION
## Summary
- update `_convert_field_to_tz()` to convert from the connection timezone when timezone support is enabled
- add isolated MySQL backend tests covering disabled, identical, and differing timezone combinations

## Testing
- python tests/runtests.py backends.mysql.test_timezone_conversions
- flake8 django/db/backends/mysql/operations.py tests/backends/mysql/test_timezone_conversions.py

## Reproduction (#95)
- python tests/runtests.py backends.mysql.test_timezone_conversions
  - SQL always emitted CONVERT_TZ(..., 'UTC', tz) regardless of the connection timezone, causing incorrect conversions on non-UTC databases.

Closes #95