### PR TITLE
swev-id: django__django-12663 fix nested SimpleLazyObject subquery filter

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -233,7 +233,7 @@ class Query(BaseExpression):
     @property
     def output_field(self):
         if len(self.select) == 1:
-            return self.select[0].field
+            return self.select[0].target
         elif len(self.annotation_select) == 1:
             return next(iter(self.annotation_select.values())).output_field
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -21,6 +21,7 @@ from django.db.models.sql import constants
 from django.db.models.sql.datastructures import Join
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 from django.test.utils import Approximate, isolate_apps
+from django.utils.functional import SimpleLazyObject
 
 from .models import (
     UUID, UUIDPK, Company, Employee, Experiment, Number, RemoteEmployee,
@@ -72,6 +73,18 @@ class BasicExpressionsTests(TestCase):
     def test_annotate_values_count(self):
         companies = Company.objects.annotate(foo=RawSQL('%s', ['value']))
         self.assertEqual(companies.count(), 3)
+
+    def test_lazyobject_filter_with_nested_subquery_foreignkey(self):
+        nested_ceo_subquery = Company.objects.filter(pk=OuterRef('pk')).annotate(
+            nested_ceo=Subquery(
+                Company.objects.filter(pk=OuterRef('pk')).values('ceo')[:1]
+            )
+        ).values('nested_ceo')[:1]
+        lazy_ceo = SimpleLazyObject(lambda: Employee.objects.get(pk=self.example_inc.ceo.pk))
+        companies = Company.objects.annotate(
+            nested_ceo=Subquery(nested_ceo_subquery)
+        ).filter(nested_ceo=lazy_ceo).order_by('name')
+        self.assertQuerysetEqual(companies, ['<Company: Example Inc.>'])
 
     @skipUnlessDBFeature('supports_boolean_expr_in_select_clause')
     def test_filtering_on_annotate_that_uses_q(self):


### PR DESCRIPTION
## Summary
- return the select target for single-column queries so foreign key lookups use relational coercion
- add regression coverage for filtering a SimpleLazyObject against a nested Subquery returning a ForeignKey
- ensure the test reuses existing expressions fixtures and reproduces the prior failure

Fixes #199.

## Testing
- PYTHONPATH=/workspace/django ./.venv/bin/tox -e py3 -- expressions
- PYTHONPATH=/workspace/django ./.venv/bin/tox -e py3 -- -k test_lazyobject_filter_with_nested_subquery_foreignkey expressions
- ./.venv/bin/flake8 django/db/models/sql/query.py tests/expressions/tests.py