### PR TITLE
fix: normalize GenericForeignKey prefetch for UUID PKs (swev-id: django__django-11211)

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -199,15 +199,16 @@ class GenericForeignKey(FieldCacheMixin):
             ct_id = getattr(obj, ct_attname)
             if ct_id is None:
                 return None
-            else:
-                model = self.get_content_type(id=ct_id,
-                                              using=obj._state.db).model_class()
-                return (model._meta.pk.get_prep_value(getattr(obj, self.fk_field)),
-                        model)
+            model = self.get_content_type(id=ct_id, using=obj._state.db).model_class()
+            fk_value = getattr(obj, self.fk_field)
+            return (model._meta.pk.to_python(fk_value), model)
+
+        def rel_key(obj):
+            return (obj._meta.pk.get_prep_value(obj.pk), obj.__class__)
 
         return (
             ret_val,
-            lambda obj: (obj.pk, obj.__class__),
+            rel_key,
             gfk_key,
             True,
             self.name,
@@ -565,18 +566,28 @@ def create_generic_related_manager(superclass, rel):
             queryset._add_hints(instance=instances[0])
             queryset = queryset.using(queryset._db or self._db)
 
+            pk_field = instances[0]._meta.pk
+
+            def rel_key(obj):
+                return obj._meta.pk.get_prep_value(obj.pk)
+
             query = {
                 '%s__pk' % self.content_type_field_name: self.content_type.id,
-                '%s__in' % self.object_id_field_name: {obj.pk for obj in instances}
+                '%s__in' % self.object_id_field_name: {rel_key(obj) for obj in instances}
             }
 
             # We (possibly) need to convert object IDs to the type of the
             # instances' PK in order to match up instances:
             object_id_converter = instances[0]._meta.pk.to_python
+
+            def relobj_key(relobj):
+                return pk_field.get_prep_value(
+                    object_id_converter(getattr(relobj, self.object_id_field_name))
+                )
             return (
                 queryset.filter(**query),
-                lambda relobj: object_id_converter(getattr(relobj, self.object_id_field_name)),
-                lambda obj: obj.pk,
+                relobj_key,
+                rel_key,
                 False,
                 self.prefetch_cache_name,
                 False,

--- a/docs/ref/contrib/contenttypes.txt
+++ b/docs/ref/contrib/contenttypes.txt
@@ -314,6 +314,15 @@ model:
    should evaluate the models you expect to be pointing to and determine
    which solution will be most effective for your use case.
 
+.. note::
+
+   When relating to models whose primary keys are
+   :class:`~django.db.models.UUIDField` instances, ensure the values stored in
+   your ``object_id`` field can be coerced to the UUID field's Python type.
+   Django accepts :class:`uuid.UUID` objects as well as hyphenated or
+   hexadecimal string representations and normalizes them automatically when
+   resolving generic relations and prefetching.
+
 .. admonition:: Serializing references to ``ContentType`` objects
 
    If you're serializing data (for example, when generating

--- a/tests/prefetch_related/test_uuid.py
+++ b/tests/prefetch_related/test_uuid.py
@@ -1,4 +1,10 @@
+import uuid
+
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
 from django.test import TestCase
+from django.test.utils import isolate_apps
 
 from .models import Flea, House, Person, Pet, Room
 
@@ -102,3 +108,61 @@ class UUIDPrefetchRelatedLookups(TestCase):
             redwood = House.objects.prefetch_related('rooms__fleas__pets_visited').get(name='Redwood')
         with self.assertNumQueries(0):
             self.assertEqual('Spooky', redwood.rooms.all()[0].fleas.all()[0].pets_visited.all()[0].name)
+
+
+@isolate_apps('prefetch_related')
+class GenericForeignKeyUUIDPrefetchTests(TestCase):
+
+    class Foo(models.Model):
+        id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+        class Meta:
+            app_label = 'prefetch_related'
+
+    class Bar(models.Model):
+        foo_content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+        foo_object_id = models.CharField(max_length=255, db_index=True)
+        foo = GenericForeignKey('foo_content_type', 'foo_object_id')
+
+        class Meta:
+            app_label = 'prefetch_related'
+
+    def test_prefetch_related_generic_foreign_key_hyphenated_uuid(self):
+        foo_id = uuid.uuid4()
+        foo = self.Foo.objects.create(id=foo_id)
+        self.Bar.objects.create(
+            foo_content_type=ContentType.objects.get_for_model(self.Foo),
+            foo_object_id=str(foo_id),
+        )
+
+        bar = self.Bar.objects.get()
+        self.assertEqual(foo.pk, bar.foo.pk)
+
+        foo_field = next(field for field in self.Bar._meta.private_fields if field.name == 'foo')
+        rel_qs, rel_key, instance_key, *_ = foo_field.get_prefetch_queryset([bar])
+        self.assertIn(instance_key(bar), {rel_key(obj) for obj in rel_qs})
+
+        bars = list(self.Bar.objects.all().prefetch_related('foo'))
+
+        self.assertIsNotNone(bars[0].foo)
+        self.assertEqual(foo.pk, bars[0].foo.pk)
+
+    def test_prefetch_related_generic_foreign_key_hex_uuid(self):
+        foo_id = uuid.uuid4()
+        foo = self.Foo.objects.create(id=foo_id)
+        self.Bar.objects.create(
+            foo_content_type=ContentType.objects.get_for_model(self.Foo),
+            foo_object_id=foo_id.hex,
+        )
+
+        bar = self.Bar.objects.get()
+        self.assertEqual(foo.pk, bar.foo.pk)
+
+        foo_field = next(field for field in self.Bar._meta.private_fields if field.name == 'foo')
+        rel_qs, rel_key, instance_key, *_ = foo_field.get_prefetch_queryset([bar])
+        self.assertIn(instance_key(bar), {rel_key(obj) for obj in rel_qs})
+
+        bars = list(self.Bar.objects.all().prefetch_related('foo'))
+
+        self.assertIsNotNone(bars[0].foo)
+        self.assertEqual(foo.pk, bars[0].foo.pk)


### PR DESCRIPTION
## Summary
- normalize GenericForeignKey prefetch keys so UUID primary keys compare using the same Python type
- add regression coverage for hyphenated and hex UUID object_id values and document coercion expectations
- reference #112 and the upstream report https://github.com/justquick/django-activity-stream/issues/245

## Reproduction steps
1. Create a UUID primary key model `Foo` and a `Bar` model with `foo = GenericForeignKey('foo_content_type', 'foo_object_id')`.
2. Save a `Bar` pointing at a `Foo` row with `foo_object_id` stored as either a hyphenated UUID string or the hex form.
3. Evaluate `list(Bar.objects.all().prefetch_related('foo'))[0].foo`.

## Observed failure (before fix)
- The prefetched relation resolves to `None` because the in-memory join compares a normalized UUID from the instances with the raw `uuid.UUID` from the related objects.
- The new regression test previously failed with:
  ```
  self.assertIsNotNone(bars[0].foo)
  AssertionError: unexpectedly None
  ```

## Fix details
- Normalize the related-object key in `GenericForeignKey.get_prefetch_queryset()` via the related model's primary key field and convert the instance-side key with `to_python` so both sides use the canonical Python type.
- Update the reverse generic manager prefetch logic to normalize keys through the related model's primary key field as well.
- Add coverage in `tests/prefetch_related/test_uuid.py` for hyphenated and hex UUID representations and ensure the join helpers agree.
- Document that `object_id` values must be coercible to the target primary key's Python type, including UUID strings.

## Risk assessment
- Localized changes inside contenttypes prefetch helpers with direct regression tests exercising both UUID string shapes.
- Behavior for non-UUID primary keys is unaffected since the normalization defers to the existing model field conversions.

## Testing
- `python tests/runtests.py prefetch_related.test_uuid.GenericForeignKeyUUIDPrefetchTests`
- `flake8 django/contrib/contenttypes/fields.py tests/prefetch_related/test_uuid.py`