### PR TITLE
swev-id: django__django-12858 - allow Meta.ordering isnull lookup

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -18,6 +18,7 @@ from django.db import (
 from django.db.models import (
     NOT_PROVIDED, ExpressionWrapper, IntegerField, Max, Value,
 )
+from django.db.models.lookups import IsNull
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.constraints import CheckConstraint, UniqueConstraint
 from django.db.models.deletion import CASCADE, Collector
@@ -1735,7 +1736,9 @@ class Model(metaclass=ModelBase):
         for field in related_fields:
             _cls = cls
             fld = None
-            for part in field.split(LOOKUP_SEP):
+            parts = field.split(LOOKUP_SEP)
+            for index, part in enumerate(parts):
+                is_last_part = index == len(parts) - 1
                 try:
                     # pk is an alias that won't be found by opts.get_field.
                     if part == 'pk':
@@ -1747,15 +1750,27 @@ class Model(metaclass=ModelBase):
                     else:
                         _cls = None
                 except (FieldDoesNotExist, AttributeError):
-                    if fld is None or fld.get_transform(part) is None:
-                        errors.append(
-                            checks.Error(
-                                "'ordering' refers to the nonexistent field, "
-                                "related field, or lookup '%s'." % field,
-                                obj=cls,
-                                id='models.E015',
-                            )
+                    transform = None if fld is None else fld.get_transform(part)
+                    if transform is not None:
+                        continue
+
+                    if fld is not None and is_last_part:
+                        lookup = fld.get_lookup(part)
+                        if (
+                            lookup is not None and
+                            inspect.isclass(lookup) and
+                            issubclass(lookup, IsNull)
+                        ):
+                            continue
+
+                    errors.append(
+                        checks.Error(
+                            "'ordering' refers to the nonexistent field, "
+                            "related field, or lookup '%s'." % field,
+                            obj=cls,
+                            id='models.E015',
                         )
+                    )
 
         # Skip ordering on pk. This is always a valid order_by field
         # but is an alias and therefore won't be found by opts.get_field.

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -893,6 +893,74 @@ class OtherModelTests(SimpleTestCase):
         with register_lookup(models.CharField, Lower):
             self.assertEqual(Model.check(), [])
 
+    def test_ordering_allows_isnull_lookup(self):
+        class Parent(models.Model):
+            pass
+
+        class Product(models.Model):
+            parent = models.ForeignKey(Parent, models.SET_NULL, null=True)
+
+        class Supply(models.Model):
+            product = models.ForeignKey(Product, models.CASCADE)
+
+        class Stock(models.Model):
+            supply = models.ForeignKey(Supply, models.CASCADE)
+
+            class Meta:
+                ordering = ['supply__product__parent__isnull']
+
+        self.assertEqual(Stock.check(), [])
+
+    def test_ordering_invalid_lookup_part(self):
+        class Parent(models.Model):
+            pass
+
+        class Product(models.Model):
+            parent = models.ForeignKey(Parent, models.SET_NULL, null=True)
+
+        class Supply(models.Model):
+            product = models.ForeignKey(Product, models.CASCADE)
+
+        class Stock(models.Model):
+            supply = models.ForeignKey(Supply, models.CASCADE)
+
+            class Meta:
+                ordering = ['supply__product__parent__doesnotexist']
+
+        self.assertEqual(Stock.check(), [
+            Error(
+                "'ordering' refers to the nonexistent field, related field, "
+                "or lookup 'supply__product__parent__doesnotexist'.",
+                obj=Stock,
+                id='models.E015',
+            ),
+        ])
+
+    def test_ordering_invalid_lookup_type(self):
+        class Parent(models.Model):
+            pass
+
+        class Product(models.Model):
+            parent = models.ForeignKey(Parent, models.SET_NULL, null=True)
+
+        class Supply(models.Model):
+            product = models.ForeignKey(Product, models.CASCADE)
+
+        class Stock(models.Model):
+            supply = models.ForeignKey(Supply, models.CASCADE)
+
+            class Meta:
+                ordering = ['supply__product__parent__contains']
+
+        self.assertEqual(Stock.check(), [
+            Error(
+                "'ordering' refers to the nonexistent field, related field, "
+                "or lookup 'supply__product__parent__contains'.",
+                obj=Stock,
+                id='models.E015',
+            ),
+        ])
+
     def test_ordering_pointing_to_related_model_pk(self):
         class Parent(models.Model):
             pass


### PR DESCRIPTION
## Summary
- accept `isnull` lookups as the final component when validating `Meta.ordering`
- extend invalid model tests to cover allowed and rejected lookups on related fields

Failure reproduction with stack trace: [Issue #216 comment](https://github.com/agyn-sandbox/django/issues/216#issuecomment-3678049704)

## Testing
- PYTHONPATH=/workspace/django python tests/runtests.py invalid_models_tests --parallel=1
- flake8 django/db/models/base.py tests/invalid_models_tests/test_models.py

Refs #216