### PR TITLE
swev-id: django__django-12741 Simplify execute_sql_flush signature

### DIFF
--- a/django/core/management/commands/flush.py
+++ b/django/core/management/commands/flush.py
@@ -60,7 +60,7 @@ Are you sure you want to do this?
 
         if confirm == 'yes':
             try:
-                connection.ops.execute_sql_flush(database, sql_list)
+                connection.ops.execute_sql_flush(sql_list)
             except Exception as exc:
                 raise CommandError(
                     "Database %s couldn't be flushed. Possible reasons:\n"

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -400,9 +400,9 @@ class BaseDatabaseOperations:
         """
         raise NotImplementedError('subclasses of BaseDatabaseOperations must provide a sql_flush() method')
 
-    def execute_sql_flush(self, using, sql_list):
+    def execute_sql_flush(self, sql_list):
         """Execute a list of SQL statements to flush the database."""
-        with transaction.atomic(using=using, savepoint=self.connection.features.can_rollback_ddl):
+        with transaction.atomic(using=self.connection.alias, savepoint=self.connection.features.can_rollback_ddl):
             with self.connection.cursor() as cursor:
                 for sql in sql_list:
                     cursor.execute(sql)

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -401,7 +401,16 @@ class BaseDatabaseOperations:
         raise NotImplementedError('subclasses of BaseDatabaseOperations must provide a sql_flush() method')
 
     def execute_sql_flush(self, sql_list):
-        """Execute a list of SQL statements to flush the database."""
+        """Execute SQL statements to flush the database using this connection.
+
+This method executes the provided SQL within:
+
+    transaction.atomic(using=self.connection.alias,
+                       savepoint=self.connection.features.can_rollback_ddl)
+
+so that flush semantics are consistent with the bound connection and backend
+DDL rollback capabilities.
+"""
         with transaction.atomic(using=self.connection.alias, savepoint=self.connection.features.can_rollback_ddl):
             with self.connection.cursor() as cursor:
                 for sql in sql_list:

--- a/tests/backends/base/test_operations.py
+++ b/tests/backends/base/test_operations.py
@@ -172,7 +172,7 @@ class SqlFlushTests(TransactionTestCase):
             reset_sequences=True,
             allow_cascade=True,
         )
-        connection.ops.execute_sql_flush(connection.alias, sql_list)
+        connection.ops.execute_sql_flush(sql_list)
 
         with transaction.atomic():
             self.assertIs(Author.objects.exists(), False)

--- a/tests/backends/tests.py
+++ b/tests/backends/tests.py
@@ -162,7 +162,7 @@ class LongNameTest(TransactionTestCase):
             VLM_m2m._meta.db_table,
         ]
         sql_list = connection.ops.sql_flush(no_style(), tables, reset_sequences=True)
-        connection.ops.execute_sql_flush(connection.alias, sql_list)
+        connection.ops.execute_sql_flush(sql_list)
 
 
 class SequenceResetTest(TestCase):


### PR DESCRIPTION
## Summary
- Simplify `BaseDatabaseOperations.execute_sql_flush` to rely on the bound connection alias.
- Update the flush management command and backend tests for the streamlined signature.
- Clarify the `execute_sql_flush` docstring to mention the implicit connection usage.

## Issue
- Implements: https://github.com/agyn-sandbox/django/issues/198

## Local Verification (SQLite)
- Minimal script confirms `execute_sql_flush(sql_list)` runs without error.
- Targeted tests (optional):
  - `tests/runtests.py backends.base --parallel=1`
  - `tests/runtests.py backends.tests --parallel=1`

## Notes
- This is an internal API simplification. Backends do not override `execute_sql_flush`; they implement `sql_flush()`.
- CI was not triggered manually per task rules.