### PR TITLE
Fix template tag kw-only defaults: correct unexpected keyword and duplicate keyword errors (swev-id: django__django-12262)

### DIFF
--- a/django/template/library.py
+++ b/django/template/library.py
@@ -261,7 +261,7 @@ def parse_bits(parser, bits, params, varargs, varkw, defaults,
         if kwarg:
             # The kwarg was successfully extracted
             param, value = kwarg.popitem()
-            if param not in params and param not in unhandled_kwargs and varkw is None:
+            if param not in params and param not in kwonly and varkw is None:
                 # An unexpected keyword argument was supplied
                 raise TemplateSyntaxError(
                     "'%s' received unexpected keyword argument '%s'" %

--- a/tests/template_tests/templatetags/inclusion.py
+++ b/tests/template_tests/templatetags/inclusion.py
@@ -136,6 +136,15 @@ def inclusion_one_default(one, two='hi'):
 inclusion_one_default.anything = "Expected inclusion_one_default __dict__"
 
 
+@register.inclusion_tag('inclusion.html')
+def inclusion_keyword_only_default(*, kwarg=42):
+    """Expected inclusion_keyword_only_default __doc__"""
+    return {"result": "inclusion_keyword_only_default - Expected result: %s" % kwarg}
+
+
+inclusion_keyword_only_default.anything = "Expected inclusion_keyword_only_default __dict__"
+
+
 @register.inclusion_tag(engine.get_template('inclusion.html'))
 def inclusion_one_default_from_template(one, two='hi'):
     """Expected inclusion_one_default_from_template __doc__"""

--- a/tests/template_tests/test_custom.py
+++ b/tests/template_tests/test_custom.py
@@ -62,6 +62,8 @@ class SimpleTagTests(TagTestCase):
                 'simple_keyword_only_param - Expected result: 37'),
             ('{% load custom %}{% simple_keyword_only_default %}',
                 'simple_keyword_only_default - Expected result: 42'),
+            ('{% load custom %}{% simple_keyword_only_default kwarg=99 %}',
+                'simple_keyword_only_default - Expected result: 99'),
             ('{% load custom %}{% simple_one_default 37 %}', 'simple_one_default - Expected result: 37, hi'),
             ('{% load custom %}{% simple_one_default 37 two="hello" %}',
                 'simple_one_default - Expected result: 37, hello'),
@@ -101,6 +103,10 @@ class SimpleTagTests(TagTestCase):
                 '{% load custom %}{% simple_unlimited_args_kwargs 37 40|add:2 eggs="scrambled" 56 four=1|add:3 %}'),
             ("'simple_unlimited_args_kwargs' received multiple values for keyword argument 'eggs'",
                 '{% load custom %}{% simple_unlimited_args_kwargs 37 eggs="scrambled" eggs="scrambled" %}'),
+            ("'simple_keyword_only_default' received multiple values for keyword argument 'kwarg'",
+                '{% load custom %}{% simple_keyword_only_default kwarg=1 kwarg=2 %}'),
+            ("'simple_keyword_only_default' received unexpected keyword argument 'unexpected'",
+                '{% load custom %}{% simple_keyword_only_default unexpected=1 %}'),
         ]
 
         for entry in errors:
@@ -174,6 +180,8 @@ class InclusionTagTests(TagTestCase):
                 '{% load inclusion %}{% inclusion_one_default 37 %}',
                 'inclusion_one_default - Expected result: 37, hi\n'
             ),
+            ('{% load inclusion %}{% inclusion_keyword_only_default kwarg="custom" %}',
+                'inclusion_keyword_only_default - Expected result: custom\n'),
             ('{% load inclusion %}{% inclusion_one_default 37 two="hello" %}',
                 'inclusion_one_default - Expected result: 37, hello\n'),
             ('{% load inclusion %}{% inclusion_one_default one=99 two="hello" %}',
@@ -215,6 +223,10 @@ class InclusionTagTests(TagTestCase):
             ),
             ("'inclusion_unlimited_args_kwargs' received multiple values for keyword argument 'eggs'",
                 '{% load inclusion %}{% inclusion_unlimited_args_kwargs 37 eggs="scrambled" eggs="scrambled" %}'),
+            ("'inclusion_keyword_only_default' received multiple values for keyword argument 'kwarg'",
+                '{% load inclusion %}{% inclusion_keyword_only_default kwarg="custom" kwarg="again" %}'),
+            ("'inclusion_keyword_only_default' received unexpected keyword argument 'unexpected'",
+                '{% load inclusion %}{% inclusion_keyword_only_default unexpected="value" %}'),
         ]
 
         for entry in errors:
@@ -274,6 +286,7 @@ class InclusionTagTests(TagTestCase):
         self.verify_tag(inclusion.inclusion_params_and_context, 'inclusion_params_and_context')
         self.verify_tag(inclusion.inclusion_two_params, 'inclusion_two_params')
         self.verify_tag(inclusion.inclusion_one_default, 'inclusion_one_default')
+        self.verify_tag(inclusion.inclusion_keyword_only_default, 'inclusion_keyword_only_default')
         self.verify_tag(inclusion.inclusion_unlimited_args, 'inclusion_unlimited_args')
         self.verify_tag(inclusion.inclusion_only_unlimited_args, 'inclusion_only_unlimited_args')
         self.verify_tag(inclusion.inclusion_tag_without_context_parameter, 'inclusion_tag_without_context_parameter')


### PR DESCRIPTION
## Summary
- fix template.Library.parse_bits to honor keyword-only defaults when checking for unexpected keywords
- extend simple_tag and inclusion_tag tests covering kw-only defaults, duplicate keywords, and unexpected keywords

## Reproduction Steps
1. Define a simple_tag without **kwargs but with a keyword-only parameter that has a default:
   ```python
   @register.simple_tag
   def kwonly_default(*, a='x'):
       return a
   ```
2. Render `{% kwonly_default a='y' %}` in a template.
3. Repeat with `{% kwonly_default a='y' a='z' %}` to supply the same keyword twice.
4. Perform the same experiment with an inclusion_tag using a keyword-only default.

## Observed Failure (before fix)
```
TemplateSyntaxError: "'kwonly_default' received unexpected keyword argument 'a'"
  at django/template/library.py:parse_bits
```
Supplying the same keyword twice raised the same unexpected keyword error instead of the duplicate keyword error.

## Issue
- Closes #183

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py template_tests.test_custom --parallel=1
- flake8 django/template/library.py tests/template_tests/test_custom.py tests/template_tests/templatetags/custom.py tests/template_tests/templatetags/inclusion.py