### PR TITLE
fix: nested migration serialization swev-id: django__django-12125

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -8,6 +8,7 @@ import math
 import re
 import types
 import uuid
+from importlib import import_module
 
 from django.conf import SettingsReference
 from django.db import models
@@ -75,6 +76,23 @@ class DecimalSerializer(BaseSerializer):
 
 class DeconstructableSerializer(BaseSerializer):
     @staticmethod
+    def _split_module_and_qualname(path):
+        parts = path.split('.')
+        for index in range(len(parts) - 1, 0, -1):
+            module = '.'.join(parts[:index])
+            qualname = '.'.join(parts[index:])
+            if not qualname:
+                continue
+            try:
+                import_module(module)
+            except ImportError:
+                continue
+            else:
+                return module, qualname
+        module, qualname = path.rsplit('.', 1)
+        return module, qualname
+
+    @staticmethod
     def serialize_deconstructed(path, args, kwargs):
         name, imports = DeconstructableSerializer._serialize_path(path)
         strings = []
@@ -90,13 +108,13 @@ class DeconstructableSerializer(BaseSerializer):
 
     @staticmethod
     def _serialize_path(path):
-        module, name = path.rsplit(".", 1)
+        module, name = DeconstructableSerializer._split_module_and_qualname(path)
         if module == "django.db.models":
             imports = {"from django.db import models"}
             name = "models.%s" % name
         else:
             imports = {"import %s" % module}
-            name = path
+            name = "%s.%s" % (module, name)
         return name, imports
 
     def serialize(self):
@@ -120,8 +138,11 @@ class EnumSerializer(BaseSerializer):
     def serialize(self):
         enum_class = self.value.__class__
         module = enum_class.__module__
+        qualname = enum_class.__qualname__
+        if '<locals>' in qualname:
+            raise ValueError('Cannot serialize %r: defined in a local scope.' % enum_class)
         return (
-            '%s.%s[%r]' % (module, enum_class.__qualname__, self.value.name),
+            '%s.%s[%r]' % (module, qualname, self.value.name),
             {'import %s' % module},
         )
 
@@ -266,10 +287,13 @@ class TypeSerializer(BaseSerializer):
                 return string, set(imports)
         if hasattr(self.value, "__module__"):
             module = self.value.__module__
+            qualname = getattr(self.value, "__qualname__", self.value.__name__)
+            if '<locals>' in qualname:
+                raise ValueError('Cannot serialize %r: defined in a local scope.' % self.value)
             if module == builtins.__name__:
-                return self.value.__name__, set()
+                return qualname, set()
             else:
-                return "%s.%s" % (module, self.value.__name__), {"import %s" % module}
+                return "%s.%s" % (module, qualname), {"import %s" % module}
 
 
 class UUIDSerializer(BaseSerializer):

--- a/django/db/migrations/writer.py
+++ b/django/db/migrations/writer.py
@@ -162,6 +162,16 @@ class MigrationWriter:
                 imports.remove(line)
                 self.needs_manual_porting = True
 
+        normalized_imports = set()
+        for line in imports:
+            if line.startswith('from '):
+                match = re.match(r'^from\s+([\w.]+)\s+import\s+([^\s,]+)$', line)
+                if match and '.' in match.group(2):
+                    normalized_imports.add(f"import {match.group(1)}")
+                    continue
+            normalized_imports.add(line)
+        imports = normalized_imports
+
         # django.db.migrations is always used, but models import may not be.
         # If models import exists, merge it with migrations import.
         if "from django.db import models" in imports:

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -61,6 +61,51 @@ class IntEnum(enum.IntEnum):
     B = 2
 
 
+class ModelWithNestedField(models.Model):
+    class InnerField(models.CharField):
+        pass
+
+    class Meta:
+        app_label = 'migrations'
+
+
+class ModelWithNestedEnum(models.Model):
+    class Status(enum.Enum):
+        ACTIVE = 'active'
+        INACTIVE = 'inactive'
+
+    class Meta:
+        app_label = 'migrations'
+
+
+class ModelWithNestedChoices(models.Model):
+    class Level(models.IntegerChoices):
+        LOW = 1, 'Low'
+        HIGH = 2, 'High'
+
+    class Label(models.TextChoices):
+        RED = 'R', 'Red'
+        BLUE = 'B', 'Blue'
+
+    class Meta:
+        app_label = 'migrations'
+
+
+class ModelWithMultiLevel(models.Model):
+    class Container:
+        class Deep(enum.Enum):
+            READY = 'ready'
+            WAITING = 'waiting'
+
+    class Meta:
+        app_label = 'migrations'
+
+
+class DeconstructibleInstances:
+    def deconstruct(self):
+        return ('DeconstructibleInstances', [], {})
+
+
 class OperationWriterTests(SimpleTestCase):
 
     def test_empty_signature(self):
@@ -340,6 +385,57 @@ class WriterTests(SimpleTestCase):
             "(2, migrations.test_writer.IntEnum['B'])], "
             "default=migrations.test_writer.IntEnum['A'])"
         )
+
+    def test_serialize_nested_field_subclass(self):
+        field = ModelWithNestedField.InnerField(max_length=32)
+        string, imports = MigrationWriter.serialize(field)
+        self.assertEqual(
+            string,
+            'migrations.test_writer.ModelWithNestedField.InnerField(max_length=32)',
+        )
+        self.assertEqual(imports, {'import migrations.test_writer'})
+
+    def test_serialize_nested_enum_member(self):
+        self.assertSerializedResultEqual(
+            ModelWithNestedEnum.Status.ACTIVE,
+            (
+                "migrations.test_writer.ModelWithNestedEnum.Status['ACTIVE']",
+                {'import migrations.test_writer'},
+            ),
+        )
+
+    def test_serialize_nested_choices_classes(self):
+        string, imports = MigrationWriter.serialize(ModelWithNestedChoices.Level)
+        self.assertEqual(
+            string,
+            'migrations.test_writer.ModelWithNestedChoices.Level',
+        )
+        self.assertEqual(imports, {'import migrations.test_writer'})
+        string, imports = MigrationWriter.serialize(ModelWithNestedChoices.Label)
+        self.assertEqual(
+            string,
+            'migrations.test_writer.ModelWithNestedChoices.Label',
+        )
+        self.assertEqual(imports, {'import migrations.test_writer'})
+
+    def test_serialize_multi_level_nested_enum_member(self):
+        self.assertSerializedResultEqual(
+            ModelWithMultiLevel.Container.Deep.READY,
+            (
+                "migrations.test_writer.ModelWithMultiLevel.Container.Deep['READY']",
+                {'import migrations.test_writer'},
+            ),
+        )
+
+    def test_serialize_function_local_class_error(self):
+        def make_local_field_class():
+            class LocalField(models.CharField):
+                pass
+
+            return LocalField
+
+        with self.assertRaisesMessage(ValueError, 'defined in a local scope'):
+            MigrationWriter.serialize(make_local_field_class())
 
     def test_serialize_choices(self):
         class TextChoices(models.TextChoices):
@@ -726,10 +822,6 @@ class WriterTests(SimpleTestCase):
         # Yes, it doesn't make sense to use a class as a default for a
         # CharField. It does make sense for custom fields though, for example
         # an enumfield that takes the enum class as an argument.
-        class DeconstructibleInstances:
-            def deconstruct(self):
-                return ('DeconstructibleInstances', [], {})
-
         string = MigrationWriter.serialize(models.CharField(default=DeconstructibleInstances))[0]
         self.assertEqual(string, "models.CharField(default=migrations.test_writer.DeconstructibleInstances)")
 


### PR DESCRIPTION
## Reproduction
1. Define nested classes inside a model (e.g. an inner `CharField` subclass or `enum.Enum`).
2. Run `manage.py makemigrations`.
3. Inspect the generated migration or apply it with `migrate`.

**Observed:** migrations import `from app.models import Outer.Inner` and later reference `Outer.Inner`, so the import fails.
**Error:** `AttributeError: module 'app.models' has no attribute 'Inner'` (or similar for nested enums/choices).

## Fix
- Resolve serialized paths using module + `__qualname__`, rejecting `<locals>` definitions with a clear error.
- Normalize migration imports to keep `import module` when the qualname has dots.
- Add regression coverage for nested field subclasses, enums, Django Choices, deeply nested enums, and the new `<locals>` failure case.

Fixes #173