### PR TITLE
fix(auth): restore username maxlength attr (swev-id: django__django-11790)

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -192,6 +192,8 @@ class AuthenticationForm(forms.Form):
         # Set the max length and label for the "username" field.
         self.username_field = UserModel._meta.get_field(UserModel.USERNAME_FIELD)
         self.fields['username'].max_length = self.username_field.max_length or 254
+        max_len = self.fields['username'].max_length
+        self.fields['username'].widget.attrs['maxlength'] = str(max_len)
         if self.fields['username'].label is None:
             self.fields['username'].label = capfirst(self.username_field.verbose_name)
 

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -282,6 +282,26 @@ class UserCreationFormTest(TestDataMixin, TestCase):
 @override_settings(AUTHENTICATION_BACKENDS=['django.contrib.auth.backends.AllowAllUsersModelBackend'])
 class AuthenticationFormTest(TestDataMixin, TestCase):
 
+    def test_username_widget_maxlength_default_user(self):
+        username_html = str(AuthenticationForm()['username'])
+        self.assertIn('maxlength="150"', username_html)
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomEmailField')
+    def test_username_widget_maxlength_custom_user(self):
+        username_html = str(AuthenticationForm()['username'])
+        self.assertIn('maxlength="255"', username_html)
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.IntegerUsernameUser')
+    def test_username_widget_maxlength_fallback(self):
+        username_html = str(AuthenticationForm()['username'])
+        self.assertIn('maxlength="254"', username_html)
+
+    def test_username_widget_attrs_preserved(self):
+        form = AuthenticationForm()
+        attrs = form.fields['username'].widget.attrs
+        self.assertTrue(attrs.get('autofocus'))
+        self.assertEqual(attrs['maxlength'], '150')
+
     def test_invalid_username(self):
         # The user submits an invalid username.
 


### PR DESCRIPTION
## Summary
- add the username widget maxlength attribute to mirror the field
- cover default, custom, fallback, and attr preservation scenarios in tests

Addresses #158.

## Observed Failure (before fix)
```
Creating test database for alias 'default'...
..................EFFF
======================================================================
ERROR: test_username_widget_attrs_preserved (auth_tests.test_forms.AuthenticationFormTest.test_username_widget_attrs_preserved)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/auth_tests/test_forms.py", line 303, in test_username_widget_attrs_preserved
    self.assertEqual(attrs['maxlength'], '150')
                     ~~~~~^^^^^^^^^^^^^
KeyError: 'maxlength'

======================================================================
FAIL: test_username_widget_maxlength_custom_user (auth_tests.test_forms.AuthenticationFormTest.test_username_widget_maxlength_custom_user)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/django/test/utils.py", line 370, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/auth_tests/test_forms.py", line 292, in test_username_widget_maxlength_custom_user
    self.assertIn('maxlength="255"', username_html)
AssertionError: 'maxlength="255"' not found in '<input type="text" name="username" autofocus autocapitalize="none" autocomplete="username" required id="id_username">'

======================================================================
FAIL: test_username_widget_maxlength_default_user (auth_tests.test_forms.AuthenticationFormTest.test_username_widget_maxlength_default_user)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/auth_tests/test_forms.py", line 287, in test_username_widget_maxlength_default_user
    self.assertIn('maxlength="150"', username_html)
AssertionError: 'maxlength="150"' not found in '<input type="text" name="username" autofocus autocapitalize="none" autocomplete="username" required id="id_username">'

======================================================================
FAIL: test_username_widget_maxlength_fallback (auth_tests.test_forms.AuthenticationFormTest.test_username_widget_maxlength_fallback)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/django/test/utils.py", line 370, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/auth_tests/test_forms.py", line 297, in test_username_widget_maxlength_fallback
    self.assertIn('maxlength="254"', username_html)
AssertionError: 'maxlength="254"' not found in '<input type="text" name="username" autofocus autocapitalize="none" autocomplete="username" required id="id_username">'

----------------------------------------------------------------------
Ran 22 tests in 0.027s

FAILED (failures=3, errors=1)
Destroying test database for alias 'default'...
```

## Reproduction Steps
1. `. /workspace/.venv/bin/activate`
2. `cd /workspace/django/tests`
3. `PYTHONPATH=/workspace/django ./runtests.py auth_tests.test_forms.AuthenticationFormTest --parallel=1`

## Testing
- `PYTHONPATH=/workspace/django ./runtests.py auth_tests.test_forms.AuthenticationFormTest --parallel=1`
- `flake8 django/contrib/auth/forms.py tests/auth_tests/test_forms.py`