### PR TITLE
Admin: fix readonly JSONField display via forms.JSONField.prepare_value (swev-id: django__django-12308)

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -398,6 +398,12 @@ def display_for_field(value, field, empty_value_display):
         return formats.number_format(value)
     elif isinstance(field, models.FileField) and value:
         return format_html('<a href="{}">{}</a>', value.url, value)
+    elif isinstance(field, models.JSONField):
+        form_field = field.formfield()
+        try:
+            return form_field.prepare_value(value)
+        except TypeError:
+            return display_for_value(value, empty_value_display)
     else:
         return display_for_value(value, empty_value_display)
 

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -204,6 +204,19 @@ class UtilsTests(SimpleTestCase):
         display_value = display_for_value([1, 2, 'buckle', 'my', 'shoe'], self.empty_value)
         self.assertEqual(display_value, '1, 2, buckle, my, shoe')
 
+    def test_jsonfield_display_for_field(self):
+        field = models.JSONField()
+        cases = [
+            ({'foo': 'bar'}, '{"foo": "bar"}'),
+            ([1, 2], '[1, 2]'),
+            ('baz', '"baz"'),
+            ({}, '{}'),
+            ([], '[]'),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(display_for_field(value, field, self.empty_value), expected)
+
     @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
     def test_list_display_for_value_boolean(self):
         self.assertEqual(

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -30,7 +30,7 @@ from .models import (
     EmptyModelHidden, EmptyModelMixin, EmptyModelVisible, ExplicitlyProvidedPK,
     ExternalSubscriber, Fabric, FancyDoodad, FieldOverridePost,
     FilteredManager, FooAccount, FoodDelivery, FunkyTag, Gadget, Gallery,
-    GenRelReference, Grommet, ImplicitlyGeneratedPK, Ingredient,
+    GenRelReference, Grommet, ImplicitlyGeneratedPK, Ingredient, JSONRecord,
     InlineReference, InlineReferer, Inquisition, Language, Link,
     MainPrepopulated, ModelWithStringPrimaryKey, NotReferenced, OldSubscriber,
     OtherStory, Paper, Parent, ParentWithDependentChildren, ParentWithUUIDPK,
@@ -537,6 +537,10 @@ class ToppingAdmin(admin.ModelAdmin):
 
 class PizzaAdmin(admin.ModelAdmin):
     readonly_fields = ('toppings',)
+
+
+class JSONRecordAdmin(admin.ModelAdmin):
+    readonly_fields = ('data',)
 
 
 class StudentAdmin(admin.ModelAdmin):
@@ -1106,6 +1110,7 @@ site.register(NotReferenced)
 site.register(ExplicitlyProvidedPK, GetFormsetsArgumentCheckingAdmin)
 site.register(ImplicitlyGeneratedPK, GetFormsetsArgumentCheckingAdmin)
 site.register(UserProxy)
+site.register(JSONRecord, JSONRecordAdmin)
 
 # Register core models we need in our tests
 site.register(User, UserAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -999,3 +999,7 @@ class UserProxy(User):
     """Proxy a model with a different app_label."""
     class Meta:
         proxy = True
+
+
+class JSONRecord(models.Model):
+    data = models.JSONField()

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import re
+from html import unescape
 import unittest
 from unittest import mock
 from urllib.parse import parse_qsl, urljoin, urlparse
@@ -53,7 +54,7 @@ from .models import (
     ShortMessage, Simple, Song, State, Story, SuperSecretHideout, SuperVillain,
     Telegram, TitleTranslation, Topping, UnchangeableObject, UndeletableObject,
     UnorderedObject, UserProxy, Villain, Vodcast, Whatsit, Widget, Worker,
-    WorkHour,
+    WorkHour, JSONRecord,
 )
 
 ERROR_MESSAGE = "Please enter the correct username and password \
@@ -4932,6 +4933,14 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
         response = self.client.get(reverse('admin:admin_views_pizza_change', args=(pizza.pk,)))
         self.assertContains(response, '<label>Toppings:</label>', html=True)
         self.assertContains(response, '<div class="readonly">Salami</div>', html=True)
+
+    def test_readonly_jsonfield_display(self):
+        record = JSONRecord.objects.create(data={'foo': 'bar'})
+        url = reverse('admin:admin_views_jsonrecord_change', args=(record.pk,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        field = self.get_admin_readonly_field(response, 'data')
+        self.assertEqual(unescape(field.contents()), '{"foo": "bar"}')
 
     def test_readonly_onetoone_backwards_ref(self):
         """


### PR DESCRIPTION
## Summary
- render admin readonly JSONField values using the field's form prepare_value()
- add admin integration coverage via JSONRecord with readonly JSONField display
- extend admin_utils tests to assert JSONField values serialize with JSON formatting

## Observed failure (pre-fix)

Reproduce with:
```bash
python tests/runtests.py admin_utils admin_views
```

Excerpt:
```text
FAIL: test_readonly_jsonfield_display (admin_views.tests.ReadonlyTest.test_readonly_jsonfield_display)
AssertionError: '{&#x27;foo&#x27;: &#x27;bar&#x27;}' != '{"foo": "bar"}'

FAIL: test_jsonfield_display_for_field (admin_utils.tests.UtilsTests.test_jsonfield_display_for_field) [value={'foo': 'bar'}]
AssertionError: "{'foo': 'bar'}" != '{"foo": "bar"}'
```

_Not running CI per instructions._

Resolves #193.