### PR TITLE
fix: swev-id: django__django-11490 avoid values selection mutation

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -409,28 +409,31 @@ class SQLCompiler:
 
     def get_combinator_sql(self, combinator, all):
         features = self.connection.features
-        compilers = [
-            query.get_compiler(self.using, self.connection)
-            for query in self.query.combined_queries if not query.is_empty()
+        queries = [
+            query for query in self.query.combined_queries
+            if not query.is_empty()
         ]
+        compilers = [query.get_compiler(self.using, self.connection) for query in queries]
         if not features.supports_slicing_ordering_in_compound:
-            for query, compiler in zip(self.query.combined_queries, compilers):
+            for query, compiler in zip(queries, compilers):
                 if query.low_mark or query.high_mark:
                     raise DatabaseError('LIMIT/OFFSET not allowed in subqueries of compound statements.')
                 if compiler.get_order_by():
                     raise DatabaseError('ORDER BY not allowed in subqueries of compound statements.')
         parts = ()
-        for compiler in compilers:
+        for query, compiler in zip(queries, compilers):
             try:
                 # If the columns list is limited, then all combined queries
                 # must have the same columns list. Set the selects defined on
                 # the query on all combined queries, if not already set.
                 if not compiler.query.values_select and self.query.values_select:
-                    compiler.query.set_values((
+                    query = query.clone()
+                    query.set_values((
                         *self.query.extra_select,
                         *self.query.values_select,
                         *self.query.annotation_select,
                     ))
+                    compiler = query.get_compiler(self.using, self.connection)
                 part_sql, part_args = compiler.as_sql()
                 if compiler.query.combinator:
                     # Wrap in a subquery if wrapping in parentheses isn't

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -124,6 +124,30 @@ class QuerySetSetOperationTests(TestCase):
         reserved_name = qs1.union(qs1).values_list('name', 'order', 'id').get()
         self.assertEqual(reserved_name[:2], ('a', 2))
 
+    def test_union_values_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.union(base)
+        initial = combined.values('name', 'order')
+        self.assertEqual(list(initial), [{'name': 'a', 'order': 2}])
+        self.assertEqual(list(combined.values('order')), [{'order': 2}])
+
+    def test_union_values_list_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.union(base)
+        initial = combined.values_list('name', 'order')
+        self.assertEqual(list(initial), [('a', 2)])
+        self.assertEqual(list(combined.values_list('order')), [(2,)])
+
+    def test_union_values_list_flat_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.union(base)
+        initial = combined.values_list('name', 'order')
+        self.assertEqual(list(initial), [('a', 2)])
+        self.assertEqual(list(combined.values_list('order', flat=True)), [2])
+
     def test_union_with_two_annotated_values_list(self):
         qs1 = Number.objects.filter(num=1).annotate(
             count=Value(0, IntegerField()),
@@ -149,6 +173,42 @@ class QuerySetSetOperationTests(TestCase):
         ).filter(has_reserved_name=True)
         qs2 = Number.objects.filter(num=9)
         self.assertCountEqual(qs1.union(qs2).values_list('num', flat=True), [1, 9])
+
+    @skipUnlessDBFeature('supports_select_intersection')
+    def test_intersection_values_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.intersection(base)
+        initial = combined.values('name', 'order')
+        self.assertEqual(list(initial), [{'name': 'a', 'order': 2}])
+        self.assertEqual(list(combined.values('order')), [{'order': 2}])
+
+    @skipUnlessDBFeature('supports_select_intersection')
+    def test_intersection_values_list_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.intersection(base)
+        initial = combined.values_list('name', 'order')
+        self.assertEqual(list(initial), [('a', 2)])
+        self.assertEqual(list(combined.values_list('order')), [(2,)])
+
+    @skipUnlessDBFeature('supports_select_difference')
+    def test_difference_values_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.difference(ReservedName.objects.none())
+        initial = combined.values('name', 'order')
+        self.assertEqual(list(initial), [{'name': 'a', 'order': 2}])
+        self.assertEqual(list(combined.values('order')), [{'order': 2}])
+
+    @skipUnlessDBFeature('supports_select_difference')
+    def test_difference_values_list_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.difference(ReservedName.objects.none())
+        initial = combined.values_list('name', 'order')
+        self.assertEqual(list(initial), [('a', 2)])
+        self.assertEqual(list(combined.values_list('order')), [(2,)])
 
     def test_count_union(self):
         qs1 = Number.objects.filter(num__lte=1).values('num')

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -192,6 +192,15 @@ class QuerySetSetOperationTests(TestCase):
         self.assertEqual(list(initial), [('a', 2)])
         self.assertEqual(list(combined.values_list('order')), [(2,)])
 
+    @skipUnlessDBFeature('supports_select_intersection')
+    def test_intersection_values_list_flat_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.intersection(base)
+        initial = combined.values_list('name', 'order')
+        self.assertEqual(list(initial), [('a', 2)])
+        self.assertEqual(list(combined.values_list('order', flat=True)), [2])
+
     @skipUnlessDBFeature('supports_select_difference')
     def test_difference_values_selection_after_evaluation(self):
         ReservedName.objects.create(name='a', order=2)
@@ -209,6 +218,15 @@ class QuerySetSetOperationTests(TestCase):
         initial = combined.values_list('name', 'order')
         self.assertEqual(list(initial), [('a', 2)])
         self.assertEqual(list(combined.values_list('order')), [(2,)])
+
+    @skipUnlessDBFeature('supports_select_difference')
+    def test_difference_values_list_flat_selection_after_evaluation(self):
+        ReservedName.objects.create(name='a', order=2)
+        base = ReservedName.objects.all()
+        combined = base.difference(ReservedName.objects.none())
+        initial = combined.values_list('name', 'order')
+        self.assertEqual(list(initial), [('a', 2)])
+        self.assertEqual(list(combined.values_list('order', flat=True)), [2])
 
     def test_count_union(self):
         qs1 = Number.objects.filter(num__lte=1).values('num')


### PR DESCRIPTION
## Summary
- Avoid mutating combined subqueries by compiling clones when aligning values selections in composed queries (union/intersection/difference).
- Add regression coverage for union/intersection/difference values()/values_list() re-selection cases, including flat=True.

## References
- Fixes #142
- Task reference: swev-id: django__django-11490

## Reproduction steps
- Environment: Python 3.11, SQLite via Django test runner
- Commands:
```
python3.11 -m venv .venv
. .venv/bin/activate
pip install -e .
python tests/runtests.py queries.test_regression_11490 --verbosity=2
```
- Minimal regression module contains:
```py
from django.test import TestCase
from tests.queries.models import ReservedName

class ComposedValuesColumnsRegressionTests(TestCase):
    databases = {'default'}

    def setUp(self):
        ReservedName.objects.create(name='a', order=2)

    def test_union_values_list_columns_change(self):
        base = ReservedName.objects.values_list('name', 'order')
        combined = base.union(base)
        self.assertEqual(list(combined), [('a', 2)])
        changed = combined.values_list('order')
        self.assertEqual(list(changed), [(2,)])

    def test_union_values_columns_change(self):
        base = ReservedName.objects.values('name', 'order')
        combined = base.union(base)
        self.assertEqual(list(combined), [{'name': 'a', 'order': 2}])
        changed = combined.values('order')
        self.assertEqual(list(changed), [{'order': 2}])
```

## Observed failure (before fix)
```
FAIL: test_union_values_columns_change (...)
Traceback (most recent call last):
  File "tests/queries/test_regression_11490.py", line 22, in test_union_values_columns_change
    self.assertEqual(list(changed), [{'order': 2}])
AssertionError: Lists differ: [{'order': 'a'}] != [{'order': 2}]

FAIL: test_union_values_list_columns_change (...)
Traceback (most recent call last):
  File "tests/queries/test_regression_11490.py", line 15, in test_union_values_list_columns_change
    self.assertEqual(list(changed), [(2,)])
AssertionError: Lists differ: [('a', 2)] != [(2,)]
```

## Implementation details
- File: `django/db/models/sql/compiler.py`
- Function: `SQLCompiler.get_combinator_sql()`
- Change: When the composed query has `values_select` and a subquery lacks it, compile the subquery from a clone with `set_values()` applied (including `extra_select` and `annotation_select`). Do not persist selection changes on original subqueries. Preserve behavior for subqueries with explicit `values_select` and ordering/slicing validations.

## Local testing
- `./.venv/bin/python tests/runtests.py queries` → green on relevant suites
- Lint: `./.venv/bin/flake8 django/db/models/sql/compiler.py tests/queries/test_qs_combinators.py`

Note: CI was not manually triggered.