### PR TITLE
Fix admin.E108 for instance-only accessible fields (swev-id: django__django-11551)

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -716,26 +716,14 @@ class ModelAdminChecks(BaseModelAdminChecks):
             ))
 
     def _check_list_display_item(self, obj, item, label):
-        if callable(item):
+        if callable(item) or hasattr(obj, item):
             return []
-        elif hasattr(obj, item):
-            return []
-        elif hasattr(obj.model, item):
-            try:
-                field = obj.model._meta.get_field(item)
-            except FieldDoesNotExist:
+
+        try:
+            field = obj.model._meta.get_field(item)
+        except FieldDoesNotExist:
+            if hasattr(obj.model, item):
                 return []
-            else:
-                if isinstance(field, models.ManyToManyField):
-                    return [
-                        checks.Error(
-                            "The value of '%s' must not be a ManyToManyField." % label,
-                            obj=obj.__class__,
-                            id='admin.E109',
-                        )
-                    ]
-                return []
-        else:
             return [
                 checks.Error(
                     "The value of '%s' refers to '%s', which is not a callable, "
@@ -747,6 +735,16 @@ class ModelAdminChecks(BaseModelAdminChecks):
                     id='admin.E108',
                 )
             ]
+
+        if isinstance(field, models.ManyToManyField):
+            return [
+                checks.Error(
+                    "The value of '%s' must not be a ManyToManyField." % label,
+                    obj=obj.__class__,
+                    id='admin.E109',
+                )
+            ]
+        return []
 
     def _check_list_display_links(self, obj):
         """ Check that list_display_links is a unique subset of list_display.

--- a/tests/modeladmin/test_checks.py
+++ b/tests/modeladmin/test_checks.py
@@ -3,10 +3,12 @@ from django.contrib.admin import BooleanFieldListFilter, SimpleListFilter
 from django.contrib.admin.options import VERTICAL, ModelAdmin, TabularInline
 from django.contrib.admin.sites import AdminSite
 from django.core.checks import Error
+from django.db import models
 from django.db.models import F
 from django.db.models.functions import Upper
 from django.forms.models import BaseModelFormSet
 from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
 
 from .models import (
     Band, Song, User, ValidationTestInlineModel, ValidationTestModel,
@@ -508,6 +510,37 @@ class ListDisplayTests(CheckTestCase):
             list_display = ('name', 'decade_published_in', 'a_method', a_callable)
 
         self.assertIsValid(TestModelAdmin, ValidationTestModel)
+
+    def test_field_accessible_only_via_instance(self):
+        class RaisingDescriptor:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+
+            def __get__(self, instance, owner=None):
+                if instance is None:
+                    raise AttributeError('position unavailable on class')
+                return self.wrapped.__get__(instance, owner)
+
+            def __set__(self, instance, value):
+                return self.wrapped.__set__(instance, value)
+
+            def __delete__(self, instance):
+                return self.wrapped.__delete__(instance)
+
+        with isolate_apps('modeladmin'):
+            class TempModel(models.Model):
+                position = models.IntegerField()
+
+                class Meta:
+                    app_label = 'modeladmin'
+
+            descriptor = TempModel.__dict__['position']
+            TempModel.position = RaisingDescriptor(descriptor)
+
+            class TempModelAdmin(ModelAdmin):
+                list_display = ('position',)
+
+            self.assertIsValid(TempModelAdmin, TempModel)
 
 
 class ListDisplayLinksCheckTests(CheckTestCase):


### PR DESCRIPTION
## Summary
- Fixes #139 by ensuring ModelAdmin list_display checks accept fields exposed only at runtime on model instances.
- Always resolves the model field before checking model attribute fallbacks while preserving the ManyToMany rejection.
- Adds regression coverage for descriptors that raise AttributeError when accessed on the model class.

## Reproduction
```bash
cd /workspace/django/tests
python -m pip install -e ..
python -m pip install -r requirements/py3.txt
./runtests.py modeladmin.test_checks.ListDisplayTests.test_field_accessible_only_via_instance
```

## Observed Failure
```text
F
======================================================================
FAIL: test_field_accessible_only_via_instance (modeladmin.test_checks.ListDisplayTests.test_field_accessible_only_via_instance)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/modeladmin/test_checks.py", line 543, in test_field_accessible_only_via_instance
    self.assertIsValid(TempModelAdmin, TempModel)
  File "/workspace/django/tests/modeladmin/test_checks.py", line 45, in assertIsValid
    self.assertEqual(admin_obj.check(), [])
AssertionError: Lists differ: [<Error: level=40, msg="The value of 'list[291 chars]08'>] != []

First list contains 1 additional elements.
First extra element 0:
<Error: level=40, msg="The value of 'list_display[0]' refers to 'position', which is not a callable, an attribute of 'TempModelAdmin', or an attribute or method on 'modeladmin.TempModel'.", hint=None, obj=<class 'modeladmin.test_checks.ListDisplayTests.test_field_accessible_only_via_instance.<locals>.TempModelAdmin'>, id='admin.E108'>

- [<Error: level=40, msg="The value of 'list_display[0]' refers to 'position', which is not a callable, an attribute of 'TempModelAdmin', or an attribute or method on 'modeladmin.TempModel'.", hint=None, obj=<class 'modeladmin.test_checks.ListDisplayTests.test_field_accessible_only_via_instance.<locals>.TempModelAdmin'>, id='admin.E108'>]
+ []

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (failures=1)
Testing against Django installed in '/workspace/django/django' with up to 16 processes
System check identified no issues (0 silenced).
```

## Testing
- ./runtests.py modeladmin.test_checks.ListDisplayTests.test_field_accessible_only_via_instance
- ./runtests.py modeladmin.test_checks
- python -m flake8 django/contrib/admin/checks.py tests/modeladmin/test_checks.py

## Notes
- CI should not be run per project instruction.
