### PR TITLE
swev-id: django__django-11820 — Fix models.E015 for related __pk in Meta.ordering

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1712,6 +1712,8 @@ class Model(metaclass=ModelBase):
                     if fld.is_relation:
                         _cls = fld.get_path_info()[-1].to_opts.model
                 except (FieldDoesNotExist, AttributeError):
+                    if part == 'pk' and fld is not None and fld.is_relation:
+                        continue
                     if fld is None or fld.get_transform(part) is None:
                         errors.append(
                             checks.Error(

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -836,6 +836,89 @@ class OtherModelTests(SimpleTestCase):
 
         self.assertFalse(Child.check())
 
+    def test_ordering_allows_related_pk(self):
+        class Option(models.Model):
+            pass
+
+        class Model(models.Model):
+            option = models.ForeignKey(Option, models.CASCADE)
+
+            class Meta:
+                ordering = ['option__pk']
+
+        self.assertEqual(Model.check(), [])
+
+    def test_ordering_allows_related_desc_pk(self):
+        class Option(models.Model):
+            pass
+
+        class Model(models.Model):
+            option = models.ForeignKey(Option, models.CASCADE)
+
+            class Meta:
+                ordering = ['-option__pk']
+
+        self.assertEqual(Model.check(), [])
+
+    def test_ordering_rejects_non_relation_pk(self):
+        class Model(models.Model):
+            name = models.CharField(max_length=32)
+
+            class Meta:
+                ordering = ['name__pk']
+
+        self.assertEqual(Model.check(), [
+            Error(
+                "'ordering' refers to the nonexistent field, related field, "
+                "or lookup 'name__pk'.",
+                obj=Model,
+                id='models.E015',
+            ),
+        ])
+
+    def test_ordering_related_id_matches_pk(self):
+        class Option(models.Model):
+            pass
+
+        class Model(models.Model):
+            option = models.ForeignKey(Option, models.CASCADE)
+
+            class Meta:
+                ordering = ['option__id']
+
+        self.assertEqual(Model.check(), [])
+
+    def test_ordering_related_id_without_matching_pk(self):
+        class Option(models.Model):
+            code = models.CharField(max_length=32, primary_key=True)
+
+        class Model(models.Model):
+            option = models.ForeignKey(Option, models.CASCADE)
+
+            class Meta:
+                ordering = ['option__id']
+
+        self.assertEqual(Model.check(), [
+            Error(
+                "'ordering' refers to the nonexistent field, related field, "
+                "or lookup 'option__id'.",
+                obj=Model,
+                id='models.E015',
+            ),
+        ])
+
+    def test_ordering_related_pk_with_custom_primary_key(self):
+        class Option(models.Model):
+            code = models.CharField(max_length=32, primary_key=True)
+
+        class Model(models.Model):
+            option = models.ForeignKey(Option, models.CASCADE)
+
+            class Meta:
+                ordering = ['option__pk']
+
+        self.assertEqual(Model.check(), [])
+
     def test_name_beginning_with_underscore(self):
         class _Model(models.Model):
             pass


### PR DESCRIPTION
## Summary
- Allow `Model._check_ordering()` to treat `__pk` as a valid lookup after traversing a relation.
- Add regression coverage for related primary key ordering combinations and non-relational rejections.

## Issue
- Closes #154

## Observed failure
<details>
<summary>`./tests/runtests.py invalid_models_tests.test_models.OtherModelTests` (pre-fix)</summary>

```
..............FF...........F........
======================================================================
FAIL: test_ordering_allows_related_desc_pk (invalid_models_tests.test_models.OtherModelTests.test_ordering_allows_related_desc_pk)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/invalid_models_tests/test_models.py", line 861, in test_ordering_allows_related_desc_pk
    self.assertEqual(Model.check(), [])
AssertionError: Lists differ: [<Error: level=40, msg="'ordering' refers [207 chars]15'>] != []

First list contains 1 additional elements.
First extra element 0:
<Error: level=40, msg="'ordering' refers to the nonexistent field, related field, or lookup 'option__pk'.", hint=None, obj=<class 'invalid_models_tests.test_models.OtherModelTests.test_ordering_allows_related_desc_pk.<locals>.Model'>, id='models.E015'>

======================================================================
FAIL: test_ordering_allows_related_pk (invalid_models_tests.test_models.OtherModelTests.test_ordering_allows_related_pk)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/invalid_models_tests/test_models.py", line 849, in test_ordering_allows_related_pk
    self.assertEqual(Model.check(), [])
AssertionError: Lists differ: [<Error: level=40, msg="'ordering' refers [202 chars]15'>] != []

First list contains 1 additional elements.
First extra element 0:
<Error: level=40, msg="'ordering' refers to the nonexistent field, related field, or lookup 'option__pk'.", hint=None, obj=<class 'invalid_models_tests.test_models.OtherModelTests.test_ordering_allows_related_pk.<locals>.Model'>, id='models.E015'>

======================================================================
FAIL: test_ordering_related_pk_with_custom_primary_key (invalid_models_tests.test_models.OtherModelTests.test_ordering_related_pk_with_custom_primary_key)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/invalid_models_tests/test_models.py", line 920, in test_ordering_related_pk_with_custom_primary_key
    self.assertEqual(Model.check(), [])
AssertionError: Lists differ: [<Error: level=40, msg="'ordering' refers [219 chars]15'>] != []

First list contains 1 additional elements.
First extra element 0:
<Error: level=40, msg="'ordering' refers to the nonexistent field, related field, or lookup 'option__pk'.", hint=None, obj=<class 'invalid_models_tests.test_models.OtherModelTests.test_ordering_related_pk_with_custom_primary_key.<locals>.Model'>, id='models.E015'>

----------------------------------------------------------------------
Ran 36 tests in 0.028s

FAILED (failures=3)
```
</details>

### Reproduction steps
1. `uv venv .venv --python $(which python3)`
2. `uv pip install -e .`
3. `.venv/bin/python tests/runtests.py invalid_models_tests.test_models.OtherModelTests`

### Failure location
- `django/db/models/base.py`, `Model._check_ordering()` raising `models.E015` when resolving `part == 'pk'` after traversing a relation.

## Testing
- `.venv/bin/python tests/runtests.py invalid_models_tests.test_models.OtherModelTests`
- `.venv/bin/flake8 django/db/models/base.py tests/invalid_models_tests/test_models.py`

## Notes
- Added regression tests covering positive/negative related pk ordering, non-relational `__pk` usage, `__id` success/failure depending on pk name, and custom primary key aliases.
