### PR TITLE
fix(admin): respect ordering fallback in filters (swev-id: django__django-11400)

### DIFF
--- a/django/contrib/admin/filters.py
+++ b/django/contrib/admin/filters.py
@@ -194,10 +194,11 @@ class RelatedFieldListFilter(FieldListFilter):
         return [self.lookup_kwarg, self.lookup_kwarg_isnull]
 
     def field_choices(self, field, request, model_admin):
-        ordering = ()
-        related_admin = model_admin.admin_site._registry.get(field.remote_field.model)
-        if related_admin is not None:
-            ordering = related_admin.get_ordering(request)
+        related_model = field.remote_field.model
+        related_admin = model_admin.admin_site._registry.get(related_model)
+        ordering = related_admin.get_ordering(request) if related_admin is not None else ()
+        if not ordering:
+            ordering = related_model._meta.ordering or ()
         return field.get_choices(include_blank=False, ordering=ordering)
 
     def choices(self, changelist):
@@ -419,4 +420,13 @@ FieldListFilter.register(lambda f: True, AllValuesFieldListFilter)
 class RelatedOnlyFieldListFilter(RelatedFieldListFilter):
     def field_choices(self, field, request, model_admin):
         pk_qs = model_admin.get_queryset(request).distinct().values_list('%s__pk' % self.field_path, flat=True)
-        return field.get_choices(include_blank=False, limit_choices_to={'pk__in': pk_qs})
+        related_model = field.remote_field.model
+        related_admin = model_admin.admin_site._registry.get(related_model)
+        ordering = related_admin.get_ordering(request) if related_admin is not None else ()
+        if not ordering:
+            ordering = related_model._meta.ordering or ()
+        return field.get_choices(
+            include_blank=False,
+            limit_choices_to={'pk__in': pk_qs},
+            ordering=ordering,
+        )

--- a/tests/admin_filters/models.py
+++ b/tests/admin_filters/models.py
@@ -77,3 +77,21 @@ class Bookmark(models.Model):
 
     def __str__(self):
         return self.url
+
+
+class OrderedCategory(models.Model):
+    name = models.CharField(max_length=50)
+
+    class Meta:
+        ordering = ['name']
+
+    def __str__(self):
+        return self.name
+
+
+class Item(models.Model):
+    name = models.CharField(max_length=50)
+    category = models.ForeignKey(OrderedCategory, models.CASCADE)
+
+    def __str__(self):
+        return self.name

--- a/tests/admin_filters/tests.py
+++ b/tests/admin_filters/tests.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
 
-from .models import Book, Bookmark, Department, Employee, TaggedItem
+from .models import Book, Bookmark, Department, Employee, Item, OrderedCategory, TaggedItem
 
 
 def select_by(dictlist, key, value):
@@ -589,6 +589,50 @@ class ListFiltersTests(TestCase):
         changelist = modeladmin.get_changelist_instance(request)
         filterspec = changelist.get_filters(request)[0][0]
         expected = [(self.john.pk, 'John Blue'), (self.jack.pk, 'Jack Red')]
+        self.assertEqual(filterspec.lookup_choices, expected)
+
+    def test_relatedfieldlistfilter_uses_related_model_ordering_when_admin_empty(self):
+        class OrderedCategoryAdmin(ModelAdmin):
+            ordering = []
+
+        class ItemAdmin(ModelAdmin):
+            list_filter = ('category',)
+
+        site.register(OrderedCategory, OrderedCategoryAdmin)
+        self.addCleanup(lambda: site.unregister(OrderedCategory))
+        bravo = OrderedCategory.objects.create(name='Bravo')
+        alpha = OrderedCategory.objects.create(name='Alpha')
+        Item.objects.create(name='Bravo Item', category=bravo)
+        Item.objects.create(name='Alpha Item', category=alpha)
+
+        modeladmin = ItemAdmin(Item, site)
+        request = self.request_factory.get('/')
+        request.user = self.alfred
+        changelist = modeladmin.get_changelist_instance(request)
+        filterspec = changelist.get_filters(request)[0][0]
+        expected = [(alpha.pk, 'Alpha'), (bravo.pk, 'Bravo')]
+        self.assertEqual(filterspec.lookup_choices, expected)
+
+    def test_relatedonlyfieldlistfilter_uses_related_model_ordering_when_admin_empty(self):
+        class OrderedCategoryAdmin(ModelAdmin):
+            ordering = []
+
+        class ItemAdmin(ModelAdmin):
+            list_filter = (('category', RelatedOnlyFieldListFilter),)
+
+        site.register(OrderedCategory, OrderedCategoryAdmin)
+        self.addCleanup(lambda: site.unregister(OrderedCategory))
+        bravo = OrderedCategory.objects.create(name='Bravo')
+        alpha = OrderedCategory.objects.create(name='Alpha')
+        Item.objects.create(name='Bravo Item', category=bravo)
+        Item.objects.create(name='Alpha Item', category=alpha)
+
+        modeladmin = ItemAdmin(Item, site)
+        request = self.request_factory.get('/')
+        request.user = self.alfred
+        changelist = modeladmin.get_changelist_instance(request)
+        filterspec = changelist.get_filters(request)[0][0]
+        expected = [(alpha.pk, 'Alpha'), (bravo.pk, 'Bravo')]
         self.assertEqual(filterspec.lookup_choices, expected)
 
     def test_relatedfieldlistfilter_manytomany(self):


### PR DESCRIPTION
## Problem
RelatedFieldListFilter and RelatedOnlyFieldListFilter lose deterministic ordering when the related ModelAdmin defines an empty ordering, so the admin shows related choices by primary key instead of the related model's Meta.ordering (see #122).

## Changes
- add OrderedCategory and Item helper models to exercise ordering behavior in admin list filters
- extend ListFiltersTests with coverage for RelatedFieldListFilter and RelatedOnlyFieldListFilter fallback ordering
- update RelatedFieldListFilter and RelatedOnlyFieldListFilter to fall back to the related model Meta.ordering whenever the related ModelAdmin ordering is empty

## Tests Added
- admin_filters.tests.ListFiltersTests.test_relatedfieldlistfilter_uses_related_model_ordering_when_admin_empty
- admin_filters.tests.ListFiltersTests.test_relatedonlyfieldlistfilter_uses_related_model_ordering_when_admin_empty

## Reproduction Steps
1. source /workspace/.venv/bin/activate
2. cd /workspace/django/tests
3. PYTHONPATH=/workspace/django ./runtests.py admin_filters.tests.ListFiltersTests --parallel=1

## Observed Failure (pre-fix)
```
FAIL: test_relatedfieldlistfilter_uses_related_model_ordering_when_admin_empty (admin_filters.tests.ListFiltersTests)
AssertionError: Lists differ: [(1, 'Bravo'), (2, 'Alpha')] != [(2, 'Alpha'), (1, 'Bravo')]
```

## Post-Fix Verification
- PYTHONPATH=/workspace/django ./runtests.py admin_filters.tests.ListFiltersTests --parallel=1
- flake8 django/contrib/admin/filters.py tests/admin_filters/tests.py tests/admin_filters/models.py

## Issue
- Closes #122