### PR TITLE
swev-id: django__django-12273 Reset MTI parent pks on copy

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -569,7 +569,28 @@ class Model(metaclass=ModelBase):
         return getattr(self, meta.pk.attname)
 
     def _set_pk_val(self, value):
-        return setattr(self, self._meta.pk.attname, value)
+        setattr(self, self._meta.pk.attname, value)
+        if value is not None:
+            return
+
+        visited = set()
+
+        def clear_parent_values(model):
+            for parent_model, parent_link_field in model._meta.parents.items():
+                if parent_model in visited:
+                    continue
+                visited.add(parent_model)
+
+                setattr(self, parent_model._meta.pk.attname, None)
+
+                if parent_link_field and parent_link_field.concrete:
+                    setattr(self, parent_link_field.attname, None)
+                    if parent_link_field.is_cached(self):
+                        parent_link_field.delete_cached_value(self)
+
+                clear_parent_values(parent_model)
+
+        clear_parent_values(self.__class__)
 
     pk = property(_get_pk_val, _set_pk_val)
 

--- a/tests/model_inheritance/models.py
+++ b/tests/model_inheritance/models.py
@@ -135,6 +135,37 @@ class ParkingLot(Place):
         return "%s the parking lot" % self.name
 
 
+class MultiParentA(models.Model):
+    a_id = models.AutoField(primary_key=True)
+    a_field = models.CharField(max_length=50)
+
+
+class MultiParentB(models.Model):
+    b_id = models.AutoField(primary_key=True)
+    b_field = models.CharField(max_length=50)
+
+
+class MultiChild(MultiParentA, MultiParentB):
+    note = models.CharField(max_length=50)
+
+
+class SlugParent(models.Model):
+    slug = models.SlugField(primary_key=True)
+    name = models.CharField(max_length=50)
+
+
+class SlugChild(SlugParent):
+    parent = models.OneToOneField(
+        SlugParent,
+        models.CASCADE,
+        parent_link=True,
+        to_field='slug',
+        db_column='parent_slug',
+        primary_key=True,
+    )
+    tagline = models.CharField(max_length=50)
+
+
 #
 # Abstract base classes with related models where the sub-class has the
 # same name in a different app and inherits from the same abstract base

--- a/tests/model_inheritance/tests.py
+++ b/tests/model_inheritance/tests.py
@@ -7,8 +7,9 @@ from django.test.utils import CaptureQueriesContext, isolate_apps
 
 from .models import (
     Base, Chef, CommonInfo, GrandChild, GrandParent, ItalianRestaurant,
-    MixinModel, ParkingLot, Place, Post, Restaurant, Student, SubBase,
-    Supplier, Title, Worker,
+    MixinModel, MultiChild, MultiParentA, MultiParentB, ParkingLot, Place,
+    Post, Restaurant, SlugChild, SlugParent, Student, SubBase, Supplier,
+    Title, Worker,
 )
 
 
@@ -459,6 +460,114 @@ class ModelInheritanceDataTests(TestCase):
             ],
             attrgetter("name")
         )
+
+
+class ModelInheritancePrimaryKeyResetTests(TestCase):
+    def test_reset_pk_single_inheritance_creates_copy(self):
+        restaurant = Restaurant.objects.create(
+            name="Original",
+            address="123 Main St",
+            serves_hot_dogs=True,
+            serves_pizza=False,
+            rating=3,
+        )
+        clone = Restaurant.objects.get(pk=restaurant.pk)
+
+        clone.pk = None
+        clone.name = "Copied"
+        clone.address = "456 Elm St"
+        clone.serves_pizza = True
+        clone.rating = 4
+        clone.save()
+
+        self.assertEqual(Place.objects.count(), 2)
+        self.assertEqual(Restaurant.objects.count(), 2)
+
+        original = Restaurant.objects.get(pk=restaurant.pk)
+        self.assertEqual(original.name, "Original")
+        self.assertEqual(original.address, "123 Main St")
+        copied = Restaurant.objects.exclude(pk=restaurant.pk).get()
+        self.assertEqual(copied.name, "Copied")
+        self.assertEqual(copied.address, "456 Elm St")
+        self.assertTrue(copied.serves_pizza)
+        self.assertEqual(copied.rating, 4)
+
+    def test_reset_pk_multiple_inheritance_creates_copy(self):
+        child = MultiChild.objects.create(
+            a_field="first",
+            b_field="second",
+            note="original",
+        )
+        clone = MultiChild.objects.get(pk=child.pk)
+
+        clone.pk = None
+        clone.a_field = "first-copy"
+        clone.b_field = "second-copy"
+        clone.note = "copied"
+        clone.save()
+
+        self.assertEqual(MultiParentA.objects.count(), 2)
+        self.assertEqual(MultiParentB.objects.count(), 2)
+        self.assertEqual(MultiChild.objects.count(), 2)
+
+        original = MultiChild.objects.get(pk=child.pk)
+        self.assertEqual(original.note, "original")
+        copied = MultiChild.objects.exclude(pk=child.pk).get()
+        self.assertEqual(copied.note, "copied")
+        self.assertEqual(copied.a_field, "first-copy")
+        self.assertEqual(copied.b_field, "second-copy")
+
+    def test_reset_pk_to_field_parent_link(self):
+        parent = SlugParent.objects.create(slug="original", name="Original Parent")
+        child = SlugChild.objects.create(
+            parent=parent,
+            name="Original Parent",
+            tagline="original",
+        )
+        clone = SlugChild.objects.get(pk=child.pk)
+
+        clone.pk = None
+        clone.slug = "copy"
+        clone.name = "Copy Parent"
+        clone.tagline = "copied"
+        clone.save()
+
+        self.assertEqual(SlugParent.objects.count(), 2)
+        self.assertEqual(SlugChild.objects.count(), 2)
+        self.assertTrue(SlugParent.objects.filter(slug="original", name="Original Parent").exists())
+        self.assertTrue(SlugParent.objects.filter(slug="copy", name="Copy Parent").exists())
+        copied = SlugChild.objects.get(slug="copy")
+        self.assertEqual(copied.tagline, "copied")
+
+    def test_reset_pk_clears_parent_link_cache(self):
+        main_site = Place.objects.create(name="Main Site", address="1 Main")
+        parking_lot = ParkingLot.objects.create(
+            name="Lot",
+            address="3 Lot",
+            main_site=main_site,
+        )
+        parent_link_field = ParkingLot._meta.get_ancestor_link(Place)
+
+        parking_lot = ParkingLot.objects.get(pk=parking_lot.pk)
+        _ = parking_lot.parent
+        self.assertTrue(parent_link_field.is_cached(parking_lot))
+
+        original_pk = parking_lot.pk
+
+        parking_lot.pk = None
+
+        self.assertIsNone(getattr(parking_lot, Place._meta.pk.attname))
+        self.assertIsNone(getattr(parking_lot, parent_link_field.attname))
+        self.assertFalse(parent_link_field.is_cached(parking_lot))
+
+        parking_lot.name = "Lot Copy"
+        parking_lot.address = "5 Lot"
+        parking_lot.main_site = main_site
+        parking_lot.save()
+
+        self.assertEqual(ParkingLot.objects.count(), 2)
+        self.assertTrue(ParkingLot.objects.filter(pk=original_pk, name="Lot").exists())
+        self.assertTrue(ParkingLot.objects.filter(name="Lot Copy").exclude(pk=original_pk).exists())
 
 
 @isolate_apps('model_inheritance', 'model_inheritance.tests')


### PR DESCRIPTION
## Issue
- Closes #182

## Summary
- add regression coverage for MTI primary key resets, including multi-parent and to_field parent links
- clear parent chain primary keys and cached parent links when a model primary key is reset to `None`

## Reproduction Steps
1. Apply this patch without the fix commit.
2. Run `PYTHONPATH=/workspace/django ./tests/runtests.py model_inheritance.tests.ModelInheritancePrimaryKeyResetTests --parallel=1`.

## Observed Failure
```
Creating test database for alias 'default'...
FFF.
======================================================================
FAIL: test_reset_pk_clears_parent_link_cache (model_inheritance.tests.ModelInheritancePrimaryKeyResetTests.test_reset_pk_clears_parent_link_cache)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_inheritance/tests.py", line 559, in test_reset_pk_clears_parent_link_cache
    self.assertIsNone(getattr(parking_lot, Place._meta.pk.attname))
AssertionError: 2 is not None

======================================================================
FAIL: test_reset_pk_multiple_inheritance_creates_copy (model_inheritance.tests.ModelInheritancePrimaryKeyResetTests.test_reset_pk_multiple_inheritance_creates_copy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_inheritance/tests.py", line 509, in test_reset_pk_multiple_inheritance_creates_copy
    self.assertEqual(MultiParentA.objects.count(), 2)
AssertionError: 1 != 2

======================================================================
FAIL: test_reset_pk_single_inheritance_creates_copy (model_inheritance.tests.ModelInheritancePrimaryKeyResetTests.test_reset_pk_single_inheritance_creates_copy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_inheritance/tests.py", line 483, in test_reset_pk_single_inheritance_creates_copy
    self.assertEqual(Place.objects.count(), 2)
AssertionError: 1 != 2

----------------------------------------------------------------------
Ran 4 tests in 0.006s

FAILED (failures=3)
Destroying test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
System check identified no issues (0 silenced).
```

## Testing
- `PYTHONPATH=/workspace/django ./tests/runtests.py model_inheritance.tests.ModelInheritancePrimaryKeyResetTests --parallel=1`
- `flake8 django/db/models/base.py tests/model_inheritance/tests.py tests/model_inheritance/models.py`