### PR TITLE
swev-id: django__django-13012 — Delegate ExpressionWrapper.get_group_by_cols to wrapped expression; add regression tests

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -548,6 +548,9 @@ class F(Combinable):
     def __hash__(self):
         return hash(self.name)
 
+    def get_group_by_cols(self, alias=None):
+        return [self]
+
 
 class ResolvedOuterRef(F):
     """
@@ -862,6 +865,9 @@ class ExpressionWrapper(Expression):
 
     def get_source_expressions(self):
         return [self.expression]
+
+    def get_group_by_cols(self, alias=None):
+        return self.expression.get_group_by_cols(alias=alias)
 
     def as_sql(self, compiler, connection):
         return self.expression.as_sql(compiler, connection)

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -29,6 +29,16 @@ from .models import (
 )
 
 
+class ExpressionWrapperGroupByTests(SimpleTestCase):
+    def test_group_by_cols_wrapper_over_value_is_empty(self):
+        expr = ExpressionWrapper(Value(42), output_field=IntegerField())
+        self.assertEqual(expr.get_group_by_cols(alias=None), [])
+
+    def test_group_by_cols_wrapper_over_field_propagates(self):
+        expr = ExpressionWrapper(F('num_employees'), output_field=IntegerField())
+        self.assertEqual(expr.get_group_by_cols(alias=None), [F('num_employees')])
+
+
 class BasicExpressionsTests(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
Fixes: #215

Summary
Constant expressions wrapped in ExpressionWrapper were incorrectly included in GROUP BY on PostgreSQL.

Reproduction steps
```python
from django.db.models import ExpressionWrapper, IntegerField, Sum, Value
def execQuery(expr):
    expr = ExpressionWrapper(expr, output_field=IntegerField())
    return Model.objects.annotate(expr_res=expr).values('expr_res', 'column_a').annotate(sum=Sum('column_b'))
# Passing Value(3) leads to grouping by a constant
```

Observed SQL
```sql
SELECT \"model\".\"column_a\", 3 AS \"expr_res\", SUM(\"model\".\"column_b\") AS \"sum\"\nFROM \"model\"\nGROUP BY \"model\".\"column_a\", 3
```

Observed failure (Postgres)
```
django.db.utils.ProgrammingError: aggregate functions are not allowed in GROUP BY\nLINE 1: SELECT \"model\".\"column_a\", 3 AS \"expr_res\", SUM(\"model\".\"col...
```

Root cause
ExpressionWrapper inherits BaseExpression.get_group_by_cols which returns [self] when no aggregates; Value.get_group_by_cols returns [] for constants. The wrapper incorrectly made constants appear as GROUP BY columns.

Fix
Delegate get_group_by_cols() to the wrapped expression.

Tests
- SimpleTestCase asserting ExpressionWrapper(Value(42)).get_group_by_cols(None) == []
- Delegation to non-constant expression (F('num_employees')) preserved