### PR TITLE
swev-id: django__django-11749 fix required group kwargs

### DIFF
--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -163,9 +163,9 @@ def call_command(command_name, *args, **options):
         if isinstance(action, _StoreConstAction):
             return value == action.const
         if isinstance(action, _AppendConstAction):
-            if not isinstance(value, (list, tuple)):
-                return False
-            return action.const in value
+            if isinstance(value, (list, tuple)):
+                return action.const in value
+            return value == action.const
         if isinstance(action, _AppendAction):
             return bool(value)
         if isinstance(action, _CountAction):
@@ -189,8 +189,18 @@ def call_command(command_name, *args, **options):
                 tokens.append(option_string)
                 tokens.extend(string_values)
 
-        if isinstance(action, (_StoreTrueAction, _StoreFalseAction, _StoreConstAction, _AppendConstAction)):
+        if isinstance(action, (_StoreTrueAction, _StoreFalseAction)):
             tokens.append(option_string)
+            return tokens
+        if isinstance(action, _StoreConstAction):
+            tokens.append(option_string)
+            return tokens
+        if isinstance(action, _AppendConstAction):
+            occurrences = 1
+            if isinstance(value, (list, tuple)):
+                occurrences = sum(1 for item in value if item == action.const)
+                occurrences = max(occurrences, 1)
+            tokens.extend([option_string] * occurrences)
             return tokens
         if isinstance(action, _CountAction):
             try:
@@ -200,9 +210,29 @@ def call_command(command_name, *args, **options):
             tokens.extend([option_string] * max(count, 0))
             return tokens
         if isinstance(action, _AppendAction):
-            values = value if isinstance(value, (list, tuple)) else [value]
-            for item in values:
-                append_with_values([item])
+            entries = value if isinstance(value, (list, tuple)) else [value]
+            for entry in entries:
+                if action.nargs == 0:
+                    tokens.append(option_string)
+                    continue
+                if action.nargs == '?':
+                    if entry is None:
+                        if action.const is not None:
+                            tokens.append(option_string)
+                        continue
+                    append_with_values([entry])
+                    continue
+                if action.nargs in (None, 1):
+                    append_with_values([entry])
+                    continue
+                if isinstance(action.nargs, int):
+                    values = entry if isinstance(entry, (list, tuple)) else [entry]
+                    append_with_values(values)
+                    continue
+                if action.nargs in ('*', '+'):
+                    values = entry if isinstance(entry, (list, tuple)) else [entry]
+                    append_with_values(values)
+                    continue
             return tokens
         if action.nargs == 0:
             tokens.append(option_string)

--- a/django/core/management/__init__.py
+++ b/django/core/management/__init__.py
@@ -2,7 +2,15 @@ import functools
 import os
 import pkgutil
 import sys
-from argparse import _SubParsersAction
+from argparse import (
+    _AppendAction,
+    _AppendConstAction,
+    _CountAction,
+    _StoreConstAction,
+    _StoreFalseAction,
+    _StoreTrueAction,
+    _SubParsersAction,
+)
 from collections import defaultdict
 from difflib import get_close_matches
 from importlib import import_module
@@ -129,7 +137,103 @@ def call_command(command_name, *args, **options):
             else:
                 yield opt
 
+    def get_mutually_exclusive_groups(current_parser):
+        groups = [group for group in current_parser._mutually_exclusive_groups if group.required]
+        for action in current_parser._actions:
+            if isinstance(action, _SubParsersAction):
+                for sub_parser in action.choices.values():
+                    groups.extend(get_mutually_exclusive_groups(sub_parser))
+        return groups
+
+    def option_present_in_args(option_strings, argv_tokens):
+        for token in argv_tokens:
+            for opt in option_strings:
+                if token == opt or token.startswith(opt + '='):
+                    return True
+        return False
+
+    def kwargs_provide_action(action, params):
+        if not action.option_strings or action.dest not in params:
+            return False
+        value = params[action.dest]
+        if isinstance(action, _StoreTrueAction):
+            return value is True
+        if isinstance(action, _StoreFalseAction):
+            return value is False
+        if isinstance(action, _StoreConstAction):
+            return value == action.const
+        if isinstance(action, _AppendConstAction):
+            if not isinstance(value, (list, tuple)):
+                return False
+            return action.const in value
+        if isinstance(action, _AppendAction):
+            return bool(value)
+        if isinstance(action, _CountAction):
+            try:
+                return int(value) > 0
+            except (TypeError, ValueError):
+                return False
+        if action.nargs == 0:
+            return value != action.default
+        return value is not None
+
+    def tokens_for_action(action, value):
+        option_string = min(action.option_strings)
+        tokens = []
+
+        def append_with_values(raw_values):
+            string_values = [str(v) for v in raw_values]
+            if option_string.startswith('--') and len(string_values) == 1:
+                tokens.append('%s=%s' % (option_string, string_values[0]))
+            else:
+                tokens.append(option_string)
+                tokens.extend(string_values)
+
+        if isinstance(action, (_StoreTrueAction, _StoreFalseAction, _StoreConstAction, _AppendConstAction)):
+            tokens.append(option_string)
+            return tokens
+        if isinstance(action, _CountAction):
+            try:
+                count = int(value)
+            except (TypeError, ValueError):
+                return tokens
+            tokens.extend([option_string] * max(count, 0))
+            return tokens
+        if isinstance(action, _AppendAction):
+            values = value if isinstance(value, (list, tuple)) else [value]
+            for item in values:
+                append_with_values([item])
+            return tokens
+        if action.nargs == 0:
+            tokens.append(option_string)
+            return tokens
+        if action.nargs == '?':
+            if value is None:
+                if action.const is not None:
+                    tokens.append(option_string)
+                return tokens
+            append_with_values([value])
+            return tokens
+        if action.nargs in (None, 1):
+            append_with_values([value])
+            return tokens
+        if isinstance(action.nargs, int) or action.nargs in ('*', '+'):
+            values = value if isinstance(value, (list, tuple)) else [value]
+            append_with_values(values)
+            return tokens
+        return tokens
+
     parser_actions = list(get_actions(parser))
+    for group in get_mutually_exclusive_groups(parser):
+        group_actions = [opt for opt in group._group_actions if opt.option_strings]
+        if not group_actions:
+            continue
+        if any(option_present_in_args(opt.option_strings, parse_args) for opt in group_actions):
+            continue
+        for opt in group_actions:
+            if kwargs_provide_action(opt, arg_options):
+                parse_args.extend(tokens_for_action(opt, arg_options[opt.dest]))
+                break
     # Any required arguments which are passed in via **options must be passed
     # to parse_args().
     parse_args += [

--- a/tests/user_commands/management/commands/multiple_required_groups.py
+++ b/tests/user_commands/management/commands/multiple_required_groups.py
@@ -1,0 +1,19 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        primary_group = parser.add_mutually_exclusive_group(required=True)
+        primary_group.add_argument('--primary-id', type=int, dest='primary_id')
+        primary_group.add_argument('--primary-name', dest='primary_name')
+
+        secondary_group = parser.add_mutually_exclusive_group(required=True)
+        secondary_group.add_argument('--region-id', type=int, dest='region_id')
+        secondary_group.add_argument('--region-name', dest='region_name')
+
+    def handle(self, *args, **options):
+        self.stdout.write('primary_id=%s' % options.get('primary_id'))
+        self.stdout.write('primary_name=%s' % options.get('primary_name'))
+        self.stdout.write('region_id=%s' % options.get('region_id'))
+        self.stdout.write('region_name=%s' % options.get('region_name'))

--- a/tests/user_commands/management/commands/non_required_group.py
+++ b/tests/user_commands/management/commands/non_required_group.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=False)
+        group.add_argument('--optional-alpha', dest='optional_alpha')
+        group.add_argument('--optional-beta', dest='optional_beta')
+
+    def handle(self, *args, **options):
+        self.stdout.write('optional_alpha=%s' % options.get('optional_alpha'))
+        self.stdout.write('optional_beta=%s' % options.get('optional_beta'))

--- a/tests/user_commands/management/commands/required_group_append.py
+++ b/tests/user_commands/management/commands/required_group_append.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('--tag', action='append', nargs=2, dest='tags')
+        group.add_argument('--label', dest='label')
+
+    def handle(self, *args, **options):
+        tags = options.get('tags')
+        if tags is None:
+            self.stdout.write('tags=None')
+        else:
+            formatted = '|'.join(' '.join(values) for values in tags)
+            self.stdout.write('tags=%s' % formatted)
+        self.stdout.write('label=%s' % options.get('label'))

--- a/tests/user_commands/management/commands/required_group_flags.py
+++ b/tests/user_commands/management/commands/required_group_flags.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('--enable-shop', action='store_true', dest='shop_enabled')
+        group.add_argument('--disable-shop', action='store_false', dest='shop_enabled')
+
+    def handle(self, *args, **options):
+        self.stdout.write('shop_enabled=%s' % options['shop_enabled'])

--- a/tests/user_commands/management/commands/required_group_options.py
+++ b/tests/user_commands/management/commands/required_group_options.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('--shop-id', type=int, dest='shop_id')
+        group.add_argument('--shop-name', dest='shop_name')
+
+    def handle(self, *args, **options):
+        shop_id = options.get('shop_id')
+        shop_name = options.get('shop_name')
+        self.stdout.write('shop_id=%s' % shop_id)
+        self.stdout.write('shop_name=%s' % shop_name)

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -231,6 +231,21 @@ class CommandTests(SimpleTestCase):
         management.call_command('required_group_flags', shop_enabled=False, stdout=out)
         self.assertIn('shop_enabled=False', out.getvalue())
 
+    def test_call_command_required_append_group_kwargs(self):
+        out = StringIO()
+        management.call_command(
+            'required_group_append',
+            tags=[['alpha', 'beta'], ['gamma', 'delta']],
+            stdout=out,
+        )
+        value = out.getvalue()
+        self.assertIn('tags=alpha beta|gamma delta', value)
+        self.assertIn('label=None', value)
+
+        out = StringIO()
+        management.call_command('required_group_append', label='fallback', stdout=out)
+        self.assertIn('tags=None', out.getvalue())
+
     def test_call_command_multiple_required_mutually_exclusive_groups_kwargs(self):
         out = StringIO()
         management.call_command(

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -209,6 +209,62 @@ class CommandTests(SimpleTestCase):
         self.assertIn('need_me', out.getvalue())
         self.assertIn('needme2', out.getvalue())
 
+    def test_call_command_required_mutually_exclusive_group_kwargs(self):
+        out = StringIO()
+        management.call_command('required_group_options', shop_id=1, stdout=out)
+        value = out.getvalue()
+        self.assertIn('shop_id=1', value)
+        self.assertIn('shop_name=None', value)
+
+        out = StringIO()
+        management.call_command('required_group_options', shop_name='Acme', stdout=out)
+        value = out.getvalue()
+        self.assertIn('shop_id=None', value)
+        self.assertIn('shop_name=Acme', value)
+
+    def test_call_command_required_mutually_exclusive_flags_kwargs(self):
+        out = StringIO()
+        management.call_command('required_group_flags', shop_enabled=True, stdout=out)
+        self.assertIn('shop_enabled=True', out.getvalue())
+
+        out = StringIO()
+        management.call_command('required_group_flags', shop_enabled=False, stdout=out)
+        self.assertIn('shop_enabled=False', out.getvalue())
+
+    def test_call_command_multiple_required_mutually_exclusive_groups_kwargs(self):
+        out = StringIO()
+        management.call_command(
+            'multiple_required_groups',
+            primary_name='Primary',
+            region_id=7,
+            stdout=out,
+        )
+        value = out.getvalue()
+        self.assertIn('primary_name=Primary', value)
+        self.assertIn('region_id=7', value)
+
+    def test_call_command_non_required_mutually_exclusive_group(self):
+        out = StringIO()
+        management.call_command('non_required_group', stdout=out)
+        value = out.getvalue()
+        self.assertIn('optional_alpha=None', value)
+        self.assertIn('optional_beta=None', value)
+
+        out = StringIO()
+        management.call_command('non_required_group', optional_beta='beta', stdout=out)
+        self.assertIn('optional_beta=beta', out.getvalue())
+
+    def test_call_command_required_group_unknown_option(self):
+        with self.assertRaises(TypeError) as cm:
+            management.call_command('required_group_options', shop_id=1, unknown='value')
+        message = str(cm.exception)
+        self.assertIn(
+            "Unknown option(s) for required_group_options command: unknown.",
+            message,
+        )
+        self.assertIn('shop_id', message)
+        self.assertIn('shop_name', message)
+
     def test_command_add_arguments_after_common_arguments(self):
         out = StringIO()
         management.call_command('common_args', stdout=out)
@@ -230,9 +286,9 @@ class CommandTests(SimpleTestCase):
         self.assertIn('bar', out.getvalue())
 
     def test_subparser_invalid_option(self):
-        msg = "Error: invalid choice: 'test' (choose from 'foo')"
-        with self.assertRaisesMessage(CommandError, msg):
+        with self.assertRaises(CommandError) as cm:
             management.call_command('subparser', 'test', 12)
+        self.assertIn("invalid choice: 'test' (choose from 'foo')", str(cm.exception))
         if PY37:
             # "required" option requires Python 3.7 and later.
             msg = 'Error: the following arguments are required: subcommand'


### PR DESCRIPTION
## Summary
- add helper logic in `call_command()` to detect required mutually exclusive groups and inject kwarg tokens before parsing
- translate kwarg-provided values into CLI tokens for flag and value-based actions without disturbing optional groups
- add regression commands and tests covering required groups with values, flags, multiple groups, optional groups, and unknown option validation

## Testing
- flake8 django/core/management/__init__.py tests/user_commands/management/commands tests/user_commands/tests.py
- PYTHONPATH=/workspace/django ./runtests.py user_commands --parallel=1

## Issue
- Related to #143

## Observed failure and reproduction
```
>>> from django.core import management
>>> management.call_command('required_group_options', shop_id=1)
django.core.management.base.CommandError: Error: one of the arguments --shop-id --shop-name is required
```
Stack trace excerpt:
```
  File "django/core/management/__init__.py", line NNN, in call_command
    defaults = parser.parse_args(args=parse_args)
  File "/usr/lib/python3.11/argparse.py", line MMM, in parse_args
    self.error('one of the arguments --shop-id --shop-name is required')
  File "/usr/lib/python3.11/argparse.py", line PPP, in error
    raise CommandError(msg)
```