### PR TITLE
swev-id: django__django-13023 - Fix DecimalField.to_python to raise ValidationError for dict inputs

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1501,7 +1501,7 @@ class DecimalField(Field):
             return self.context.create_decimal_from_float(value)
         try:
             return decimal.Decimal(value)
-        except decimal.InvalidOperation:
+        except (decimal.InvalidOperation, TypeError, ValueError):
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],
                 code='invalid',

--- a/tests/model_fields/test_decimalfield.py
+++ b/tests/model_fields/test_decimalfield.py
@@ -25,6 +25,46 @@ class DecimalFieldTests(TestCase):
         with self.assertRaisesMessage(ValidationError, msg):
             f.to_python('abc')
 
+    def test_to_python_invalid_types(self):
+        field = models.DecimalField(max_digits=4, decimal_places=2)
+        invalid_values = [
+            {},
+            [],
+            {'a'},
+            (1,),
+            object(),
+            complex(1, 0),
+            'abc',
+            b'abc',
+        ]
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError) as cm:
+                    field.to_python(value)
+                error = cm.exception
+                self.assertEqual(error.error_list[0].code, 'invalid')
+                self.assertIn('value must be a decimal number.', error.messages[0])
+
+    def test_clean_invalid_types(self):
+        field = models.DecimalField(max_digits=4, decimal_places=2)
+        invalid_values = [
+            {},
+            [],
+            {'a'},
+            (1,),
+            object(),
+            complex(1, 0),
+            'abc',
+            b'abc',
+        ]
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError) as cm:
+                    field.clean(value, None)
+                error = cm.exception
+                self.assertEqual(error.error_list[0].code, 'invalid')
+                self.assertIn('value must be a decimal number.', error.messages[0])
+
     def test_default(self):
         f = models.DecimalField(default=Decimal('0.00'))
         self.assertEqual(f.get_default(), Decimal('0.00'))
@@ -87,3 +127,10 @@ class DecimalFieldTests(TestCase):
         obj = Foo.objects.create(a='bar', d=Decimal('8.320'))
         obj.refresh_from_db()
         self.assertEqual(obj.d.compare_total(Decimal('8.320')), Decimal('0'))
+
+    def test_model_save_invalid_type(self):
+        with self.assertRaises(ValidationError) as cm:
+            Foo.objects.create(a='bar', d={})
+        error = cm.exception
+        self.assertEqual(error.error_list[0].code, 'invalid')
+        self.assertIn('value must be a decimal number.', error.messages[0])


### PR DESCRIPTION
### Summary
Fix DecimalField.to_python() so invalid non-numeric inputs (e.g., dict) raise ValidationError instead of TypeError/ValueError.

- Base: django__django-13023
- Issue: https://github.com/agyn-sandbox/django/issues/218
- Upstream reference: https://github.com/django/django/pull/13023

### What changed
- Expanded exception handling in django/db/models/fields/__init__.py (DecimalField.to_python): catch (decimal.InvalidOperation, TypeError, ValueError) and raise ValidationError with code='invalid' and the message '"%(value)s" value must be a decimal number.'
- Added tests covering to_python() and clean() on invalid inputs (dict, list, set, tuple, object(), complex, non-numeric str/bytes) and an integration test for model save path.

### Observed failure and reproduction (pre-fix)
Reproduction:
```
cd /workspace/django
. .venv/bin/activate
python - <<'PY'
from django.db.models import DecimalField
try:
    DecimalField().to_python({})
except Exception:
    import traceback
    traceback.print_exc()
PY
```

Stack trace:
```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/workspace/django/django/db/models/fields/__init__.py", line 1503, in to_python
    return decimal.Decimal(value)
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: conversion from dict to Decimal is not supported
```

### Tests
- Local run: `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite ./tests/runtests.py model_fields.test_decimalfield --parallel=1`
- Result: 14 passed (1 skipped), 0 failed.

### Notes
- This PR targets django__django-13023 and does not modify the base branch directly.
- CI is not required per task rules.