### PR TITLE
swev-id: django__django-12276 fix fileinput required attr

### DIFF
--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -140,7 +140,7 @@ class Media:
         except CyclicDependencyError:
             warnings.warn(
                 'Detected duplicate Media files in an opposite order: {}'.format(
-                    ', '.join(repr(l) for l in lists)
+                    ', '.join(repr(list_) for list_ in lists)
                 ), MediaOrderConflictWarning,
             )
             return list(all_items)
@@ -387,6 +387,9 @@ class FileInput(Input):
     def value_omitted_from_data(self, data, files, name):
         return name not in files
 
+    def use_required_attribute(self, initial):
+        return super().use_required_attribute(initial) and not bool(initial)
+
 
 FILE_INPUT_CONTRADICTION = object()
 
@@ -450,9 +453,6 @@ class ClearableFileInput(FileInput):
             # False signals to clear any existing value, as opposed to just None
             return False
         return upload
-
-    def use_required_attribute(self, initial):
-        return super().use_required_attribute(initial) and not initial
 
     def value_omitted_from_data(self, data, files, name):
         return (

--- a/docs/ref/forms/widgets.txt
+++ b/docs/ref/forms/widgets.txt
@@ -325,8 +325,9 @@ foundation for custom widgets.
         to display the ``required`` attribute for each field.
 
         By default, returns ``False`` for hidden widgets and ``True``
-        otherwise. Special cases are :class:`~django.forms.ClearableFileInput`,
-        which returns ``False`` when ``initial`` is set, and
+        otherwise. Special cases are :class:`~django.forms.FileInput` and
+        :class:`~django.forms.ClearableFileInput`, which return ``False`` when
+        ``initial`` is set, and
         :class:`~django.forms.CheckboxSelectMultiple`, which always returns
         ``False`` because browser validation would require all checkboxes to be
         checked instead of at least one.
@@ -814,6 +815,9 @@ File upload widgets
 
     * ``template_name``: ``'django/forms/widgets/file.html'``
     * Renders as: ``<input type="file" ...>``
+    * Omits the ``required`` HTML attribute when ``initial`` data is
+      provided, allowing existing files to be kept without browser
+      validation errors.
 
 ``ClearableFileInput``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/forms_tests/widget_tests/test_fileinput.py
+++ b/tests/forms_tests/widget_tests/test_fileinput.py
@@ -1,4 +1,7 @@
+from django import forms
+from django.core.files.base import ContentFile
 from django.forms import FileInput
+from django.test import SimpleTestCase
 
 from .base import WidgetTest
 
@@ -18,3 +21,58 @@ class FileInputTest(WidgetTest):
     def test_value_omitted_from_data(self):
         self.assertIs(self.widget.value_omitted_from_data({}, {}, 'field'), True)
         self.assertIs(self.widget.value_omitted_from_data({}, {'field': 'value'}, 'field'), False)
+
+
+class FileInputRequiredAttributeTest(SimpleTestCase):
+
+    def test_required_field_without_initial_renders_required(self):
+        class FileForm(forms.Form):
+            file = forms.FileField(widget=FileInput(), required=True)
+
+        form = FileForm()
+        self.assertHTMLEqual(
+            str(form['file']),
+            '<input type="file" name="file" required id="id_file">',
+        )
+
+    def test_required_field_with_initial_omits_required(self):
+        class FileForm(forms.Form):
+            file = forms.FileField(widget=FileInput(), required=True)
+
+        form = FileForm(initial={'file': ContentFile(b'baz', name='baz.txt')})
+        self.assertHTMLEqual(
+            str(form['file']),
+            '<input type="file" name="file" id="id_file">',
+        )
+
+    def test_optional_field_never_renders_required(self):
+        class FileForm(forms.Form):
+            file = forms.FileField(widget=FileInput(), required=False)
+
+        form = FileForm()
+        self.assertHTMLEqual(
+            str(form['file']),
+            '<input type="file" name="file" id="id_file">',
+        )
+
+    def test_explicit_required_attr_is_preserved(self):
+        class FileForm(forms.Form):
+            file = forms.FileField(
+                widget=FileInput(attrs={'required': 'required'}),
+                required=False,
+            )
+
+        form = FileForm(initial={'file': ContentFile(b'bar', name='bar.txt')})
+        self.assertHTMLEqual(
+            str(form['file']),
+            '<input type="file" name="file" required id="id_file">',
+        )
+
+    def test_use_required_attribute_truth_table(self):
+        widget = FileInput()
+        widget.is_required = True
+
+        self.assertTrue(widget.use_required_attribute(None))
+        self.assertTrue(widget.use_required_attribute(''))
+        self.assertFalse(widget.use_required_attribute('resume.txt'))
+        self.assertFalse(widget.use_required_attribute(ContentFile(b'data', name='cv.pdf')))


### PR DESCRIPTION
## Summary
- lift FileInput's required-attribute gate into the base widget
- align ClearableFileInput with the shared logic and document the behavior
- add regression tests for rendering, use_required_attribute(), and optional fields

## Issue
- Fixes #180

## Reproduction Steps
1. python3.11 -m venv .venv
2. .venv/bin/pip install -e .
3. PYTHONPATH=$PWD .venv/bin/python tests/runtests.py forms_tests.widget_tests.test_fileinput --parallel=1

Python 3.11.14 on Linux (containerized CI image).

### Observed Failure
```
F..
======================================================================
FAIL: test_required_attribute_omitted_with_initial (forms_tests.widget_tests.test_fileinput.FileInputRequiredAttributeTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/forms_tests/widget_tests/test_fileinput.py", line 33, in test_required_attribute_omitted_with_initial
    self.assertEqual(
AssertionError: '<input type="file" name="file" required id="id_file">' != '<input type="file" name="file" id="id_file">'

----------------------------------------------------------------------
Ran 3 tests in 0.005s

FAILED (failures=1)
```

## Fix Details
- implement FileInput.use_required_attribute() to suppress required when initial is truthy
- let ClearableFileInput inherit the logic and keep its behavior in sync
- expand documentation to note the shared special case

## Tests
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py forms_tests.widget_tests.test_fileinput --parallel=1
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py forms_tests.widget_tests.test_clearablefileinput --parallel=1
- .venv/bin/flake8 django/forms/widgets.py tests/forms_tests/widget_tests/test_fileinput.py