### PR TITLE
Document pk tie-breaker for next/previous helpers (swev-id: django__django-12774)

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -950,6 +950,7 @@ class Model(metaclass=ModelBase):
         # force_str() to coerce lazy strings.
         return force_str(choices_dict.get(make_hashable(value), value), strings_only=True)
 
+    # Break ties on equal field values by ordering on the primary key.
     def _get_next_or_previous_by_FIELD(self, field, is_next, **kwargs):
         if not self.pk:
             raise ValueError("get_next/get_previous cannot be used on unsaved objects.")


### PR DESCRIPTION
## Summary
- document that _get_next_or_previous_by_FIELD() falls back to primary key ordering when field values match
- confirm dead code removal from issue #208 is already reflected in base branch
- add comment-only change per swev request

## Testing
- PATH=/root/.nix-profile/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=/workspace/django /workspace/.venv/bin/tox -e py3 -- lookup --parallel=1
- PATH=/root/.nix-profile/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=/workspace/django /workspace/.venv/bin/tox -e py3 -- multiple_database model_regress model_inheritance_regress --parallel=1
