### PR TITLE
swev-id: django__django-12754 - ensure MTI subclass waits on removed fields

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from collections import defaultdict
 from itertools import chain
 
 from django.conf import settings
@@ -525,6 +526,13 @@ class MigrationAutodetector:
             sorted(added_models, key=self.swappable_first_key, reverse=True),
             sorted(added_unmanaged_models, key=self.swappable_first_key, reverse=True)
         )
+        removed_fields_by_model = defaultdict(set)
+        for app_label, model_name, field_name in self.old_field_keys - self.new_field_keys:
+            removed_fields_by_model[(app_label, model_name.lower())].add(field_name)
+        renamed_models_reverse = {
+            (app_label, old_model_name.lower()): new_model_name
+            for (app_label, new_model_name), old_model_name in self.renamed_models.items()
+        }
         for app_label, model_name in all_added_models:
             model_state = self.to_state.models[app_label, model_name]
             model_opts = self.new_apps.get_model(app_label, model_name)._meta
@@ -563,6 +571,31 @@ class MigrationAutodetector:
                 if isinstance(base, str) and "." in base:
                     base_app_label, base_name = base.split(".", 1)
                     dependencies.append((base_app_label, base_name, None, True))
+            subclass_field_names = {
+                name for name, field in model_state.fields.items()
+                if not getattr(getattr(field, "remote_field", None), "parent_link", False)
+            }
+            remove_dependencies = set()
+            for base in model_state.bases:
+                if not (isinstance(base, str) and "." in base):
+                    continue
+                base_app_label, base_name = base.split(".", 1)
+                candidate_base_names = {base_name}
+                renamed_base = self.renamed_models.get((base_app_label, base_name))
+                if renamed_base:
+                    candidate_base_names.add(renamed_base)
+                renamed_new = renamed_models_reverse.get((base_app_label, base_name.lower()))
+                if renamed_new:
+                    candidate_base_names.add(renamed_new)
+                for candidate_base_name in candidate_base_names:
+                    candidate_lookup = (base_app_label, candidate_base_name.lower())
+                    removed_fields = removed_fields_by_model.get(candidate_lookup)
+                    if not removed_fields:
+                        continue
+                    for field_name in subclass_field_names & removed_fields:
+                        remove_dependencies.add((base_app_label, candidate_lookup[1], field_name, False))
+            if remove_dependencies:
+                dependencies.extend(sorted(remove_dependencies))
             # Depend on the other end of the primary key if it's a relation
             if primary_key_rel:
                 dependencies.append((

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -204,6 +204,49 @@ class AutodetectorTests(TestCase):
         ("name", models.CharField(blank=True)),
         ("biography", models.TextField(blank=True)),
     ])
+    mti_base_with_shared_field = ModelState("testapp", "MTIBase", [
+        ("id", models.AutoField(primary_key=True)),
+        ("shared", models.CharField(max_length=20)),
+    ])
+    mti_base_without_shared_field = ModelState("testapp", "MTIBase", [
+        ("id", models.AutoField(primary_key=True)),
+    ])
+    mti_child_with_shared_field = ModelState("testapp", "MTIChild", [
+        ("mtibase_ptr", models.OneToOneField(
+            "testapp.MTIBase",
+            models.CASCADE,
+            auto_created=True,
+            parent_link=True,
+            primary_key=True,
+            serialize=False,
+            to_field="id",
+        )),
+        ("shared", models.CharField(max_length=20)),
+    ], bases=("testapp.MTIBase",))
+    mti_second_child_with_shared_field = ModelState("testapp", "MTISecondChild", [
+        ("mtibase_ptr", models.OneToOneField(
+            "testapp.MTIBase",
+            models.CASCADE,
+            auto_created=True,
+            parent_link=True,
+            primary_key=True,
+            serialize=False,
+            to_field="id",
+        )),
+        ("shared", models.CharField(max_length=20)),
+    ], bases=("testapp.MTIBase",))
+    mti_cross_app_child_with_shared_field = ModelState("otherapp", "MTIOtherChild", [
+        ("mtibase_ptr", models.OneToOneField(
+            "testapp.MTIBase",
+            models.CASCADE,
+            auto_created=True,
+            parent_link=True,
+            primary_key=True,
+            serialize=False,
+            to_field="id",
+        )),
+        ("shared", models.CharField(max_length=20)),
+    ], bases=("testapp.MTIBase",))
     author_with_book = ModelState("testapp", "Author", [
         ("id", models.AutoField(primary_key=True)),
         ("name", models.CharField(max_length=200)),
@@ -1927,6 +1970,44 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'testapp', 0, ["RemoveField", "DeleteModel"])
         self.assertOperationAttributes(changes, 'testapp', 0, 0, name="publisher")
         self.assertOperationAttributes(changes, 'testapp', 0, 1, name="Publisher")
+
+    def test_create_subclass_depends_on_remove_field_from_base(self):
+        before = [self.mti_base_with_shared_field]
+        after = [self.mti_base_without_shared_field, self.mti_child_with_shared_field]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField", "CreateModel"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="mtibase", name="shared")
+        create_op = changes["testapp"][0].operations[1]
+        self.assertEqual(create_op.name, "MTIChild")
+        self.assertIn(("testapp", "mtibase", "shared", False), create_op._auto_deps)
+
+    def test_multiple_subclasses_depend_on_single_base_remove(self):
+        before = [self.mti_base_with_shared_field]
+        after = [
+            self.mti_base_without_shared_field,
+            self.mti_child_with_shared_field,
+            self.mti_second_child_with_shared_field,
+        ]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField", "CreateModel", "CreateModel"])
+        dependency = ("testapp", "mtibase", "shared", False)
+        create_ops = changes["testapp"][0].operations[1:]
+        self.assertTrue(all(dependency in op._auto_deps for op in create_ops))
+
+    def test_cross_app_subclass_depends_on_base_remove(self):
+        before = [self.mti_base_with_shared_field]
+        after = [self.mti_base_without_shared_field, self.mti_cross_app_child_with_shared_field]
+        changes = self.get_changes(before, after)
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertNumberMigrations(changes, "otherapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["RemoveField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, model_name="mtibase", name="shared")
+        self.assertOperationTypes(changes, "otherapp", 0, ["CreateModel"])
+        create_op = changes["otherapp"][0].operations[0]
+        self.assertEqual(create_op.name, "MTIOtherChild")
+        self.assertIn(("testapp", "mtibase", "shared", False), create_op._auto_deps)
 
     @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_addition',
                 side_effect=AssertionError("Should not have prompted for not null addition"))


### PR DESCRIPTION
## Summary
- detect shared field moves from a multi-table base and add `RemoveField` dependencies to child `CreateModel`
- normalise dependency keys for renamed bases and ignore parent link fields
- add regression coverage for single, multiple, and cross-app subclasses relying on the base removal

## Reproduction
1. Start from `django__django-12754`.
2. Move a field from an existing multi-table base model to a new concrete subclass in the same changeset.
3. Run `./manage.py makemigrations`.

**Observed:** `django.core.exceptions.FieldError: Local field 'shared' in class 'MTIChild' clashes with field of the same name from base class 'MTIBase'.`

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py migrations.test_autodetector --parallel=1
- flake8 django/db/migrations/autodetector.py tests/migrations/test_autodetector.py

Fixes #207.