### PR TITLE
swev-id: django__django-11451 - short-circuit missing auth queries

### DIFF
--- a/django/contrib/auth/backends.py
+++ b/django/contrib/auth/backends.py
@@ -39,6 +39,8 @@ class ModelBackend(BaseBackend):
     def authenticate(self, request, username=None, password=None, **kwargs):
         if username is None:
             username = kwargs.get(UserModel.USERNAME_FIELD)
+        if username is None or password is None:
+            return
         try:
             user = UserModel._default_manager.get_by_natural_key(username)
         except UserModel.DoesNotExist:

--- a/tests/auth_tests/test_auth_backends.py
+++ b/tests/auth_tests/test_auth_backends.py
@@ -242,6 +242,24 @@ class ModelBackendTest(BaseModelBackendTest, TestCase):
             password='test',
         )
 
+    @override_settings(PASSWORD_HASHERS=['auth_tests.test_auth_backends.CountingMD5PasswordHasher'])
+    def test_authenticate_missing_credentials_short_circuits(self):
+        backend = ModelBackend()
+        scenarios = (
+            {},
+            {'username': self.user_credentials['username']},
+            {'password': self.user_credentials['password']},
+        )
+        for credentials in scenarios:
+            with self.subTest(credentials=credentials):
+                CountingMD5PasswordHasher.calls = 0
+                with self.assertNumQueries(0):
+                    self.assertIsNone(backend.authenticate(None, **credentials))
+                self.assertEqual(CountingMD5PasswordHasher.calls, 0)
+
+    def test_authenticate_success_with_complete_credentials(self):
+        self.assertEqual(authenticate(**self.user_credentials), self.user)
+
     def test_authenticate_inactive(self):
         """
         An inactive user can't authenticate.


### PR DESCRIPTION
## Summary
- add an early return in `ModelBackend.authenticate()` for missing credentials to avoid hitting the database and password hashers
- extend auth backend tests with coverage for missing credential scenarios and confirm the success path still authenticates
- keep timing mitigation in place for unknown usernames with passwords via the existing counting hasher assertions

## Observed failure
- Steps to reproduce:
  1. Check out branch `django__django-11451`.
  2. Run `PYTHONPATH=/workspace/django /workspace/.venv/bin/python tests/runtests.py auth_tests.test_auth_backends --parallel=1`.
  3. Under the original code, calling `ModelBackend().authenticate(None, password='test')` produced a query like `SELECT "auth_user"."id", ... WHERE "auth_user"."username" IS NULL` and invoked `CountingMD5PasswordHasher.encode()` even though no user could match.
- The extra query and hasher call created unnecessary load and leaked timing information when credentials were incomplete.

## Fix verification
- New regression test `ModelBackendTest.test_authenticate_missing_credentials_short_circuits` asserts `assertNumQueries(0)` for `{}`, `{username}`, and `{password}` and checks `CountingMD5PasswordHasher.calls == 0`.
- `ModelBackendTest.test_authenticate_success_with_complete_credentials` confirms full credentials still authenticate successfully.
- The existing `test_authentication_timing` continues to show a single hash invocation for a non-existent username with a password, preserving the mitigation.

## Testing
- PYTHONPATH=/workspace/django /workspace/.venv/bin/python tests/runtests.py auth_tests.test_auth_backends --parallel=1
- /workspace/.venv/bin/flake8 django/contrib/auth/backends.py tests/auth_tests/test_auth_backends.py

Fixes #118