### PR TITLE
swev-id: django__django-11728 — Fix trailing group replacement in simplify_regex()

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -167,18 +167,17 @@ def replace_named_groups(pattern):
         # Handle nested parentheses, e.g. '^(?P<a>(x|y))/b'.
         unmatched_open_brackets, prev_char = 1, None
         for idx, val in enumerate(pattern[end:]):
-            # If brackets are balanced, the end of the string for the current
-            # named capture group pattern has been reached.
-            if unmatched_open_brackets == 0:
-                group_pattern_and_name.append((pattern[start:end + idx], group_name))
-                break
-
             # Check for unescaped `(` and `)`. They mark the start and end of a
             # nested group.
             if val == '(' and prev_char != '\\':
                 unmatched_open_brackets += 1
             elif val == ')' and prev_char != '\\':
                 unmatched_open_brackets -= 1
+            # If brackets are balanced, the end of the string for the current
+            # named capture group pattern has been reached.
+            if unmatched_open_brackets == 0:
+                group_pattern_and_name.append((pattern[start:end + idx + 1], group_name))
+                break
             prev_char = val
 
     # Replace the string for named capture groups with their group names.
@@ -201,16 +200,15 @@ def replace_unnamed_groups(pattern):
         # Handle nested parentheses, e.g. '^b/((x|y)\w+)$'.
         unmatched_open_brackets, prev_char = 1, None
         for idx, val in enumerate(pattern[start + 1:]):
-            if unmatched_open_brackets == 0:
-                group_indices.append((start, start + 1 + idx))
-                break
-
             # Check for unescaped `(` and `)`. They mark the start and end of
             # a nested group.
             if val == '(' and prev_char != '\\':
                 unmatched_open_brackets += 1
             elif val == ')' and prev_char != '\\':
                 unmatched_open_brackets -= 1
+            if unmatched_open_brackets == 0:
+                group_indices.append((start, start + idx + 2))
+                break
             prev_char = val
 
     # Remove unnamed group matches inside other unnamed capture groups.

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -354,6 +354,21 @@ class AdminDocViewFunctionsTests(SimpleTestCase):
             (r'^(?P<a>(x|y))/b/(?P<c>\w+)ab', '/<a>/b/<c>ab'),
             (r'^(?P<a>(x|y)(\(|\)))/b/(?P<c>\w+)ab', '/<a>/b/<c>ab'),
             (r'^a/?$', '/a/'),
+            (
+                r'entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)',
+                '/entries/<pk>/relationships/<related_field>',
+            ),
+            (
+                r'^entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)$',
+                '/entries/<pk>/relationships/<related_field>',
+            ),
+            (
+                r'entries/(?P<pk>[^/.]+)/relationships/(?P<related_field>\w+)/',
+                '/entries/<pk>/relationships/<related_field>/',
+            ),
+            (r'entries/(\w+)', '/entries/<var>'),
+            (r'(?P<a>\w+)/b/(\w+)', '/<a>/b/<var>'),
+            (r'foo/(?P<a>(x|y)(\(|\)))', '/foo/<a>'),
         )
         for pattern, output in tests:
             with self.subTest(pattern=pattern):


### PR DESCRIPTION
## Summary
- ensure replace_named_groups() and replace_unnamed_groups() include trailing closing parens when collecting segments
- keep simplified boundary/local logic by updating counters before the balance check
- add regression cases covering trailing named/unnamed combinations and nested escaped groups

## Testing
- Python 3.11.14
- PYTHONPATH=/workspace/django ./tests/runtests.py admin_docs.test_views.AdminDocViewFunctionsTests
- flake8 django/contrib/admindocs/utils.py tests/admin_docs/test_views.py

## Reproduction
1. Save the demonstration script from #135 (demo.py) locally.
2. Run `python demo.py`.
3. Observe the missing replacement for the trailing group without a trailing slash.

## Stack trace
```
Traceback (most recent call last):
  File "demo.py", line 21, in <module>
    assert path == expected_path, "path without trailing slash didn't match expected"
AssertionError: path without trailing slash didn't match expected
```

Fixes #135.