### PR TITLE
Fix MTI parent_link selection with multiple OneToOne (swev-id: django__django-12325)

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -201,10 +201,11 @@ class ModelBase(type):
             if base != new_class and not base._meta.abstract:
                 continue
             # Locate OneToOneField instances.
-            for field in base._meta.local_fields:
-                if isinstance(field, OneToOneField):
-                    related = resolve_relation(new_class, field.remote_field.model)
-                    parent_links[make_model_tuple(related)] = field
+            fields = [f for f in base._meta.local_fields if isinstance(f, OneToOneField)]
+            for field in sorted(fields, key=lambda f: f.remote_field.parent_link, reverse=True):
+                related_key = make_model_tuple(resolve_relation(new_class, field.remote_field.model))
+                if related_key not in parent_links:
+                    parent_links[related_key] = field
 
         # Track fields inherited from base models.
         inherited_attributes = set()

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -204,7 +204,10 @@ class ModelBase(type):
             fields = [f for f in base._meta.local_fields if isinstance(f, OneToOneField)]
             for field in sorted(fields, key=lambda f: f.remote_field.parent_link, reverse=True):
                 related_key = make_model_tuple(resolve_relation(new_class, field.remote_field.model))
-                if related_key not in parent_links:
+                existing = parent_links.get(related_key)
+                if existing is None or (
+                    field.remote_field.parent_link and not existing.remote_field.parent_link
+                ):
                     parent_links[related_key] = field
 
         # Track fields inherited from base models.

--- a/tests/model_inheritance/test_parent_link_selection.py
+++ b/tests/model_inheritance/test_parent_link_selection.py
@@ -1,0 +1,106 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
+
+
+class ParentLinkSelectionTests(SimpleTestCase):
+    @isolate_apps('model_inheritance')
+    def test_parent_link_selected_regardless_of_field_order(self):
+        class Parent(models.Model):
+            marker = models.CharField(max_length=8, default='')
+
+            class Meta:
+                app_label = 'model_inheritance'
+
+        class ParentLinkFirst(Parent):
+            parent_ptr = models.OneToOneField(
+                Parent,
+                models.CASCADE,
+                parent_link=True,
+                related_name='+',
+            )
+            alt_parent = models.OneToOneField(
+                'Parent',
+                models.CASCADE,
+                related_name='+',
+            )
+
+            class Meta:
+                app_label = 'model_inheritance'
+
+        class ParentLinkLast(Parent):
+            alt_parent = models.OneToOneField(
+                Parent,
+                models.CASCADE,
+                related_name='+',
+            )
+            parent_ptr = models.OneToOneField(
+                'Parent',
+                models.CASCADE,
+                parent_link=True,
+                related_name='+',
+            )
+
+            class Meta:
+                app_label = 'model_inheritance'
+
+        for model in (ParentLinkFirst, ParentLinkLast):
+            parent_field = model._meta.parents[Parent]
+            self.assertTrue(parent_field.remote_field.parent_link)
+            self.assertIs(parent_field, model._meta.get_field('parent_ptr'))
+            self.assertIs(model._meta.get_field('alt_parent').remote_field.model, Parent)
+
+    @isolate_apps('model_inheritance')
+    def test_non_parent_link_on_parent_raises(self):
+        class Parent(models.Model):
+            class Meta:
+                app_label = 'model_inheritance'
+
+        msg = "Add parent_link=True to"
+        with self.assertRaisesMessage(ImproperlyConfigured, msg):
+            class InvalidChild(Parent):
+                parent_ptr = models.OneToOneField(
+                    Parent,
+                    models.CASCADE,
+                    related_name='+',
+                )
+
+                class Meta:
+                    app_label = 'model_inheritance'
+
+    @isolate_apps('model_inheritance')
+    def test_parent_link_from_abstract_base_not_overwritten(self):
+        class Parent(models.Model):
+            class Meta:
+                app_label = 'model_inheritance'
+
+        class Other(models.Model):
+            class Meta:
+                app_label = 'model_inheritance'
+
+        class ParentLinkMixin(models.Model):
+            parent_ptr = models.OneToOneField(
+                Parent,
+                models.CASCADE,
+                parent_link=True,
+                related_name='+',
+            )
+
+            class Meta:
+                app_label = 'model_inheritance'
+                abstract = True
+
+        class Child(ParentLinkMixin, Parent):
+            sibling = models.OneToOneField(
+                Other,
+                models.CASCADE,
+                related_name='+',
+            )
+
+            class Meta:
+                app_label = 'model_inheritance'
+
+        parent_field = Child._meta.parents[Parent]
+        self.assertTrue(parent_field.remote_field.parent_link)
+        self.assertEqual(parent_field.name, 'parent_ptr')

--- a/tests/model_inheritance/test_parent_link_selection.py
+++ b/tests/model_inheritance/test_parent_link_selection.py
@@ -104,3 +104,35 @@ class ParentLinkSelectionTests(SimpleTestCase):
         parent_field = Child._meta.parents[Parent]
         self.assertTrue(parent_field.remote_field.parent_link)
         self.assertEqual(parent_field.name, 'parent_ptr')
+
+    @isolate_apps('model_inheritance')
+    def test_parent_link_overrides_non_parent_mixin_relation(self):
+        class Parent(models.Model):
+            class Meta:
+                app_label = 'model_inheritance'
+
+        class NonParentMixin(models.Model):
+            parent_relation = models.OneToOneField(
+                Parent,
+                models.CASCADE,
+                related_name='+',
+            )
+
+            class Meta:
+                app_label = 'model_inheritance'
+                abstract = True
+
+        class Child(NonParentMixin, Parent):
+            parent_ptr = models.OneToOneField(
+                Parent,
+                models.CASCADE,
+                parent_link=True,
+                related_name='+',
+            )
+
+            class Meta:
+                app_label = 'model_inheritance'
+
+        parent_field = Child._meta.parents[Parent]
+        self.assertTrue(parent_field.remote_field.parent_link)
+        self.assertEqual(parent_field.name, 'parent_ptr')


### PR DESCRIPTION
## Summary
- prefer parent_link=True OneToOne fields when collecting MTI parent links
- add regression coverage for multiple parent relations, string references, and abstract mixin scenarios
- keep ImproperlyConfigured guard when no parent_link=True relation exists

## Observed failure
On django__django-12325, defining a child with both a parent link and another OneToOne to the same parent raises during model construction:
```
Traceback (most recent call last):
  File "django/tests/model_inheritance/test_parent_link_selection.py", line 16, in test_parent_link_selected_regardless_of_field_order
    class ParentLinkFirst(Parent):
  File "django/db/models/base.py", line 320, in __new__
    new_class._prepare()
  File "django/db/models/base.py", line 333, in _prepare
    opts._prepare(cls)
  File "django/db/models/options.py", line 255, in _prepare
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Add parent_link=True to model_inheritance.ParentLinkFirst.alt_parent.
```

## Reproduction steps
1. Checkout django__django-12325
2. Apply the new regression test module
3. Run `PYTHONPATH=/workspace/django ./tests/runtests.py model_inheritance.test_parent_link_selection.ParentLinkSelectionTests.test_parent_link_selected_regardless_of_field_order --parallel=1`

## Testing
- PYTHONPATH=/workspace/django ./tests/runtests.py model_inheritance.test_parent_link_selection --parallel=1
- flake8 django/db/models/base.py tests/model_inheritance/test_parent_link_selection.py

Fixes #191