### PR TITLE
swev-id: django__django-11299 forward SimpleCol through nested Q

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1338,7 +1338,7 @@ class Query(BaseExpression):
             if isinstance(child, Node):
                 child_clause, needed_inner = self._add_q(
                     child, used_aliases, branch_negated,
-                    current_negated, allow_joins, split_subq)
+                    current_negated, allow_joins, split_subq, simple_col=simple_col)
                 joinpromoter.add_votes(needed_inner)
             else:
                 child_clause, needed_inner = self.build_filter(

--- a/tests/constraints/models.py
+++ b/tests/constraints/models.py
@@ -20,3 +20,36 @@ class Product(models.Model):
                 condition=models.Q(color__isnull=True),
             ),
         ]
+
+
+class MixedCheck(models.Model):
+    first_value = models.IntegerField()
+    second_value = models.IntegerField()
+    third_value = models.IntegerField(null=True)
+    fourth_value = models.IntegerField()
+    flag = models.BooleanField(default=False)
+
+    class Meta:
+        constraints = [
+            models.CheckConstraint(
+                check=(
+                    models.Q(first_value__gt=models.F('second_value')) | (
+                        models.Q(third_value__isnull=False)
+                        & models.Q(fourth_value__lt=models.F('second_value'))
+                    )
+                )
+                & models.Q(flag=True),
+                name='mixed_or_and_check',
+            ),
+            models.UniqueConstraint(
+                fields=['first_value', 'flag'],
+                name='mixed_or_and_unique',
+                condition=(
+                    models.Q(third_value__gt=models.F('fourth_value'))
+                    | (
+                        models.Q(second_value__lte=models.F('fourth_value'))
+                        & models.Q(third_value__isnull=True)
+                    )
+                ),
+            ),
+        ]

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -3,7 +3,7 @@ from django.db import IntegrityError, connection, models
 from django.db.models.constraints import BaseConstraint
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 
-from .models import Product
+from .models import MixedCheck, Product
 
 
 def get_constraints(table):
@@ -187,3 +187,31 @@ class UniqueConstraintTests(TestCase):
     def test_condition_must_be_q(self):
         with self.assertRaisesMessage(ValueError, 'UniqueConstraint.condition must be a Q instance.'):
             models.UniqueConstraint(name='uniq', fields=['name'], condition='invalid')
+
+
+class ConstraintSQLGenerationTests(TestCase):
+    @skipUnlessDBFeature('supports_table_check_constraints')
+    def test_check_constraint_sql_uses_unqualified_columns_on_sqlite(self):
+        if connection.vendor != 'sqlite':
+            self.skipTest('Test only applies to SQLite.')
+        constraint = MixedCheck._meta.constraints[0]
+        editor = connection.schema_editor(collect_sql=True)
+        sql = constraint._get_check_sql(MixedCheck, editor)
+        table = MixedCheck._meta.db_table
+        self.assertNotIn('"%s"."' % table, sql)
+        self.assertNotIn('new__', sql)
+        for column in ['first_value', 'second_value', 'third_value', 'fourth_value', 'flag']:
+            self.assertIn('"%s"' % column, sql)
+
+    @skipUnlessDBFeature('supports_table_check_constraints')
+    def test_unique_constraint_condition_sql_uses_unqualified_columns_on_sqlite(self):
+        if connection.vendor != 'sqlite':
+            self.skipTest('Test only applies to SQLite.')
+        constraint = MixedCheck._meta.constraints[1]
+        editor = connection.schema_editor(collect_sql=True)
+        sql = constraint._get_condition_sql(MixedCheck, editor)
+        table = MixedCheck._meta.db_table
+        self.assertNotIn('"%s"."' % table, sql)
+        self.assertNotIn('new__', sql)
+        for column in ['second_value', 'third_value', 'fourth_value']:
+            self.assertIn('"%s"' % column, sql)


### PR DESCRIPTION
## Summary
- forward the `simple_col` flag when recursing through `Query._add_q()` so nested Q objects used by constraints keep using `SimpleCol`
- add a regression model + SQLite assertions covering mixed OR/AND CheckConstraint and conditional UniqueConstraint SQL

## Testing
- PYTHONPATH=/workspace/django ./runtests.py constraints --parallel=1

## Reproduction
1. Check out commit 6866c91b63 (before this patch)
2. Run `PYTHONPATH=/workspace/django ./runtests.py constraints.tests.ConstraintSQLGenerationTests --parallel=1`
3. SQLite fails while remaking the table with `OperationalError: malformed database schema (constraints_mixedcheck) - no such column: new__constraints_mixedcheck.first_value`

Fixes #121
