### PR TITLE
fix: swev-id: django__django-12193 isolate checkbox attr contexts

### DIFF
--- a/django/contrib/postgres/forms/array.py
+++ b/django/contrib/postgres/forms/array.py
@@ -131,24 +131,23 @@ class SplitArrayWidget(forms.Widget):
         return id_
 
     def get_context(self, name, value, attrs=None):
-        attrs = {} if attrs is None else attrs
         context = super().get_context(name, value, attrs)
         if self.is_localized:
             self.widget.is_localized = self.is_localized
         value = value or []
         context['widget']['subwidgets'] = []
-        final_attrs = self.build_attrs(attrs)
-        id_ = final_attrs.get('id')
+        base_attrs = self.build_attrs(attrs or {})
+        id_ = base_attrs.get('id')
         for i in range(max(len(value), self.size)):
             try:
                 widget_value = value[i]
             except IndexError:
                 widget_value = None
+            item_attrs = base_attrs.copy()
             if id_:
-                final_attrs = {**final_attrs, 'id': '%s_%s' % (id_, i)}
-            context['widget']['subwidgets'].append(
-                self.widget.get_context(name + '_%s' % i, widget_value, final_attrs)['widget']
-            )
+                item_attrs['id'] = '%s_%s' % (id_, i)
+            sub_ctx = self.widget.get_context('%s_%s' % (name, i), widget_value, item_attrs)
+            context['widget']['subwidgets'].append(sub_ctx['widget'])
         return context
 
     @property

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -521,11 +521,10 @@ class CheckboxInput(Input):
         return str(value)
 
     def get_context(self, name, value, attrs):
+        local_attrs = {} if attrs is None else attrs.copy()
         if self.check_test(value):
-            if attrs is None:
-                attrs = {}
-            attrs['checked'] = True
-        return super().get_context(name, value, attrs)
+            local_attrs['checked'] = True
+        return super().get_context(name, value, local_attrs)
 
     def value_from_datadict(self, data, files, name):
         if name not in data:

--- a/tests/forms_tests/widget_tests/test_checkboxinput.py
+++ b/tests/forms_tests/widget_tests/test_checkboxinput.py
@@ -89,3 +89,16 @@ class CheckboxInputTest(WidgetTest):
     def test_value_omitted_from_data(self):
         self.assertIs(self.widget.value_omitted_from_data({'field': 'value'}, {}, 'field'), False)
         self.assertIs(self.widget.value_omitted_from_data({}, {}, 'field'), False)
+
+    def test_checkboxinput_get_context_does_not_mutate_attrs(self):
+        widget = CheckboxInput()
+        attrs = {'data-test': 'value'}
+        widget.get_context('is_cool', True, attrs)
+        self.assertEqual(attrs, {'data-test': 'value'})
+
+    def test_checkboxinput_checked_attr_set_when_true_only(self):
+        widget = CheckboxInput()
+        context_true = widget.get_context('is_cool', True, {})
+        self.assertIs(context_true['widget']['attrs'].get('checked'), True)
+        context_false = widget.get_context('is_cool', False, {})
+        self.assertNotIn('checked', context_false['widget']['attrs'])

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1130,3 +1130,22 @@ class TestSplitFormWidget(PostgreSQLWidgetTestCase):
         self.assertIs(widget.value_omitted_from_data({'field_0': 'value'}, {}, 'field'), False)
         self.assertIs(widget.value_omitted_from_data({'field_1': 'value'}, {}, 'field'), False)
         self.assertIs(widget.value_omitted_from_data({'field_0': 'value', 'field_1': 'value'}, {}, 'field'), False)
+
+    def test_splitarraywidget_boolean_checked_flags_initial(self):
+        widget = SplitArrayWidget(forms.CheckboxInput(), size=2)
+        attrs = {'id': 'checkboxes'}
+        context = widget.get_context('checkboxes', [True, False], attrs)
+        subwidgets = context['widget']['subwidgets']
+        self.assertIs(subwidgets[0]['attrs'].get('checked'), True)
+        self.assertNotIn('checked', subwidgets[1]['attrs'])
+        self.assertEqual(attrs, {'id': 'checkboxes'})
+
+    def test_splitarraywidget_boolean_checked_flags_bound_data(self):
+        widget = SplitArrayWidget(forms.CheckboxInput(), size=2)
+        attrs = {'id': 'checkboxes'}
+        value = widget.value_from_datadict({'checkboxes_0': 'on'}, {}, 'checkboxes')
+        context = widget.get_context('checkboxes', value, attrs)
+        subwidgets = context['widget']['subwidgets']
+        self.assertIs(subwidgets[0]['attrs'].get('checked'), True)
+        self.assertNotIn('checked', subwidgets[1]['attrs'])
+        self.assertEqual(attrs, {'id': 'checkboxes'})


### PR DESCRIPTION
Resolves #176.

## Summary
- copy CheckboxInput attrs before mutation so checked flags stay local
- ensure SplitArrayWidget clones base attrs for each subwidget
- add regression coverage for checkbox contexts and split array checkboxes

## Reproduction
1. Instantiate `SplitArrayWidget(forms.CheckboxInput(), size=2)` with initial data `[True, False]` or bind POST data where only `_0` is submitted.
2. Call `get_context()`; the shared attrs dict is mutated with `checked=True` on the first subwidget.
3. Subsequent subwidgets reuse that dict and incorrectly render with `checked` despite false values.

Observed: unchecked positions render with a `checked` attribute.
Expected: only values that evaluate truthy via `check_test` render as checked.

## Fix
Copy incoming attrs in `CheckboxInput.get_context()` and clone the base attrs for each SplitArrayWidget iteration so state cannot leak between widgets.

## Testing
- cd tests && PYTHONPATH=/workspace/django ./runtests.py forms_tests.widget_tests.test_checkboxinput postgres_tests.test_array --parallel=1
- flake8 --extend-ignore=E741 django/forms/widgets.py
- flake8 django/contrib/postgres/forms/array.py tests/forms_tests/widget_tests/test_checkboxinput.py tests/postgres_tests/test_array.py