### PR TITLE
fix: swev-id: django__django-11265 preserve filtered relations in excludes

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1666,11 +1666,18 @@ class Query(BaseExpression):
             filter_expr = (filter_lhs, OuterRef(filter_rhs.name))
         # Generate the inner query.
         query = Query(self.model)
+        if self._filtered_relations:
+            query._filtered_relations = {
+                alias: filtered_relation.clone()
+                for alias, filtered_relation in self._filtered_relations.items()
+            }
         query.add_filter(filter_expr)
         query.clear_ordering(True)
         # Try to have as simple as possible subquery -> trim leading joins from
         # the subquery.
         trimmed_prefix, contains_louter = query.trim_start(names_with_path)
+        if self._filtered_relations:
+            query.external_aliases.update(self._filtered_relations)
 
         # Add extra check to make sure the selected field will not be null
         # since we are adding an IN <subquery> clause. This prevents the
@@ -2119,13 +2126,22 @@ class Query(BaseExpression):
             t for t in self.alias_map
             if t in self._lookup_joins or t == self.base_table
         ]
-        for trimmed_paths, path in enumerate(all_paths):
-            if path.m2m:
+        trimmed_any = False
+        trimmed_paths = 0
+        for idx, current_path in enumerate(all_paths):
+            if current_path.m2m or current_path.filtered_relation is not None:
+                trimmed_paths = idx
+                path = current_path
                 break
-            if self.alias_map[lookup_tables[trimmed_paths + 1]].join_type == LOUTER:
+            next_alias = lookup_tables[idx + 1]
+            if self.alias_map[next_alias].join_type == LOUTER:
                 contains_louter = True
-            alias = lookup_tables[trimmed_paths]
+            alias = lookup_tables[idx]
             self.unref_alias(alias)
+            trimmed_any = True
+        else:
+            trimmed_paths = len(all_paths) - 1
+            path = all_paths[-1]
         # The path.join_field is a Rel, lets get the other side's field
         join_field = path.join_field.field
         # Build the filter prefix.
@@ -2145,7 +2161,8 @@ class Query(BaseExpression):
         if self.alias_map[lookup_tables[trimmed_paths + 1]].join_type != LOUTER:
             select_fields = [r[0] for r in join_field.related_fields]
             select_alias = lookup_tables[trimmed_paths + 1]
-            self.unref_alias(lookup_tables[trimmed_paths])
+            if trimmed_any:
+                self.unref_alias(lookup_tables[trimmed_paths])
             extra_restriction = join_field.get_extra_restriction(
                 self.where_class, None, lookup_tables[trimmed_paths + 1])
             if extra_restriction:

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -139,6 +139,54 @@ class FilteredRelationTests(TestCase):
             [self.author1]
         )
 
+    def test_exclude_isnull_on_filtered_relation(self):
+        qs = Author.objects.annotate(
+            book_alice=FilteredRelation(
+                'book', condition=Q(book__title__iexact='poem by alice')
+            ),
+        ).exclude(book_alice__isnull=False)
+        self.assertSequenceEqual(qs.order_by('pk'), [self.author2])
+
+    def test_exclude_deep_lookup_on_filtered_relation(self):
+        qs = Author.objects.annotate(
+            book_alice=FilteredRelation(
+                'book', condition=Q(book__title__iexact='poem by alice')
+            ),
+        ).exclude(book_alice__title__icontains='Jane')
+        self.assertSequenceEqual(qs.order_by('pk'), [self.author1, self.author2])
+
+    def test_exclude_uses_filtered_alias_in_subquery(self):
+        qs = Author.objects.annotate(
+            book_jane=FilteredRelation(
+                'book', condition=Q(book__title__icontains='jane')
+            ),
+        ).exclude(book_jane__isnull=False)
+        sql = str(qs.query)
+        author_id = '%s.%s' % (
+            connection.ops.quote_name('filtered_relation_author'),
+            connection.ops.quote_name('id'),
+        )
+        self.assertIn(f'NOT ({author_id} IN', sql)
+        self.assertIn(connection.ops.quote_name('filtered_relation_book'), sql)
+        where_node = qs.query.where.children[0]
+        in_lookup = where_node.children[0]
+        subquery = in_lookup.rhs
+        filtered_aliases = [
+            join.filtered_relation.alias
+            for join in subquery.alias_map.values()
+            if getattr(join, 'filtered_relation', None)
+        ]
+        self.assertIn('book_jane', filtered_aliases)
+
+    def test_exclude_isnull_on_m2m_filtered_relation(self):
+        qs = Author.objects.annotate(
+            favorite_books_written_by_jane=FilteredRelation(
+                'favorite_books',
+                condition=Q(favorite_books__author=self.author2),
+            ),
+        ).exclude(favorite_books_written_by_jane__isnull=False)
+        self.assertSequenceEqual(qs.order_by('pk'), [self.author2])
+
     def test_exclude_relation_with_join(self):
         self.assertSequenceEqual(
             Author.objects.annotate(


### PR DESCRIPTION
## Summary
- copy filtered relation definitions into exclude subqueries
- guard trim_start from discarding filtered joins so ON clauses persist
- add regression coverage for exclude filters on annotated and m2m filtered relations

## Testing
- PYTHONPATH=/workspace/django python3 tests/runtests.py filtered_relation

Fixes #124