### PR TITLE
swev-id: django__django-12050 Fix Query.resolve_lookup_value to preserve iterable type

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1050,7 +1050,7 @@ class Query(BaseExpression):
             sql = '(%s)' % sql
         return sql, params
 
-    def resolve_lookup_value(self, value, can_reuse, allow_joins, simple_col):
+    def resolve_lookup_value(self, value, can_reuse, allow_joins, simple_col, lookups):
         if hasattr(value, 'resolve_expression'):
             kwargs = {'reuse': can_reuse, 'allow_joins': allow_joins}
             if isinstance(value, F):
@@ -1073,7 +1073,11 @@ class Query(BaseExpression):
                         ))
                 else:
                     resolved_values.append(sub_value)
-            value = tuple(resolved_values)
+            lookup_name = lookups[-1] if lookups else 'exact'
+            if lookup_name in {'exact', 'iexact'} and isinstance(value, list):
+                value = resolved_values
+            else:
+                value = tuple(resolved_values)
         return value
 
     def solve_lookup_type(self, lookup):
@@ -1255,7 +1259,7 @@ class Query(BaseExpression):
             raise FieldError("Joined field references are not permitted in this query")
 
         pre_joins = self.alias_refcount.copy()
-        value = self.resolve_lookup_value(value, can_reuse, allow_joins, simple_col)
+        value = self.resolve_lookup_value(value, can_reuse, allow_joins, simple_col, lookups)
         used_joins = {k for k, v in self.alias_refcount.items() if v > pre_joins.get(k, 0)}
 
         self.check_filterable(value)

--- a/tests/model_fields/models.py
+++ b/tests/model_fields/models.py
@@ -1,4 +1,6 @@
+import base64
 import os
+import pickle
 import tempfile
 import uuid
 
@@ -8,6 +10,7 @@ from django.contrib.contenttypes.fields import (
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.storage import FileSystemStorage
 from django.db import models
+from django.db.models.lookups import IExact
 from django.db.models.fields.files import ImageField, ImageFieldFile
 from django.db.models.fields.related import (
     ForeignKey, ForeignObject, ManyToManyField, OneToOneField,
@@ -405,3 +408,47 @@ class UUIDChild(PrimaryKeyUUIDModel):
 
 class UUIDGrandchild(UUIDChild):
     pass
+
+
+class TypePreservingPickledField(models.TextField):
+    description = "Pickled object that preserves the original Python type."
+
+    def to_python(self, value):
+        if value is None:
+            return None
+        if isinstance(value, (list, tuple, dict, set, int, float, bool)):
+            return value
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            value = bytes(value).decode("ascii")
+        if isinstance(value, str):
+            data = base64.b64decode(value.encode("ascii"))
+            return pickle.loads(data)
+        return value
+
+    def from_db_value(self, value, expression, connection):
+        return self.to_python(value)
+
+    def get_prep_value(self, value):
+        if value is None:
+            return None
+        data = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        return base64.b64encode(data).decode("ascii")
+
+    def get_db_prep_save(self, value, connection):
+        return self.get_prep_value(value)
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if value is None:
+            return None
+        if not prepared:
+            value = self.get_prep_value(value)
+        return value
+
+
+@TypePreservingPickledField.register_lookup
+class TypePreservingIExact(IExact):
+    prepare_rhs = True
+
+
+class PickledTypePreservingModel(models.Model):
+    payload = TypePreservingPickledField()

--- a/tests/model_fields/test_pickled_exact_lookup.py
+++ b/tests/model_fields/test_pickled_exact_lookup.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+from .models import PickledTypePreservingModel
+
+
+class PickledIterableExactLookupTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.model = PickledTypePreservingModel
+        cls.list_value = ["alpha", "beta"]
+        cls.tuple_value = ("alpha", "beta")
+        cls.list_instance = cls.model.objects.create(payload=cls.list_value)
+        cls.tuple_instance = cls.model.objects.create(payload=cls.tuple_value)
+        cls.list_instance.refresh_from_db()
+        cls.tuple_instance.refresh_from_db()
+
+    def test_exact_lookup_preserves_iterable_type(self):
+        self.assertEqual(
+            self.model.objects.get(payload__exact=self.list_value),
+            self.list_instance,
+        )
+        self.assertEqual(
+            self.model.objects.get(payload__exact=self.tuple_value),
+            self.tuple_instance,
+        )
+
+    def test_iexact_lookup_preserves_iterable_type(self):
+        self.assertEqual(
+            self.model.objects.get(payload__iexact=self.list_value),
+            self.list_instance,
+        )
+        self.assertEqual(
+            self.model.objects.get(payload__iexact=self.tuple_value),
+            self.tuple_instance,
+        )
+
+    def test_implicit_exact_lookup_preserves_iterable_type(self):
+        self.assertEqual(
+            self.model.objects.get(payload=self.list_value),
+            self.list_instance,
+        )
+        self.assertEqual(
+            self.model.objects.get(payload=self.tuple_value),
+            self.tuple_instance,
+        )


### PR DESCRIPTION
## Summary
- add regression tests covering iterable exact/iexact on pickled field, including implicit exact path
- ensure TypePreservingPickledField serializes lists without losing type information
- keep list inputs intact in Query.resolve_lookup_value for exact/iexact lookups

## Testing
- python tests/runtests.py model_fields.test_pickled_exact_lookup --parallel=1 -v 2
- python tests/runtests.py model_fields --parallel=1
- python -m flake8 tests/model_fields/test_pickled_exact_lookup.py tests/model_fields/models.py django/db/models/sql/query.py

Closes #171