### PR TITLE
Fix RFC 850 HTTP date pivot (swev-id: django__django-11848)

### DIFF
--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -175,16 +175,33 @@ def parse_http_date(date):
         raise ValueError("%r is not in a valid HTTP date format" % date)
     try:
         year = int(m.group('year'))
-        if year < 100:
-            if year < 70:
-                year += 2000
-            else:
-                year += 1900
         month = MONTHS.index(m.group('mon').lower()) + 1
         day = int(m.group('day'))
         hour = int(m.group('hour'))
         min = int(m.group('min'))
         sec = int(m.group('sec'))
+        if regex is RFC850_DATE and year < 100:
+            now_utc = datetime.datetime.utcnow()
+            base_century = (now_utc.year // 100) * 100
+            candidate_year = base_century + year
+            candidate_fields = (candidate_year, month, day, hour, min, sec)
+            threshold_fields = (
+                now_utc.year + 50,
+                now_utc.month,
+                now_utc.day,
+                now_utc.hour,
+                now_utc.minute,
+                now_utc.second,
+            )
+            # RFC 7231 §7.1.1.1: roll back two-digit RFC 850 years >50 years ahead.
+            if candidate_fields > threshold_fields:
+                candidate_year -= 100
+            year = candidate_year
+        elif year < 100:
+            if year < 70:
+                year += 2000
+            else:
+                year += 1900
         result = datetime.datetime(year, month, day, hour, min, sec)
         return calendar.timegm(result.utctimetuple())
     except Exception as exc:

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -1,5 +1,7 @@
+import calendar
 import unittest
 from datetime import datetime
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, ignore_warnings
 from django.utils.datastructures import MultiValueDict
@@ -308,6 +310,19 @@ class ETagProcessingTests(unittest.TestCase):
 
 
 class HttpDateProcessingTests(unittest.TestCase):
+    @staticmethod
+    def _freeze_http_datetime(value):
+        class FrozenDatetime(datetime):
+            @classmethod
+            def utcnow(cls):
+                return value
+
+        return patch('django.utils.http.datetime.datetime', FrozenDatetime)
+
+    def _parse_http_date_with_frozen_now(self, date_string, frozen_now):
+        with self._freeze_http_datetime(frozen_now):
+            return parse_http_date(date_string)
+
     def test_http_date(self):
         t = 1167616461.0
         self.assertEqual(http_date(t), 'Mon, 01 Jan 2007 01:54:21 GMT')
@@ -327,6 +342,61 @@ class HttpDateProcessingTests(unittest.TestCase):
     def test_parsing_year_less_than_70(self):
         parsed = parse_http_date('Sun Nov  6 08:49:37 0037')
         self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(2037, 11, 6, 8, 49, 37))
+
+    def test_parsing_rfc850_two_digit_year_rolls_back_over_50_years(self):
+        frozen_now = datetime(2018, 1, 1, 0, 0)
+        expected_timestamp = calendar.timegm(
+            datetime(1969, 11, 6, 8, 49, 37).utctimetuple()
+        )
+        parsed = self._parse_http_date_with_frozen_now(
+            'Thursday, 06-Nov-69 08:49:37 GMT',
+            frozen_now,
+        )
+        self.assertEqual(parsed, expected_timestamp)
+
+    def test_parsing_rfc850_two_digit_year_matches_current_year(self):
+        frozen_now = datetime(2018, 1, 1, 0, 0)
+        expected_timestamp = calendar.timegm(
+            datetime(2018, 1, 1, 0, 0, 0).utctimetuple()
+        )
+        parsed = self._parse_http_date_with_frozen_now(
+            'Monday, 01-Jan-18 00:00:00 GMT',
+            frozen_now,
+        )
+        self.assertEqual(parsed, expected_timestamp)
+
+    def test_parsing_rfc850_two_digit_year_exactly_fifty_years_ahead(self):
+        frozen_now = datetime(2018, 1, 1, 0, 0)
+        expected_timestamp = calendar.timegm(
+            datetime(2068, 1, 1, 0, 0, 0).utctimetuple()
+        )
+        parsed = self._parse_http_date_with_frozen_now(
+            'Monday, 01-Jan-68 00:00:00 GMT',
+            frozen_now,
+        )
+        self.assertEqual(parsed, expected_timestamp)
+
+    def test_parsing_rfc850_two_digit_year_just_over_fifty_years_rolls_back(self):
+        frozen_now = datetime(2018, 1, 1, 0, 0)
+        expected_timestamp = calendar.timegm(
+            datetime(1968, 1, 1, 0, 0, 1).utctimetuple()
+        )
+        parsed = self._parse_http_date_with_frozen_now(
+            'Monday, 01-Jan-68 00:00:01 GMT',
+            frozen_now,
+        )
+        self.assertEqual(parsed, expected_timestamp)
+
+    def test_parsing_rfc850_two_digit_year_regression_for_existing_range(self):
+        frozen_now = datetime(2018, 1, 1, 0, 0)
+        expected_timestamp = calendar.timegm(
+            datetime(2004, 11, 6, 8, 49, 37).utctimetuple()
+        )
+        parsed = self._parse_http_date_with_frozen_now(
+            'Saturday, 06-Nov-04 08:49:37 GMT',
+            frozen_now,
+        )
+        self.assertEqual(parsed, expected_timestamp)
 
 
 class EscapeLeadingSlashesTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- resolves #153 by aligning django.utils.http.parse_http_date with RFC 7231 §7.1.1.1 when parsing two-digit RFC 850 years
- compute the candidate year relative to datetime.utcnow() and roll back 100 years if the date would be more than 50 years in the future, while leaving other formats untouched
- add deterministic tests that patch django.utils.http.datetime.datetime to freeze utcnow() so coverage includes equal digits, >50-year rollback, 50-year boundary, +1 second over the boundary, and regression behavior for existing mappings

## Pre-fix failure
- Environment: Python 3.12.3 virtualenv with `pip install -e .`, `pip install -r tests/requirements/py3.txt`, and `pip install pytz`
- Command: `PYTHONPATH=/workspace/django ./tests/runtests.py utils_tests.test_http.HttpDateProcessingTests --parallel=1`
- Stack trace:
```
Traceback (most recent call last):
  File "tests/utils_tests/test_http.py", line 349, in test_parsing_rfc850_two_digit_year_rolls_back_over_50_years
    self.assertEqual(parsed, expected_timestamp)
AssertionError: 3150953377 != -4806623
```

## Testing
- `PYTHONPATH=/workspace/django ./tests/runtests.py utils_tests.test_http.HttpDateProcessingTests --parallel=1`
- `flake8 django/utils/http.py tests/utils_tests/test_http.py`