### PR TITLE
Fix explicit pk with default primary key save behavior (swev-id: django__django-12209)

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -528,6 +528,16 @@ class Model(metaclass=ModelBase):
         super().__init__()
         post_init.send(sender=cls, instance=self)
 
+    def __setattr__(self, name, value):
+        if (
+            name == self._meta.pk.attname and
+            value is not None and
+            value is not DEFERRED and
+            '_state' in self.__dict__
+        ):
+            self._state.pk_set_explicitly = True
+        super().__setattr__(name, value)
+
     @classmethod
     def from_db(cls, db, field_names, values):
         if len(values) != len(cls._meta.concrete_fields):

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -399,6 +399,7 @@ class ModelState:
     # on the actual save.
     adding = True
     fields_cache = ModelStateFieldsCacheDescriptor()
+    pk_set_explicitly = False
 
 
 class Model(metaclass=ModelBase):
@@ -414,6 +415,7 @@ class Model(metaclass=ModelBase):
 
         # Set up the storage for instance state
         self._state = ModelState()
+        self._state.pk_set_explicitly = False
 
         # There is a rather weird disparity here; if kwargs, it's set, then args
         # overrides it. It should be one or the other; don't duplicate the work
@@ -433,6 +435,8 @@ class Model(metaclass=ModelBase):
                 if val is _DEFERRED:
                     continue
                 _setattr(self, field.attname, val)
+                if field.primary_key:
+                    self._state.pk_set_explicitly = True
         else:
             # Slower, kwargs-ready version.
             fields_iter = iter(opts.fields)
@@ -440,6 +444,8 @@ class Model(metaclass=ModelBase):
                 if val is _DEFERRED:
                     continue
                 _setattr(self, field.attname, val)
+                if field.primary_key:
+                    self._state.pk_set_explicitly = True
                 kwargs.pop(field.name, None)
 
         # Now we're left with the unprocessed fields that *must* come from
@@ -450,29 +456,37 @@ class Model(metaclass=ModelBase):
             # Virtual field
             if field.attname not in kwargs and field.column is None:
                 continue
+            value_set_explicitly = None
             if kwargs:
                 if isinstance(field.remote_field, ForeignObjectRel):
                     try:
                         # Assume object instance was passed in.
                         rel_obj = kwargs.pop(field.name)
                         is_related_object = True
+                        if field.primary_key:
+                            self._state.pk_set_explicitly = True
                     except KeyError:
                         try:
                             # Object instance wasn't passed in -- must be an ID.
                             val = kwargs.pop(field.attname)
+                            value_set_explicitly = True
                         except KeyError:
                             val = field.get_default()
+                            value_set_explicitly = False
                 else:
                     try:
                         val = kwargs.pop(field.attname)
+                        value_set_explicitly = True
                     except KeyError:
                         # This is done with an exception rather than the
                         # default argument on pop because we don't want
                         # get_default() to be evaluated, and then not used.
                         # Refs #12057.
                         val = field.get_default()
+                        value_set_explicitly = False
             else:
                 val = field.get_default()
+                value_set_explicitly = False
 
             if is_related_object:
                 # If we are passed a related instance, set it using the
@@ -484,6 +498,8 @@ class Model(metaclass=ModelBase):
             else:
                 if val is not _DEFERRED:
                     _setattr(self, field.attname, val)
+                    if field.primary_key and value_set_explicitly is not None:
+                        self._state.pk_set_explicitly = value_set_explicitly
 
         if kwargs:
             property_names = opts._property_names
@@ -491,9 +507,19 @@ class Model(metaclass=ModelBase):
                 try:
                     # Any remaining kwargs must correspond to properties or
                     # virtual fields.
-                    if prop in property_names or opts.get_field(prop):
-                        if kwargs[prop] is not _DEFERRED:
-                            _setattr(self, prop, kwargs[prop])
+                    value = kwargs[prop]
+                    if prop in property_names:
+                        if value is not _DEFERRED:
+                            _setattr(self, prop, value)
+                            if prop == 'pk':
+                                self._state.pk_set_explicitly = True
+                        del kwargs[prop]
+                    else:
+                        field = opts.get_field(prop)
+                        if value is not _DEFERRED:
+                            _setattr(self, prop, value)
+                            if field.primary_key:
+                                self._state.pk_set_explicitly = True
                         del kwargs[prop]
                 except (AttributeError, FieldDoesNotExist):
                     pass
@@ -843,6 +869,8 @@ class Model(metaclass=ModelBase):
         if pk_val is None:
             pk_val = meta.pk.get_pk_value_on_save(self)
             setattr(self, meta.pk.attname, pk_val)
+            if hasattr(self._state, 'pk_set_explicitly'):
+                self._state.pk_set_explicitly = False
         pk_set = pk_val is not None
         if not pk_set and (force_update or update_fields):
             raise ValueError("Cannot force an update in save() with no primary key.")
@@ -851,8 +879,9 @@ class Model(metaclass=ModelBase):
         if (
             not force_insert and
             self._state.adding and
-            self._meta.pk.default and
-            self._meta.pk.default is not NOT_PROVIDED
+            self._meta.pk.default is not NOT_PROVIDED and
+            not raw and
+            not getattr(self._state, 'pk_set_explicitly', False)
         ):
             force_insert = True
         # If possible, try an UPDATE. If that doesn't update anything, do an INSERT.

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -46,3 +46,4 @@ class SelfRef(models.Model):
 
 class PrimaryKeyWithDefault(models.Model):
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    name = models.CharField(max_length=64, blank=True)

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -134,10 +134,41 @@ class ModelInstanceCreationTests(TestCase):
         # ... but there will often be more efficient ways if that is all you need:
         self.assertTrue(Article.objects.filter(id=a.id).exists())
 
-    def test_save_primary_with_default(self):
-        # An UPDATE attempt is skipped when a primary key has default.
+    def test_save_primary_with_default_still_inserts_once(self):
+        obj = PrimaryKeyWithDefault(name='created with default')
         with self.assertNumQueries(1):
-            PrimaryKeyWithDefault().save()
+            obj.save()
+        self.assertTrue(
+            PrimaryKeyWithDefault.objects.filter(pk=obj.pk, name='created with default').exists()
+        )
+
+    def test_save_with_explicit_pk_updates(self):
+        existing = PrimaryKeyWithDefault.objects.create(name='initial name')
+        replacement = PrimaryKeyWithDefault(pk=existing.pk, name='updated name')
+
+        with self.assertNumQueries(1):
+            replacement.save()
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.name, 'updated name')
+        self.assertEqual(PrimaryKeyWithDefault.objects.count(), 1)
+
+    def test_save_raw_does_not_force_insert_with_pk_default(self):
+        existing = PrimaryKeyWithDefault.objects.create(name='existing')
+        existing.name = 'raw update'
+
+        with self.assertNumQueries(1):
+            existing.save_base(raw=True)
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.name, 'raw update')
+
+        new_instance = PrimaryKeyWithDefault(name='raw insert')
+
+        new_instance.save_base(raw=True)
+
+        new_instance.refresh_from_db()
+        self.assertEqual(new_instance.name, 'raw insert')
 
 
 class ModelTest(TestCase):

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -170,6 +170,18 @@ class ModelInstanceCreationTests(TestCase):
         new_instance.refresh_from_db()
         self.assertEqual(new_instance.name, 'raw insert')
 
+    def test_explicit_pk_set_after_init_updates(self):
+        existing = PrimaryKeyWithDefault.objects.create(name='initial')
+        replacement = PrimaryKeyWithDefault(name='replacement')
+        replacement.pk = existing.pk
+
+        with self.assertNumQueries(1):
+            replacement.save()
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.name, 'replacement')
+        self.assertEqual(PrimaryKeyWithDefault.objects.count(), 1)
+
 
 class ModelTest(TestCase):
     def test_objects_attribute_is_only_available_on_the_class_itself(self):


### PR DESCRIPTION
## Problem summary
- Regression detailed in [#179](https://github.com/agyn-sandbox/django/issues/179) forces INSERT whenever a primary key field has a default, even if the caller provided an explicit pk.
- Saving an instance constructed with `PrimaryKeyWithDefault(pk=existing.pk, name='updated')` triggers `IntegrityError: UNIQUE constraint failed: basic_primarykeywithdefault.uuid`.
- Reproduced by running:
  ```
  PYTHONPATH=/workspace/django ./tests/runtests.py basic.tests.ModelInstanceCreationTests.test_save_with_explicit_pk_updates --parallel=1
  ```
  on the base branch (fails with the IntegrityError above).

## Fix summary
- Track whether `Model.__init__()` received an explicit pk via `self._state.pk_set_explicitly`, and reset it when defaults are generated during save.
- Restrict the forced-insert optimization in `_save_table()` to non-raw saves where the pk is default-generated.
- Extend `PrimaryKeyWithDefault` with a `name` field and add regression tests covering explicit pk updates, default inserts, and raw fixture saves.

## Testing
- `PYTHONPATH=/workspace/django ./tests/runtests.py basic.tests.ModelInstanceCreationTests --parallel=1`
- `flake8 django/db/models/base.py tests/basic/tests.py tests/basic/models.py`

Fixes #179