### PR TITLE
Add DISTINCT support for Avg and Sum aggregates (and Min/Max) [skip ci] (swev-id: django__django-11603)

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -99,6 +99,7 @@ class Aggregate(Func):
 class Avg(FixDurationInputMixin, NumericOutputFieldMixin, Aggregate):
     function = 'AVG'
     name = 'Avg'
+    allow_distinct = True
 
 
 class Count(Aggregate):
@@ -121,11 +122,13 @@ class Count(Aggregate):
 class Max(Aggregate):
     function = 'MAX'
     name = 'Max'
+    allow_distinct = True
 
 
 class Min(Aggregate):
     function = 'MIN'
     name = 'Min'
+    allow_distinct = True
 
 
 class StdDev(NumericOutputFieldMixin, Aggregate):
@@ -142,6 +145,7 @@ class StdDev(NumericOutputFieldMixin, Aggregate):
 class Sum(FixDurationInputMixin, Aggregate):
     function = 'SUM'
     name = 'Sum'
+    allow_distinct = True
 
 
 class Variance(NumericOutputFieldMixin, Aggregate):

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -140,6 +140,25 @@ class AggregateTestCase(TestCase):
         vals = Publisher.objects.aggregate(Sum("book__price"))
         self.assertEqual(vals, {'book__price__sum': Decimal('270.27')})
 
+    def test_distinct_avg_sum(self):
+        result = Author.objects.aggregate(
+            avg_distinct=Avg('age', distinct=True),
+            sum_distinct=Sum('age', distinct=True),
+        )
+        self.assertEqual(result['sum_distinct'], 308)
+        self.assertEqual(result['avg_distinct'], Approximate(38.5, places=1))
+
+    def test_distinct_min_max(self):
+        distinct = Author.objects.aggregate(
+            min_age=Min('age', distinct=True),
+            max_age=Max('age', distinct=True),
+        )
+        non_distinct = Author.objects.aggregate(
+            min_age=Min('age'),
+            max_age=Max('age'),
+        )
+        self.assertEqual(distinct, non_distinct)
+
     def test_aggregate_multi_join(self):
         vals = Store.objects.aggregate(Max("books__authors__age"))
         self.assertEqual(vals, {'books__authors__age__max': 57})

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1584,8 +1584,12 @@ class ReprTests(SimpleTestCase):
         self.assertEqual(repr(Variance('a', sample=True)), "Variance(F(a), sample=True)")
 
     def test_distinct_aggregates(self):
+        self.assertEqual(repr(Avg('a', distinct=True)), "Avg(F(a), distinct=True)")
         self.assertEqual(repr(Count('a', distinct=True)), "Count(F(a), distinct=True)")
         self.assertEqual(repr(Count('*', distinct=True)), "Count('*', distinct=True)")
+        self.assertEqual(repr(Max('a', distinct=True)), "Max(F(a), distinct=True)")
+        self.assertEqual(repr(Min('a', distinct=True)), "Min(F(a), distinct=True)")
+        self.assertEqual(repr(Sum('a', distinct=True)), "Sum(F(a), distinct=True)")
 
     def test_filtered_aggregates(self):
         filter = Q(a=1)


### PR DESCRIPTION
## Related Issue
- #134

## Reproduction
1. Save the script below as `scripts/distinct_failure.py`:

```python
import django
from django.conf import settings
from django.db import connection, models
from django.db.models import Avg, Sum


def setup_django():
    settings.configure(
        SECRET_KEY="test-key",
        INSTALLED_APPS=[__name__],
        DATABASES={
            "default": {
                "ENGINE": "django.db.backends.sqlite3",
                "NAME": ":memory:",
            }
        },
        DEFAULT_AUTO_FIELD="django.db.models.AutoField",
    )
    django.setup()


setup_django()


class Person(models.Model):
    age = models.IntegerField()


def main():
    with connection.schema_editor() as editor:
        editor.create_model(Person)
    Person.objects.bulk_create(
        [
            Person(age=20),
            Person(age=20),
            Person(age=40),
        ]
    )
    print(Person.objects.aggregate(Avg("age", distinct=True)))
    print(Person.objects.aggregate(Sum("age", distinct=True)))


if __name__ == "__main__":
    main()
```

2. Run:

```bash
PYTHONPATH=/workspace/django /workspace/.venv/bin/python scripts/distinct_failure.py
```

### Observed failure
```
Traceback (most recent call last):
  File "/workspace/django/scripts/distinct_failure.py", line 45, in <module>
    main()
  File "/workspace/django/scripts/distinct_failure.py", line 40, in main
    print(Person.objects.aggregate(Avg("age", distinct=True)))
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/models/aggregates.py", line 26, in __init__
    raise TypeError("%s does not allow distinct." % self.__class__.__name__)
TypeError: Avg does not allow distinct.
```

## Summary
- allow DISTINCT usage for Avg, Sum, Min, and Max by enabling the aggregates' `allow_distinct`
- cover aggregate behavior with new aggregation tests exercising distinct values and equality for Min/Max
- extend expression representation tests to include distinct variants of Avg/Sum/Min/Max

## Testing
- PYTHONPATH=/workspace/django /workspace/.venv/bin/python tests/runtests.py aggregation expressions --parallel=1
- /workspace/.venv/bin/flake8 django/db/models/aggregates.py tests/aggregation/tests.py tests/expressions/tests.py