### PR TITLE
swev-id: django__django-11239 — dbshell: support PostgreSQL client certificate and key (PGSSLCERT/PGSSLKEY)

### DIFF
--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -30,6 +30,18 @@ class DatabaseClient(BaseDatabaseClient):
         subprocess_env = os.environ.copy()
         if passwd:
             subprocess_env['PGPASSWORD'] = str(passwd)
+        # Map SSL-related connection parameters to libpq environment variables
+        # so that psql/libpq can establish mutual TLS when configured.
+        ssl_mapping = {
+            'sslmode': 'PGSSLMODE',
+            'sslrootcert': 'PGSSLROOTCERT',
+            'sslcert': 'PGSSLCERT',
+            'sslkey': 'PGSSLKEY',
+        }
+        for opt_key, env_key in ssl_mapping.items():
+            opt_val = conn_params.get(opt_key)
+            if opt_val:
+                subprocess_env[env_key] = str(opt_val)
         try:
             # Allow SIGINT to pass to psql to abort queries.
             signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -94,3 +94,51 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
             DatabaseClient.runshell_db({})
         # dbshell restores the original handler.
         self.assertEqual(sigint_handler, signal.getsignal(signal.SIGINT))
+
+    def test_ssl_env_mapping_present(self):
+        """SSL-related OPTIONS map to libpq environment variables for psql."""
+        captured_env = {}
+
+        def _mock_subprocess_run(*args, env=os.environ, **kwargs):
+            captured_env.update(env)
+            return subprocess.CompletedProcess(args, 0)
+
+        dbinfo = {
+            'database': 'dbname',
+            'user': 'someuser',
+            'host': 'somehost',
+            'port': '444',
+            'sslmode': 'verify-full',
+            'sslrootcert': '/tmp/root.crt',
+            'sslcert': '/tmp/client.crt',
+            'sslkey': '/tmp/client.key',
+        }
+        with mock.patch('subprocess.run', new=_mock_subprocess_run):
+            DatabaseClient.runshell_db(dbinfo)
+
+        self.assertEqual(captured_env.get('PGSSLMODE'), 'verify-full')
+        self.assertEqual(captured_env.get('PGSSLROOTCERT'), '/tmp/root.crt')
+        self.assertEqual(captured_env.get('PGSSLCERT'), '/tmp/client.crt')
+        self.assertEqual(captured_env.get('PGSSLKEY'), '/tmp/client.key')
+
+    def test_ssl_env_mapping_absent(self):
+        """SSL-related env variables are not set when OPTIONS are absent."""
+        captured_env = {}
+
+        def _mock_subprocess_run(*args, env=os.environ, **kwargs):
+            captured_env.update(env)
+            return subprocess.CompletedProcess(args, 0)
+
+        dbinfo = {
+            'database': 'dbname',
+            'user': 'someuser',
+            'host': 'somehost',
+            'port': '444',
+        }
+        with mock.patch('subprocess.run', new=_mock_subprocess_run):
+            DatabaseClient.runshell_db(dbinfo)
+
+        self.assertIsNone(captured_env.get('PGSSLMODE'))
+        self.assertIsNone(captured_env.get('PGSSLROOTCERT'))
+        self.assertIsNone(captured_env.get('PGSSLCERT'))
+        self.assertIsNone(captured_env.get('PGSSLKEY'))

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -113,8 +113,9 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
             'sslcert': '/tmp/client.crt',
             'sslkey': '/tmp/client.key',
         }
-        with mock.patch('subprocess.run', new=_mock_subprocess_run):
-            DatabaseClient.runshell_db(dbinfo)
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch('subprocess.run', new=_mock_subprocess_run):
+                DatabaseClient.runshell_db(dbinfo)
 
         self.assertEqual(captured_env.get('PGSSLMODE'), 'verify-full')
         self.assertEqual(captured_env.get('PGSSLROOTCERT'), '/tmp/root.crt')
@@ -135,8 +136,9 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
             'host': 'somehost',
             'port': '444',
         }
-        with mock.patch('subprocess.run', new=_mock_subprocess_run):
-            DatabaseClient.runshell_db(dbinfo)
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with mock.patch('subprocess.run', new=_mock_subprocess_run):
+                DatabaseClient.runshell_db(dbinfo)
 
         self.assertIsNone(captured_env.get('PGSSLMODE'))
         self.assertIsNone(captured_env.get('PGSSLROOTCERT'))


### PR DESCRIPTION
This pull request adds support for PostgreSQL client TLS certificate and key in `manage.py dbshell`.

Summary
- Propagate PostgreSQL SSL client options from `DATABASES['default']['OPTIONS']` to the `psql` subprocess via libpq environment variables:
  - `sslmode` → `PGSSLMODE`
  - `sslrootcert` → `PGSSLROOTCERT`
  - `sslcert` → `PGSSLCERT`
  - `sslkey` → `PGSSLKEY`
- Preserves existing behavior for `PGPASSWORD`, args, and SIGINT handling.

Changes
- `django/db/backends/postgresql/client.py`: map `sslmode`, `sslrootcert`, `sslcert`, `sslkey` from `conn_params` into the subprocess environment.
- Tests in `tests/dbshell/test_postgresql.py`:
  - `test_ssl_env_mapping_present`: asserts PGSSL* variables are present when OPTIONS are provided.
  - `test_ssl_env_mapping_absent`: asserts variables are absent when not configured.

Observed failure, stack trace (error output), and reproduction steps (prior to fix)
- With a PostgreSQL server requiring client cert authentication and Django settings providing `sslmode`, `sslrootcert`, `sslcert`, `sslkey`, running `python manage.py dbshell` fails because libpq doesn’t receive client cert/key parameters.
- Representative psql/libpq error outputs:
  - `FATAL:  connection requires a valid client certificate`
  - `could not establish SSL connection: certificate verify failed`
  - `could not read private key file "/path/to/client.key": No such file or directory`
- Reproduction:
  1. Configure PostgreSQL to require client certificates (`pg_hba.conf` hostssl rule with cert auth).
  2. Provide client cert and key files with proper permissions (0600), and root CA if using `verify-full`.
  3. In Django settings, set:
     ```python
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'dbname',
             'USER': 'dbuser',
             'HOST': 'db.example.com',
             'PORT': '5432',
             'OPTIONS': {
                 'sslmode': 'verify-full',
                 'sslrootcert': '/path/to/root.crt',
                 'sslcert': '/path/to/client.crt',
                 'sslkey': '/path/to/client.key',
             },
         },
     }
     ```
  4. Run `python manage.py dbshell`.
  5. Before this PR: psql/libpq errors as above because PGSSL* variables weren’t set.
  6. After this PR: psql/libpq receives the parameters and mutual TLS succeeds.

Notes
- We pass SSL parameters via environment variables for parity with `PGPASSWORD` and to align with libpq’s supported mechanisms.
- No CI runs were triggered manually for this PR.

Task reference: swev-id: django__django-11239