### PR TITLE
swev-id: django__django-11179 clear pk after fast delete

### DIFF
--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -277,6 +277,7 @@ class Collector:
             if self.can_fast_delete(instance):
                 with transaction.mark_for_rollback_on_error():
                     count = sql.DeleteQuery(model).delete_batch([instance.pk], self.using)
+                setattr(instance, instance._meta.pk.attname, None)
                 return count, {model._meta.label: count}
 
         with transaction.atomic(using=self.using, savepoint=False):

--- a/tests/delete/models.py
+++ b/tests/delete/models.py
@@ -126,3 +126,7 @@ class Base(models.Model):
 
 class RelToBase(models.Model):
     base = models.ForeignKey(Base, models.DO_NOTHING)
+
+
+class Simple(models.Model):
+    pass

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -6,7 +6,8 @@ from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
 from .models import (
     MR, A, Avatar, Base, Child, HiddenUser, HiddenUserProfile, M, M2MFrom,
-    M2MTo, MRNull, Parent, R, RChild, S, T, User, create_a, get_default_r,
+    M2MTo, MRNull, Parent, R, RChild, S, Simple, T, User, create_a,
+    get_default_r,
 )
 
 
@@ -522,3 +523,13 @@ class FastDeleteTests(TestCase):
                 User.objects.filter(avatar__desc='missing').delete(),
                 (0, {'delete.User': 0})
             )
+
+
+class FastDeletePkClearTests(TestCase):
+
+    def test_pk_cleared_on_delete_no_deps(self):
+        s = Simple.objects.create()
+        pk = s.pk
+        s.delete()
+        self.assertIsNone(s.pk)
+        self.assertFalse(Simple.objects.filter(pk=pk).exists())


### PR DESCRIPTION
## Summary
- clear in-memory PKs for the single-object fast-delete branch
- add regression coverage on a dependency-free model

## Issue
- Fixes #104

## Reproduction
1. cd tests
2. PYTHONPATH=/workspace/django ./runtests.py delete.tests.FastDeletePkClearTests.test_pk_cleared_on_delete_no_deps --parallel=1
3. In a manage.py shell:
   ```python
   from tests.delete.models import Simple
   s = Simple.objects.create()
   s.delete()
   s.pk
   ```
   returns `1`

## Observed failure
```
FAIL: test_pk_cleared_on_delete_no_deps (delete.tests.FastDeletePkClearTests.test_pk_cleared_on_delete_no_deps)
AssertionError: 1 is not None
```
`Simple.delete()` routes through `base.delete()` which terminates in the single-object fast-delete branch of `Collector.delete()` without clearing `instance._meta.pk.attname`.

## Fix
- after the fast-delete batch call, set the instance PK attribute to `None` before returning
- this branch bypasses `field_updates`, so no other mechanism clears the cached PK

## Testing
- PYTHONPATH=/workspace/django ./runtests.py delete.tests.FastDeletePkClearTests.test_pk_cleared_on_delete_no_deps --parallel=1