### PR TITLE
swev-id: django__django-12965 restore single-table delete SQL

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1407,7 +1407,9 @@ class SQLInsertCompiler(SQLCompiler):
 class SQLDeleteCompiler(SQLCompiler):
     @cached_property
     def single_alias(self):
-        return sum(self.query.alias_refcount[t] > 0 for t in self.query.alias_map) == 1
+        if not self.query.alias_map:
+            self.query.get_initial_alias()
+        return self.query.count_active_tables() == 1
 
     def _as_sql(self, query):
         result = [

--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -3,6 +3,7 @@ from math import ceil
 from django.db import connection, models
 from django.db.models import ProtectedError, RestrictedError
 from django.db.models.deletion import Collector
+from django.db.models.sql.subqueries import DeleteQuery
 from django.db.models.sql.constants import GET_ITERATOR_CHUNK_SIZE
 from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 
@@ -703,3 +704,44 @@ class FastDeleteTests(TestCase):
         referer = Referrer.objects.create(origin=origin, unique_field=42)
         with self.assertNumQueries(2):
             referer.delete()
+
+
+class DeleteSQLCompilationTests(TestCase):
+
+    def compile_delete(self, queryset):
+        query = queryset.query.chain(DeleteQuery)
+        compiler = query.get_compiler(using=queryset.db)
+        return compiler.as_sql()
+
+    def test_queryset_all_delete_plain_sql(self):
+        sql, params = self.compile_delete(Avatar.objects.all())
+        upper_sql = sql.upper()
+        quoted_name = connection.ops.quote_name(Avatar._meta.db_table)
+        self.assertTrue(upper_sql.startswith('DELETE FROM'))
+        self.assertIn(quoted_name, sql)
+        self.assertNotIn('WHERE', upper_sql)
+        self.assertNotIn('SELECT', upper_sql)
+        self.assertEqual(params, ())
+
+    def test_queryset_filtered_base_table_delete_no_subquery(self):
+        sql, params = self.compile_delete(Avatar.objects.filter(desc__isnull=False))
+        upper_sql = sql.upper()
+        quoted_name = connection.ops.quote_name(Avatar._meta.db_table)
+        self.assertTrue(upper_sql.startswith('DELETE FROM'))
+        self.assertIn(quoted_name, sql)
+        self.assertIn('WHERE', upper_sql)
+        self.assertNotIn('IN (SELECT', upper_sql)
+        self.assertNotIn('SELECT', upper_sql)
+        self.assertEqual(params, ())
+
+    def test_queryset_join_delete_uses_subquery_sql(self):
+        sql, params = self.compile_delete(
+            User.objects.filter(avatar__desc__isnull=False)
+        )
+        upper_sql = sql.upper()
+        quoted_name = connection.ops.quote_name(User._meta.db_table)
+        self.assertTrue(upper_sql.startswith('DELETE FROM'))
+        self.assertIn(quoted_name, sql)
+        self.assertIn('WHERE', upper_sql)
+        self.assertIn('IN (SELECT', upper_sql)
+        self.assertEqual(params, ())


### PR DESCRIPTION
## Summary
- restore plain delete compilation for single-table querysets by initializing the base alias before counting active tables
- add regression tests covering all(), filtered single-table, and joined queryset deletes

## Testing
- PYTHONPATH=/workspace/django ./runtests.py delete --parallel=1

## Reproduction
- Session A: `LOCK TABLES testapp_alphabet WRITE;`
- In Django 3.1, calling `Model.objects.all().delete()` produces `DELETE FROM testapp_alphabet WHERE ... IN (SELECT ...)`, raising `ERROR 1100: Table 'testapp_alphabet' was not locked with LOCK TABLES` under the lock
- On MariaDB 10.3 with 100k rows, plain delete ~0.2s vs subquery delete ~7.5s

Fixes #217