### PR TITLE
Respect widget override in formfield_for_manytomany (swev-id: django__django-12713)

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -250,15 +250,16 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
         db = kwargs.get('using')
 
         autocomplete_fields = self.get_autocomplete_fields(request)
-        if db_field.name in autocomplete_fields:
-            kwargs['widget'] = AutocompleteSelectMultiple(db_field.remote_field, self.admin_site, using=db)
-        elif db_field.name in self.raw_id_fields:
-            kwargs['widget'] = widgets.ManyToManyRawIdWidget(db_field.remote_field, self.admin_site, using=db)
-        elif db_field.name in [*self.filter_vertical, *self.filter_horizontal]:
-            kwargs['widget'] = widgets.FilteredSelectMultiple(
-                db_field.verbose_name,
-                db_field.name in self.filter_vertical
-            )
+        if 'widget' not in kwargs:
+            if db_field.name in autocomplete_fields:
+                kwargs['widget'] = AutocompleteSelectMultiple(db_field.remote_field, self.admin_site, using=db)
+            elif db_field.name in self.raw_id_fields:
+                kwargs['widget'] = widgets.ManyToManyRawIdWidget(db_field.remote_field, self.admin_site, using=db)
+            elif db_field.name in [*self.filter_vertical, *self.filter_horizontal]:
+                kwargs['widget'] = widgets.FilteredSelectMultiple(
+                    db_field.verbose_name,
+                    db_field.name in self.filter_vertical
+                )
 
         if 'queryset' not in kwargs:
             queryset = self.get_field_queryset(db, db_field, request)
@@ -1058,7 +1059,7 @@ class ModelAdmin(BaseModelAdmin):
                 level = getattr(messages.constants, level.upper())
             except AttributeError:
                 levels = messages.constants.DEFAULT_TAGS.values()
-                levels_repr = ', '.join('`%s`' % l for l in levels)
+                levels_repr = ', '.join('`%s`' % tag for tag in levels)
                 raise ValueError(
                     'Bad message level string: `%s`. Possible values are: %s'
                     % (level, levels_repr)

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -185,6 +185,77 @@ class AdminFormfieldForDBFieldTests(SimpleTestCase):
         )
 
 
+class AdminManyToManyWidgetOverrideTests(SimpleTestCase):
+
+    def _unwrap_widget(self, formfield):
+        if isinstance(formfield.widget, widgets.RelatedFieldWidgetWrapper):
+            return formfield.widget.widget
+        return formfield.widget
+
+    def test_many_to_many_widget_override_respected(self):
+        class BandAdmin(admin.ModelAdmin):
+            filter_vertical = ['members']
+
+            def formfield_for_manytomany(self, db_field, request, **kwargs):
+                if db_field.name == 'members':
+                    kwargs['widget'] = forms.CheckboxSelectMultiple()
+                return super().formfield_for_manytomany(db_field, request, **kwargs)
+
+        admin_instance = BandAdmin(Band, admin.site)
+        formfield = admin_instance.formfield_for_dbfield(Band._meta.get_field('members'), request=None)
+        widget = self._unwrap_widget(formfield)
+        self.assertIsInstance(widget, forms.CheckboxSelectMultiple)
+
+    def test_filtered_select_multiple_applied_without_override(self):
+        class BandAdmin(admin.ModelAdmin):
+            filter_vertical = ['members']
+
+        admin_instance = BandAdmin(Band, admin.site)
+        formfield = admin_instance.formfield_for_dbfield(Band._meta.get_field('members'), request=None)
+        widget = self._unwrap_widget(formfield)
+        self.assertIsInstance(widget, widgets.FilteredSelectMultiple)
+
+    def test_many_to_many_raw_id_widget_applied_without_override(self):
+        class BandAdmin(admin.ModelAdmin):
+            raw_id_fields = ['members']
+
+        admin_instance = BandAdmin(Band, admin.site)
+        formfield = admin_instance.formfield_for_dbfield(Band._meta.get_field('members'), request=None)
+        widget = self._unwrap_widget(formfield)
+        self.assertIsInstance(widget, widgets.ManyToManyRawIdWidget)
+
+    def test_many_to_many_autocomplete_widget_applied_without_override(self):
+        class BandAdmin(admin.ModelAdmin):
+            autocomplete_fields = ['members']
+
+        admin_instance = BandAdmin(Band, admin.site)
+        formfield = admin_instance.formfield_for_dbfield(Band._meta.get_field('members'), request=None)
+        widget = self._unwrap_widget(formfield)
+        self.assertIsInstance(widget, widgets.AutocompleteSelectMultiple)
+
+
+class AdminForeignKeyWidgetOverrideTests(SimpleTestCase):
+
+    def _unwrap_widget(self, formfield):
+        if isinstance(formfield.widget, widgets.RelatedFieldWidgetWrapper):
+            return formfield.widget.widget
+        return formfield.widget
+
+    def test_foreign_key_widget_override_respected(self):
+        class EventAdmin(admin.ModelAdmin):
+            raw_id_fields = ['main_band']
+
+            def formfield_for_foreignkey(self, db_field, request, **kwargs):
+                if db_field.name == 'main_band':
+                    kwargs['widget'] = forms.Select()
+                return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+        admin_instance = EventAdmin(Event, admin.site)
+        formfield = admin_instance.formfield_for_dbfield(Event._meta.get_field('main_band'), request=None)
+        widget = self._unwrap_widget(formfield)
+        self.assertIsInstance(widget, forms.Select)
+
+
 @override_settings(ROOT_URLCONF='admin_widgets.urls')
 class AdminFormfieldForDBFieldWithRequestTests(TestDataMixin, TestCase):
 


### PR DESCRIPTION
## Summary
- ensure `ModelAdmin.formfield_for_manytomany()` keeps explicit widget overrides
- add admin widget coverage for overrides, defaults, and FK parity
- rename an existing helper variable to satisfy flake8

## Reproduction
1. Checkout `django__django-12713`
2. Apply the new `AdminManyToManyWidgetOverrideTests`
3. Run `PYTHONPATH=/workspace/django ./runtests.py admin_widgets --parallel=1`

Before the fix the failure looked like:
```
======================================================================
FAIL: test_many_to_many_widget_override_respected (admin_widgets.tests.AdminManyToManyWidgetOverrideTests.test_many_to_many_widget_override_respected)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/admin_widgets/tests.py", line 207, in test_many_to_many_widget_override_respected
    self.assertIsInstance(widget, forms.CheckboxSelectMultiple)
AssertionError: <django.contrib.admin.widgets.FilteredSelectMultiple object at 0xffff7c34f350> is not an instance of <class 'django.forms.widgets.CheckboxSelectMultiple'>
```

## Testing
- `PYTHONPATH=/workspace/django ./runtests.py admin_widgets --parallel=1`
- `flake8 django/contrib/admin/options.py tests/admin_widgets/tests.py`

CI was not run manually.

Fixes #195