### PR TITLE
Fix NotSupportedError when RHS has filterable=False attribute (swev-id: django__django-13028)

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1124,7 +1124,11 @@ class Query(BaseExpression):
 
     def check_filterable(self, expression):
         """Raise an error if expression cannot be used in a WHERE clause."""
-        if not getattr(expression, 'filterable', True):
+        # Only expressions should be subject to filterability checks.
+        if (
+            hasattr(expression, 'resolve_expression') and
+            not getattr(expression, 'filterable', True)
+        ):
             raise NotSupportedError(
                 expression.__class__.__name__ + ' is disallowed in the filter '
                 'clause.'

--- a/tests/filterable_rhs/__init__.py
+++ b/tests/filterable_rhs/__init__.py
@@ -1,0 +1,1 @@
+# The isolate_apps decorator requires an importable app module.

--- a/tests/queries/test_filterable_rhs.py
+++ b/tests/queries/test_filterable_rhs.py
@@ -1,0 +1,73 @@
+from django.db import connection, models
+from django.test import TransactionTestCase
+from django.test.utils import isolate_apps
+
+
+@isolate_apps('filterable_rhs')
+class RHSFilterableAttributeTests(TransactionTestCase):
+    available_apps = []
+
+    def test_fk_rhs_instance_with_filterable_field_does_not_error(self):
+        class FilterableType(models.Model):
+            filterable = models.BooleanField(default=False)
+            name = models.CharField(max_length=50, default='')
+
+            class Meta:
+                app_label = 'filterable_rhs'
+
+        class Parent(models.Model):
+            ft = models.ForeignKey(FilterableType, models.CASCADE)
+
+            class Meta:
+                app_label = 'filterable_rhs'
+
+        with connection.schema_editor() as editor:
+            editor.create_model(FilterableType)
+            editor.create_model(Parent)
+        try:
+            ft_false = FilterableType.objects.create(filterable=False, name='false')
+            ft_true = FilterableType.objects.create(filterable=True, name='true')
+            p1 = Parent.objects.create(ft=ft_false)
+            p2 = Parent.objects.create(ft=ft_true)
+
+            # After fix: both filters should work and return expected rows.
+            self.assertQuerysetEqual(
+                Parent.objects.filter(ft=ft_false).order_by('id'),
+                [p1.pk],
+                transform=lambda x: x.pk,
+            )
+            self.assertQuerysetEqual(
+                Parent.objects.filter(ft=ft_true).order_by('id'),
+                [p2.pk],
+                transform=lambda x: x.pk,
+            )
+        finally:
+            with connection.schema_editor() as editor:
+                editor.delete_model(Parent)
+                editor.delete_model(FilterableType)
+
+    def test_non_expression_values_are_allowed(self):
+        class FilterableType(models.Model):
+            filterable = models.BooleanField(default=False)
+            name = models.CharField(max_length=50, default='')
+
+            class Meta:
+                app_label = 'filterable_rhs'
+
+        class Parent(models.Model):
+            ft = models.ForeignKey(FilterableType, models.CASCADE)
+
+            class Meta:
+                app_label = 'filterable_rhs'
+
+        with connection.schema_editor() as editor:
+            editor.create_model(FilterableType)
+            editor.create_model(Parent)
+        try:
+            ft = FilterableType.objects.create(filterable=False, name='x')
+            p = Parent.objects.create(ft=ft)
+            self.assertEqual(Parent.objects.filter(pk=p.pk).count(), 1)
+        finally:
+            with connection.schema_editor() as editor:
+                editor.delete_model(Parent)
+                editor.delete_model(FilterableType)


### PR DESCRIPTION
This PR fixes a regression where filtering with a RHS model instance that has a BooleanField named `filterable` erroneously raises `NotSupportedError`.

- Guard the `filterable` check in `Query.check_filterable()` to only apply to real expressions (`hasattr(expression, 'resolve_expression')`).
- Add tests in `tests/queries/test_filterable_rhs.py` that reproduce the failure and verify the fix.

Refs Issue #211 and regression commit `4edad1ddf6203326e0be4bdb105beecb0fe454c4`.

No CI run triggered manually per task constraints.