### PR TITLE
Optimize get_resolver caching to avoid duplicate URLResolver for default URLConf (swev-id: django__django-11333)

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -76,8 +76,9 @@ def get_resolver(urlconf=None):
     explicitly. The cache key is the supplied ``urlconf`` argument, so module
     paths, imported modules, and iterable URL pattern objects each maintain
     independent resolver instances. Use ``get_resolver.cache_clear()`` (or
-    ``clear_url_caches()``) to reset the cache, and
-    ``get_resolver.cache_info()`` to inspect hit and miss counts.
+    ``clear_url_caches()``) to reset the cache, ``get_resolver.cache_info()``
+    to inspect hit and miss counts, and ``get_resolver.cache_parameters()`` to
+    introspect configuration.
     """
     if urlconf is None:
         urlconf = settings.ROOT_URLCONF
@@ -86,6 +87,8 @@ def get_resolver(urlconf=None):
 
 get_resolver.cache_clear = _get_resolver_cached.cache_clear
 get_resolver.cache_info = _get_resolver_cached.cache_info
+if hasattr(_get_resolver_cached, "cache_parameters"):
+    get_resolver.cache_parameters = _get_resolver_cached.cache_parameters
 
 
 @functools.lru_cache(maxsize=None)

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -69,6 +69,16 @@ def _get_resolver_cached(urlconf):
 
 
 def get_resolver(urlconf=None):
+    """Return the cached URLResolver for *urlconf*.
+
+    Passing ``None`` reuses the resolver for ``settings.ROOT_URLCONF``; that
+    instance is identical to calling ``get_resolver(settings.ROOT_URLCONF)``
+    explicitly. The cache key is the supplied ``urlconf`` argument, so module
+    paths, imported modules, and iterable URL pattern objects each maintain
+    independent resolver instances. Use ``get_resolver.cache_clear()`` (or
+    ``clear_url_caches()``) to reset the cache, and
+    ``get_resolver.cache_info()`` to inspect hit and miss counts.
+    """
     if urlconf is None:
         urlconf = settings.ROOT_URLCONF
     return _get_resolver_cached(urlconf)

--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -64,10 +64,18 @@ class ResolverMatch:
 
 
 @functools.lru_cache(maxsize=None)
+def _get_resolver_cached(urlconf):
+    return URLResolver(RegexPattern(r'^/'), urlconf)
+
+
 def get_resolver(urlconf=None):
     if urlconf is None:
         urlconf = settings.ROOT_URLCONF
-    return URLResolver(RegexPattern(r'^/'), urlconf)
+    return _get_resolver_cached(urlconf)
+
+
+get_resolver.cache_clear = _get_resolver_cached.cache_clear
+get_resolver.cache_info = _get_resolver_cached.cache_info
 
 
 @functools.lru_cache(maxsize=None)

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1381,6 +1381,11 @@ class ResolverCacheTests(TestCase):
         self.assertEqual(info.misses, 0)
         self.assertEqual(info.currsize, 0)
 
+    def test_cache_parameters_exposed(self):
+        if not hasattr(get_resolver, "cache_parameters"):
+            self.skipTest("functools.lru_cache.cache_parameters unavailable")
+        self.assertEqual(get_resolver.cache_parameters(), {'maxsize': None, 'typed': False})
+
     def test_runtime_root_urlconf_change(self):
         default_resolver = get_resolver()
         self.assertEqual(default_resolver.urlconf_name, settings.ROOT_URLCONF)

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1352,3 +1352,67 @@ class ResolverCacheTests(TestCase):
         self.assertIs(default_resolver, default_again)
         self.assertIs(namespaced_resolver, namespaced_again)
         self.assertIsNot(default_resolver, namespaced_resolver)
+
+    def test_none_argument_reuses_default(self):
+        default_resolver = get_resolver()
+        none_resolver = get_resolver(None)
+        root_resolver = get_resolver(settings.ROOT_URLCONF)
+        self.assertIs(default_resolver, none_resolver)
+        self.assertIs(default_resolver, root_resolver)
+
+    def test_cache_info_counters(self):
+        info = get_resolver.cache_info()
+        self.assertEqual(info.hits, 0)
+        self.assertEqual(info.misses, 0)
+        self.assertEqual(info.currsize, 0)
+        get_resolver()
+        info = get_resolver.cache_info()
+        self.assertEqual(info.hits, 0)
+        self.assertEqual(info.misses, 1)
+        self.assertEqual(info.currsize, 1)
+        get_resolver()
+        info = get_resolver.cache_info()
+        self.assertEqual(info.hits, 1)
+        self.assertEqual(info.misses, 1)
+        self.assertEqual(info.currsize, 1)
+        get_resolver.cache_clear()
+        info = get_resolver.cache_info()
+        self.assertEqual(info.hits, 0)
+        self.assertEqual(info.misses, 0)
+        self.assertEqual(info.currsize, 0)
+
+    def test_runtime_root_urlconf_change(self):
+        default_resolver = get_resolver()
+        self.assertEqual(default_resolver.urlconf_name, settings.ROOT_URLCONF)
+        with override_settings(ROOT_URLCONF='urlpatterns_reverse.namespace_urls'):
+            clear_url_caches()
+            override_resolver = get_resolver()
+            self.assertEqual(override_resolver.urlconf_name, 'urlpatterns_reverse.namespace_urls')
+            self.assertIsNot(override_resolver, default_resolver)
+        clear_url_caches()
+        reverted_resolver = get_resolver()
+        self.assertEqual(reverted_resolver.urlconf_name, settings.ROOT_URLCONF)
+
+    def test_thread_overrides_are_isolated(self):
+        default_resolver = get_resolver()
+        results = {}
+
+        def worker(label, urlconf):
+            set_urlconf(urlconf)
+            try:
+                results[label] = get_resolver(get_urlconf())
+            finally:
+                set_urlconf(None)
+
+        first = threading.Thread(target=worker, args=('first', 'urlpatterns_reverse.namespace_urls'))
+        second = threading.Thread(target=worker, args=('second', 'urlpatterns_reverse.included_urls'))
+        first.start()
+        second.start()
+        first.join()
+        second.join()
+        self.assertIs(get_resolver(), default_resolver)
+        self.assertEqual(results['first'].urlconf_name, 'urlpatterns_reverse.namespace_urls')
+        self.assertEqual(results['second'].urlconf_name, 'urlpatterns_reverse.included_urls')
+        self.assertIsNot(results['first'], results['second'])
+        self.assertIsNot(results['first'], default_resolver)
+        self.assertIsNot(results['second'], default_resolver)

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -3,6 +3,7 @@ Unit tests for reverse URL lookups.
 """
 import sys
 import threading
+from unittest.mock import patch
 
 from admin_scripts.tests import AdminScriptTestCase
 
@@ -17,8 +18,8 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.test.utils import override_script_prefix
 from django.urls import (
     NoReverseMatch, Resolver404, ResolverMatch, URLPattern, URLResolver,
-    get_callable, get_resolver, get_urlconf, include, path, re_path, resolve,
-    reverse, reverse_lazy,
+    clear_url_caches, get_callable, get_resolver, get_urlconf, include, path,
+    re_path, resolve, reverse, reverse_lazy, set_urlconf,
 )
 from django.urls.resolvers import RegexPattern
 
@@ -1302,3 +1303,52 @@ class LookaheadTests(SimpleTestCase):
             with self.subTest(name=name, kwargs=kwargs):
                 with self.assertRaises(NoReverseMatch):
                     reverse(name, kwargs=kwargs)
+
+
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')
+class ResolverCacheTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        clear_url_caches()
+        self.addCleanup(clear_url_caches)
+        set_urlconf(None)
+        self.addCleanup(set_urlconf, None)
+
+    def test_default_resolver_reused_after_reset(self):
+        with patch(
+            'django.urls.resolvers.URLResolver.__init__',
+            autospec=True,
+            wraps=URLResolver.__init__,
+        ) as init:
+            with patch(
+                'django.urls.resolvers.URLResolver._populate',
+                autospec=True,
+                wraps=URLResolver._populate,
+            ) as populate:
+                reverse('hardcoded')
+                root_resolver = get_resolver()
+                set_urlconf(settings.ROOT_URLCONF)
+                reverse('hardcoded')
+                set_urlconf(None)
+        root_init_calls = [call for call in init.call_args_list if call.args[2] == settings.ROOT_URLCONF]
+        self.assertEqual(len(root_init_calls), 1)
+        root_populate_calls = [call for call in populate.call_args_list if call.args[0] is root_resolver]
+        self.assertEqual(len(root_populate_calls), 1)
+
+    def test_thread_local_override_uses_distinct_resolver(self):
+        default_resolver = get_resolver()
+        set_urlconf('urlpatterns_reverse.namespace_urls')
+        override_resolver = get_resolver(get_urlconf())
+        set_urlconf(None)
+        reused_resolver = get_resolver()
+        self.assertIsNot(default_resolver, override_resolver)
+        self.assertIs(default_resolver, reused_resolver)
+
+    def test_explicit_arguments_cache_independently(self):
+        default_resolver = get_resolver('urlpatterns_reverse.urls')
+        default_again = get_resolver('urlpatterns_reverse.urls')
+        namespaced_resolver = get_resolver('urlpatterns_reverse.namespace_urls')
+        namespaced_again = get_resolver('urlpatterns_reverse.namespace_urls')
+        self.assertIs(default_resolver, default_again)
+        self.assertIs(namespaced_resolver, namespaced_again)
+        self.assertIsNot(default_resolver, namespaced_resolver)


### PR DESCRIPTION
## Summary
- resolve #115 by normalizing `None` URLConfs through a shared `_get_resolver_cached()` helper
- delegate `get_resolver.cache_clear/info` to the helper so cache management stays intact
- cover default reuse, thread overrides, and explicit urlconf arguments with new resolver cache tests

## Reproduction
_Pre-change_
1. `clear_url_caches()`
2. `reverse('hardcoded')`
3. `set_urlconf(settings.ROOT_URLCONF)` then `reverse('hardcoded')`
4. Instrument `URLResolver.__init__` or `_populate` → both run twice for the root URLConf

_Post-change_
- The same sequence creates a single `URLResolver` and calls `_populate` once while still honoring overrides and explicit urlconfs.

## Compatibility
- Explicit `get_resolver(urlconf)` lookups retain distinct cache entries
- Thread-local `set_urlconf()` overrides continue to surface distinct resolvers and reuse the default after reset

## Testing
- `PYTHONPATH=/workspace/django ./runtests.py urlpatterns_reverse.tests --verbosity=2 --parallel=1`
- `flake8 django/urls/resolvers.py tests/urlpatterns_reverse/tests.py`