### PR TITLE
swev-id: django__django-12039 normalize index clause whitespace

### DIFF
--- a/django/db/backends/ddl_references.py
+++ b/django/db/backends/ddl_references.py
@@ -92,9 +92,13 @@ class Columns(TableColumns):
         else:
             try:
                 raw = suffixes[idx]
-            except (IndexError, TypeError):
+            except IndexError:
                 raw = ''
-        return (raw or '').strip()
+        if raw is None or raw == '':
+            return ''
+        if not isinstance(raw, str):
+            raise TypeError('Column suffixes must be strings.')
+        return raw.strip()
 
     def __str__(self):
         def col_str(column, idx):

--- a/django/db/backends/ddl_references.py
+++ b/django/db/backends/ddl_references.py
@@ -3,6 +3,8 @@ Helpers to manipulate deferred DDL statements that might need to be adjusted or
 discarded within when executing a migration.
 """
 
+from collections.abc import Mapping
+
 
 class Reference:
     """Base class that defines the reference interface."""
@@ -81,12 +83,26 @@ class Columns(TableColumns):
         self.col_suffixes = col_suffixes
         super().__init__(table, columns)
 
+    def _column_suffix(self, column, idx):
+        suffixes = self.col_suffixes
+        if not suffixes:
+            return ''
+        if isinstance(suffixes, Mapping):
+            raw = suffixes.get(column, '')
+        else:
+            try:
+                raw = suffixes[idx]
+            except (IndexError, TypeError):
+                raw = ''
+        return (raw or '').strip()
+
     def __str__(self):
         def col_str(column, idx):
-            try:
-                return self.quote_name(column) + self.col_suffixes[idx]
-            except IndexError:
-                return self.quote_name(column)
+            quoted = self.quote_name(column)
+            suffix = self._column_suffix(column, idx)
+            if suffix:
+                return '{} {}'.format(quoted, suffix)
+            return quoted
 
         return ', '.join(col_str(column, idx) for idx, column in enumerate(self.columns))
 
@@ -113,10 +129,9 @@ class IndexColumns(Columns):
             # Index.__init__() guarantees that self.opclasses is the same
             # length as self.columns.
             col = '{} {}'.format(self.quote_name(column), self.opclasses[idx])
-            try:
-                col = '{} {}'.format(col, self.col_suffixes[idx])
-            except IndexError:
-                pass
+            suffix = self._column_suffix(column, idx)
+            if suffix:
+                col = '{} {}'.format(col, suffix)
             return col
 
         return ', '.join(col_str(column, idx) for idx, column in enumerate(self.columns))

--- a/tests/backends/test_ddl_references.py
+++ b/tests/backends/test_ddl_references.py
@@ -1,5 +1,8 @@
+from unittest import skipUnless
+
+from django.db import connection
 from django.db.backends.ddl_references import (
-    Columns, ForeignKeyName, IndexName, Statement, Table,
+    Columns, ForeignKeyName, IndexColumns, IndexName, Statement, Table,
 )
 from django.test import SimpleTestCase
 
@@ -55,6 +58,42 @@ class ColumnsTests(TableTests):
 
     def test_str(self):
         self.assertEqual(str(self.reference), 'FIRST_COLUMN, SECOND_COLUMN')
+
+
+class ColumnClauseFormattingTests(SimpleTestCase):
+
+    @skipUnless(connection.features.supports_index_column_ordering, 'requires ordered index support')
+    def test_descending_clause_spacing(self):
+        columns = Columns('table', ['name'], connection.ops.quote_name, col_suffixes=['DESC'])
+        clause = f'({columns})'
+        self.assertEqual(clause, '("name" DESC)')
+        self.assertNotIn('"name"DESC', clause)
+
+    def test_default_ascending_clause_no_trailing_space(self):
+        columns = Columns('table', ['name'], connection.ops.quote_name, col_suffixes=[''])
+        clause = f'({columns})'
+        self.assertEqual(clause, '("name")')
+        self.assertNotIn('"name" )', clause)
+
+    @skipUnless(connection.vendor == 'postgresql', 'requires PostgreSQL opclasses')
+    def test_opclass_clause_spacing(self):
+        columns = IndexColumns(
+            'table', ['name'], connection.ops.quote_name,
+            col_suffixes=[''], opclasses=['text_pattern_ops'],
+        )
+        clause = f'({columns})'
+        self.assertEqual(clause, '("name" text_pattern_ops)')
+        self.assertNotIn('text_pattern_ops )', clause)
+
+    @skipUnless(connection.vendor == 'postgresql', 'requires PostgreSQL opclasses')
+    def test_opclass_desc_clause_spacing(self):
+        columns = IndexColumns(
+            'table', ['name'], connection.ops.quote_name,
+            col_suffixes=['DESC'], opclasses=['text_pattern_ops'],
+        )
+        clause = f'({columns})'
+        self.assertEqual(clause, '("name" text_pattern_ops DESC)')
+        self.assertNotIn('text_pattern_opsDESC', clause)
 
 
 class IndexNameTests(ColumnsTests):


### PR DESCRIPTION
## Summary
- normalize CREATE INDEX column suffix rendering via `Columns`/`IndexColumns`
- add coverage asserting DESC, opclass, and default clauses render without stray whitespace

Closes #168

## Observed failure before fix
Command:
`PYTHONPATH=/workspace/django:/workspace/django/tests DJANGO_SETTINGS_MODULE=tests.test_sqlite python -m tests.runtests --verbosity=2 tests.backends.test_ddl_references -k ColumnClauseFormattingTests --parallel=1`

```
FAIL: test_descending_clause_spacing (tests.backends.test_ddl_references.ColumnClauseFormattingTests.test_descending_clause_spacing)
AssertionError: '("name"DESC)' != '("name" DESC)'
```

## Testing
- `PYTHONPATH=/workspace/django:/workspace/django/tests DJANGO_SETTINGS_MODULE=tests.test_sqlite python -m tests.runtests --verbosity=2 tests.backends.test_ddl_references -k ColumnClauseFormattingTests --parallel=1`
- `flake8 django/db/backends/ddl_references.py tests/backends/test_ddl_references.py`