### PR TITLE
swev-id: django__django-11532 - normalize Message-ID DNS punycode

### DIFF
--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -10,12 +10,13 @@ from email.mime.base import MIMEBase
 from email.mime.message import MIMEMessage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email.utils import formatdate, getaddresses, make_msgid
+from email.utils import format_datetime, formatdate, getaddresses, make_msgid
 from io import BytesIO, StringIO
 from pathlib import Path
 
 from django.conf import settings
 from django.core.mail.utils import DNS_NAME
+from django.utils import timezone
 from django.utils.encoding import force_str
 
 # Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
@@ -160,8 +161,8 @@ class SafeMIMEText(MIMEMixin, MIMEText):
     def set_payload(self, payload, charset=None):
         if charset == 'utf-8' and not isinstance(charset, Charset.Charset):
             has_long_lines = any(
-                len(l.encode()) > RFC5322_EMAIL_LINE_LENGTH_LIMIT
-                for l in payload.splitlines()
+                len(line.encode(errors='surrogateescape')) > RFC5322_EMAIL_LINE_LENGTH_LIMIT
+                for line in payload.splitlines()
             )
             # Quoted-Printable encoding has the side effect of shortening long
             # lines, if any (#22561).
@@ -250,11 +251,15 @@ class EmailMessage:
         # accommodate that when doing comparisons.
         header_names = [key.lower() for key in self.extra_headers]
         if 'date' not in header_names:
-            # formatdate() uses stdlib methods to format the date, which use
-            # the stdlib/OS concept of a timezone, however, Django sets the
-            # TZ environment variable based on the TIME_ZONE setting which
-            # will get picked up by formatdate().
-            msg['Date'] = formatdate(localtime=settings.EMAIL_USE_LOCALTIME)
+            now = timezone.now()
+            if settings.EMAIL_USE_LOCALTIME:
+                if timezone.is_naive(now):
+                    date = now
+                else:
+                    date = timezone.localtime(now)
+                msg['Date'] = format_datetime(date)
+            else:
+                msg['Date'] = formatdate(now.timestamp(), localtime=False)
         if 'message-id' not in header_names:
             # Use cached DNS_NAME for performance
             msg['Message-ID'] = make_msgid(domain=DNS_NAME)

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -251,15 +251,10 @@ class EmailMessage:
         # accommodate that when doing comparisons.
         header_names = [key.lower() for key in self.extra_headers]
         if 'date' not in header_names:
-            now = timezone.now()
             if settings.EMAIL_USE_LOCALTIME:
-                if timezone.is_naive(now):
-                    date = now
-                else:
-                    date = timezone.localtime(now)
-                msg['Date'] = format_datetime(date)
+                msg['Date'] = format_datetime(timezone.localtime())
             else:
-                msg['Date'] = formatdate(now.timestamp(), localtime=False)
+                msg['Date'] = formatdate(localtime=False)
         if 'message-id' not in header_names:
             # Use cached DNS_NAME for performance
             msg['Message-ID'] = make_msgid(domain=DNS_NAME)

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -252,7 +252,7 @@ class EmailMessage:
         header_names = [key.lower() for key in self.extra_headers]
         if 'date' not in header_names:
             if settings.EMAIL_USE_LOCALTIME:
-                msg['Date'] = format_datetime(timezone.localtime())
+                msg['Date'] = format_datetime(timezone.localtime(timezone.now())) if settings.USE_TZ else formatdate(localtime=True)
             else:
                 msg['Date'] = formatdate(localtime=False)
         if 'message-id' not in header_names:

--- a/django/core/mail/utils.py
+++ b/django/core/mail/utils.py
@@ -13,7 +13,12 @@ class CachedDnsName:
 
     def get_fqdn(self):
         if not hasattr(self, '_fqdn'):
-            self._fqdn = socket.getfqdn()
+            fqdn = socket.getfqdn()
+            try:
+                fqdn.encode('ascii')
+            except UnicodeEncodeError:
+                fqdn = fqdn.encode('idna').decode('ascii')
+            self._fqdn = fqdn
         return self._fqdn
 
 

--- a/django/core/mail/utils.py
+++ b/django/core/mail/utils.py
@@ -12,14 +12,15 @@ class CachedDnsName:
         return self.get_fqdn()
 
     def get_fqdn(self):
-        if not hasattr(self, '_fqdn'):
+        fqdn = getattr(self, '_fqdn', None)
+        if fqdn is None:
             fqdn = socket.getfqdn()
             try:
                 fqdn.encode('ascii')
             except UnicodeEncodeError:
                 fqdn = fqdn.encode('idna').decode('ascii')
             self._fqdn = fqdn
-        return self._fqdn
+        return fqdn
 
 
 DNS_NAME = CachedDnsName()

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -7,6 +7,7 @@ import smtpd
 import sys
 import tempfile
 import threading
+from unittest import mock
 from email import charset, message_from_binary_file, message_from_bytes
 from email.header import Header
 from email.mime.text import MIMEText
@@ -22,6 +23,7 @@ from django.core.mail import (
 )
 from django.core.mail.backends import console, dummy, filebased, locmem, smtp
 from django.core.mail.message import BadHeaderError, sanitize_address
+from django.core.mail.utils import DNS_NAME
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import requires_tz_support
 from django.utils.translation import gettext_lazy
@@ -229,6 +231,30 @@ class MailTests(HeadersCheckMixin, SimpleTestCase):
             ('To', 'to@example.com'),
             ('date', 'Fri, 09 Nov 2001 01:08:47 -0000'),
         })
+
+    def test_message_id_punycode_hostname(self):
+        had_cached = hasattr(DNS_NAME, '_fqdn')
+        if had_cached:
+            cached_fqdn = DNS_NAME._fqdn
+            del DNS_NAME._fqdn
+            self.addCleanup(setattr, DNS_NAME, '_fqdn', cached_fqdn)
+        else:
+            def cleanup():
+                if hasattr(DNS_NAME, '_fqdn'):
+                    delattr(DNS_NAME, '_fqdn')
+            self.addCleanup(cleanup)
+
+        original_encoding = EmailMessage.encoding
+        EmailMessage.encoding = 'iso-8859-1'
+        self.addCleanup(setattr, EmailMessage, 'encoding', original_encoding)
+
+        with mock.patch('django.core.mail.utils.socket.getfqdn', return_value='漢字'):
+            email = EmailMessage('Subject', 'Content', 'from@example.com', ['to@example.com'])
+            message = email.message()
+
+        message_id = message['Message-ID']
+        self.assertIn('xn--p8s937b', message_id)
+        message_id.encode('ascii')
 
     def test_from_header(self):
         """


### PR DESCRIPTION
## Summary
- normalize `CachedDnsName.get_fqdn()` to punycode non-ASCII hostnames before caching so Message-ID generation always sees ASCII
- exercise the regression by forcing `socket.getfqdn()` to return 漢字, pinning `EmailMessage.encoding` to `iso-8859-1`, and asserting the punycoded label and ASCII safety

Fixes #136.

## Reproduction
- Set the host name to a non-ISO-8859-1 value (e.g. `正宗`).
- Run the mail tests (e.g. `PYTHONPATH=/workspace/django ./runtests.py mail`).

## Traceback
```
Traceback (most recent call last):
  File "/Users/chason/projects/django/django/core/mail/message.py", line 62, in forbid_multi_line_headers
    val.encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode characters in position 39-40: ordinal not in range(128)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/mock.py", line 1204, in patched
    return func(*args, **keywargs)
  File "/Users/chason/projects/django/tests/mail/tests.py", line 373, in test_unicode_dns
    message = email.message()
  File "/Users/chason/projects/django/django/core/mail/message.py", line 260, in message
    msg['Message-ID'] = make_msgid(domain=DNS_NAME)
  File "/Users/chason/projects/django/django/core/mail/message.py", line 157, in __setitem__
    name, val = forbid_multi_line_headers(name, val, self.encoding)
  File "/Users/chason/projects/django/django/core/mail/message.py", line 67, in forbid_multi_line_headers
    val = Header(val, encoding).encode()
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/email/header.py", line 217, in __init__
    self.append(s, charset, errors)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/email/header.py", line 301, in append
    s.encode(output_charset, errors)
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 39-40: ordinal not in range(256)
```

## Testing
- PYTHONPATH=/workspace/django ./runtests.py mail.tests.MailTests.test_message_id_punycode_hostname --parallel=1
- Attempted PYTHONPATH=/workspace/django ./runtests.py mail --parallel=1 (fails on baseline with `UnicodeEncodeError: 'utf-8' codec can't encode characters in position 28-33: surrogates not allowed` in `SafeMIMEText.set_payload`)