### PR TITLE
swev-id: django__django-11133 - Fix HttpResponse memoryview handling

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -229,7 +229,7 @@ class HttpResponseBase:
         # Handle string types -- we can't rely on force_bytes here because:
         # - Python attempts str conversion first
         # - when self._charset != 'utf-8' it re-encodes the content
-        if isinstance(value, bytes):
+        if isinstance(value, (bytes, memoryview)):
             return bytes(value)
         if isinstance(value, str):
             return bytes(value.encode(self.charset))
@@ -309,7 +309,7 @@ class HttpResponse(HttpResponseBase):
     @content.setter
     def content(self, value):
         # Consume iterators upon assignment to allow repeated iteration.
-        if hasattr(value, '__iter__') and not isinstance(value, (bytes, str)):
+        if hasattr(value, '__iter__') and not isinstance(value, (bytes, str, memoryview)):
             content = b''.join(self.make_bytes(chunk) for chunk in value)
             if hasattr(value, 'close'):
                 try:

--- a/tests/responses/tests.py
+++ b/tests/responses/tests.py
@@ -2,7 +2,7 @@ import io
 
 from django.conf import settings
 from django.core.cache import cache
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 from django.test import SimpleTestCase
 
@@ -143,6 +143,19 @@ class HttpResponseTests(SimpleTestCase):
         with io.TextIOWrapper(r, UTF8) as buf:
             buf.write(content)
         self.assertEqual(r.content, content.encode(UTF8))
+
+    def test_memoryview_content(self):
+        response = HttpResponse(memoryview(b'My Content'))
+        self.assertEqual(response.content, b'My Content')
+
+    def test_write_memoryview(self):
+        response = HttpResponse()
+        response.write(memoryview(b'abc'))
+        self.assertEqual(response.content, b'abc')
+
+    def test_streaming_memoryview_content(self):
+        response = StreamingHttpResponse(iter([memoryview(b'a'), memoryview(b'b')]))
+        self.assertEqual(response.getvalue(), b'ab')
 
     def test_generator_cache(self):
         generator = ("{}".format(i) for i in range(10))


### PR DESCRIPTION
## Summary
- coerce memoryview values to bytes in `HttpResponseBase.make_bytes()`
- treat memoryview inputs like byte strings in the `HttpResponse.content` setter
- add regression coverage for HttpResponse and StreamingHttpResponse memoryview inputs

## Issue
- Closes #96

## Reproduction
1. Activate the project virtualenv.
2. Run:
   ```bash
   PYTHONPATH=/workspace/django python - <<'PY'
from django.conf import settings
if not settings.configured:
    settings.configure(DEFAULT_CHARSET='utf-8')
from django.http import HttpResponse, StreamingHttpResponse
print(HttpResponse(memoryview(b'My Content')).content)
print(StreamingHttpResponse(iter([memoryview(b'a'), memoryview(b'b')])).getvalue())
PY
   ```
3. Before the fix the script prints:
   - `b'771213267111110116101110116'`
   - `b'<memory at 0x...><memory at 0x...>'`

## Testing
- `PYTHONPATH=/workspace/django ./tests/runtests.py responses --parallel=1`
- `flake8 django/http/response.py tests/responses/tests.py`
- Full test suite not run; responses subset exercised for this fix.