### PR TITLE
swev-id: django__django-11815 - serialize enums by name

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -120,9 +120,9 @@ class EnumSerializer(BaseSerializer):
     def serialize(self):
         enum_class = self.value.__class__
         module = enum_class.__module__
-        v_string, v_imports = serializer_factory(self.value.value).serialize()
-        imports = {'import %s' % module, *v_imports}
-        return "%s.%s(%s)" % (module, enum_class.__name__, v_string), imports
+        name_string, name_imports = serializer_factory(self.value.name).serialize()
+        imports = {'import %s' % module, *name_imports}
+        return "%s.%s[%s]" % (module, enum_class.__name__, name_string), imports
 
 
 class FloatSerializer(BaseSimpleSerializer):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -267,15 +267,15 @@ class WriterTests(SimpleTestCase):
 
         self.assertSerializedResultEqual(
             TextEnum.A,
-            ("migrations.test_writer.TextEnum('a-value')", {'import migrations.test_writer'})
+            ("migrations.test_writer.TextEnum['A']", {'import migrations.test_writer'})
         )
         self.assertSerializedResultEqual(
             BinaryEnum.A,
-            ("migrations.test_writer.BinaryEnum(b'a-value')", {'import migrations.test_writer'})
+            ("migrations.test_writer.BinaryEnum['A']", {'import migrations.test_writer'})
         )
         self.assertSerializedResultEqual(
             IntEnum.B,
-            ("migrations.test_writer.IntEnum(2)", {'import migrations.test_writer'})
+            ("migrations.test_writer.IntEnum['B']", {'import migrations.test_writer'})
         )
 
         field = models.CharField(default=TextEnum.B, choices=[(m.value, m) for m in TextEnum])
@@ -283,28 +283,39 @@ class WriterTests(SimpleTestCase):
         self.assertEqual(
             string,
             "models.CharField(choices=["
-            "('a-value', migrations.test_writer.TextEnum('a-value')), "
-            "('value-b', migrations.test_writer.TextEnum('value-b'))], "
-            "default=migrations.test_writer.TextEnum('value-b'))"
+            "('a-value', migrations.test_writer.TextEnum['A']), "
+            "('value-b', migrations.test_writer.TextEnum['B'])], "
+            "default=migrations.test_writer.TextEnum['B'])"
         )
         field = models.CharField(default=BinaryEnum.B, choices=[(m.value, m) for m in BinaryEnum])
         string = MigrationWriter.serialize(field)[0]
         self.assertEqual(
             string,
             "models.CharField(choices=["
-            "(b'a-value', migrations.test_writer.BinaryEnum(b'a-value')), "
-            "(b'value-b', migrations.test_writer.BinaryEnum(b'value-b'))], "
-            "default=migrations.test_writer.BinaryEnum(b'value-b'))"
+            "(b'a-value', migrations.test_writer.BinaryEnum['A']), "
+            "(b'value-b', migrations.test_writer.BinaryEnum['B'])], "
+            "default=migrations.test_writer.BinaryEnum['B'])"
         )
         field = models.IntegerField(default=IntEnum.A, choices=[(m.value, m) for m in IntEnum])
         string = MigrationWriter.serialize(field)[0]
         self.assertEqual(
             string,
             "models.IntegerField(choices=["
-            "(1, migrations.test_writer.IntEnum(1)), "
-            "(2, migrations.test_writer.IntEnum(2))], "
-            "default=migrations.test_writer.IntEnum(1))"
+            "(1, migrations.test_writer.IntEnum['A']), "
+            "(2, migrations.test_writer.IntEnum['B'])], "
+            "default=migrations.test_writer.IntEnum['A'])"
         )
+
+    def test_serialize_enums_with_lazy_values(self):
+        class LazyEnum(enum.Enum):
+            HELLO = _('Hello')
+            GOODBYE = _('Goodbye')
+
+        serialized, imports = MigrationWriter.serialize(LazyEnum.HELLO)
+        self.assertEqual(serialized, "migrations.test_writer.LazyEnum['HELLO']")
+        self.assertEqual(imports, {'import migrations.test_writer'})
+        self.assertNotIn('gettext_lazy', serialized)
+        self.assertNotIn('Hello', serialized)
 
     def test_serialize_choices(self):
         class TextChoices(models.TextChoices):
@@ -454,7 +465,7 @@ class WriterTests(SimpleTestCase):
         # Test a string regex with flag
         validator = RegexValidator(r'^[0-9]+$', flags=re.S)
         string = MigrationWriter.serialize(validator)[0]
-        self.assertEqual(string, "django.core.validators.RegexValidator('^[0-9]+$', flags=re.RegexFlag(16))")
+        self.assertEqual(string, "django.core.validators.RegexValidator('^[0-9]+$', flags=re.RegexFlag['DOTALL'])")
         self.serialize_round_trip(validator)
 
         # Test message and code


### PR DESCRIPTION
## Summary
- serialize plain enums by member name so migrations resolve regardless of localized values
- update enum-related migration writer expectations and cover gettext_lazy-backed enums
- align RegexValidator flag expectation with name-based enum serialization

Fixes #157

## Testing
- `cd tests && PYTHONPATH=/workspace/django ./runtests.py migrations.test_writer --parallel=1`
- `flake8 django/db/migrations/serializer.py tests/migrations/test_writer.py`

## Reproduction
1. In a clean checkout of `django__django-11815`, run `django-admin startproject enum_repro` and `python manage.py startapp demo`.
2. Define an enum-backed model using lazy translations, for example:

   ```python
   import enum

   from django.db import models
   from django.utils.translation import gettext_lazy as _


   class PublicationStatus(enum.Enum):
       DRAFT = _('No')
       PUBLISHED = _('Yes')


   class Article(models.Model):
       title = models.CharField(max_length=100)
       status = models.CharField(
           max_length=20,
           choices=[(choice.value, choice) for choice in PublicationStatus],
           default=PublicationStatus.PUBLISHED,
       )
   ```
3. Add `demo` to `INSTALLED_APPS`, then run `python manage.py makemigrations`.
4. Observe `demo/migrations/0001_initial.py` contains `PublicationStatus('Yes')` in the choices/default.
5. Change `LANGUAGE_CODE` to `fr-FR` (or activate `translation.activate('fr')`) and run `python manage.py migrate`.

### Observed failure

```text
Traceback (most recent call last):
  File "/workspace/django-base/enum_repro/manage.py", line 21, in <module>
    main()
  File "/workspace/django-base/enum_repro/manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/workspace/django-base/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/workspace/django-base/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/workspace/django-base/django/core/management/base.py", line 328, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/workspace/django-base/django/core/management/base.py", line 369, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django-base/django/core/management/base.py", line 83, in wrapped
    res = handle_func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django-base/django/core/management/commands/migrate.py", line 86, in handle
    executor = MigrationExecutor(connection, self.migration_progress_callback)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django-base/django/db/migrations/executor.py", line 18, in __init__
    self.loader = MigrationLoader(self.connection)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django-base/django/db/migrations/loader.py", line 49, in __init__
    self.build_graph()
  File "/workspace/django-base/django/db/migrations/loader.py", line 206, in build_graph
    self.load_disk()
  File "/workspace/django-base/django/db/migrations/loader.py", line 108, in load_disk
    migration_module = import_module(migration_path)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/workspace/django-base/enum_repro/demo/migrations/0001_initial.py", line 7, in <module>
    class Migration(migrations.Migration):
  File "/workspace/django-base/enum_repro/demo/migrations/0001_initial.py", line 20, in Migration
    ('status', models.CharField(choices=[('No', demo.models.PublicationStatus('No')), ('Yes', demo.models.PublicationStatus('Yes'))], default=demo.models.PublicationStatus('Yes'), max_length=20)),
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/enum.py", line 714, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/enum.py", line 1137, in __new__
    raise ve_exc
ValueError: 'No' is not a valid PublicationStatus
```

**CI**: Not triggered (per instructions)
