### PR TITLE
swev-id: django__django-13109 — Use _base_manager in ForeignKey.validate()

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -914,7 +914,7 @@ class ForeignKey(ForeignObject):
             return
 
         using = router.db_for_read(self.remote_field.model, instance=model_instance)
-        qs = self.remote_field.model._default_manager.using(using).filter(
+        qs = self.remote_field.model._base_manager.using(using).filter(
             **{self.remote_field.field_name: value}
         )
         qs = qs.complex_filter(self.get_limit_choices_to())

--- a/tests/model_forms/base_manager_app/__init__.py
+++ b/tests/model_forms/base_manager_app/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'tests.model_forms.base_manager_app.apps.BaseManagerAppConfig'

--- a/tests/model_forms/base_manager_app/apps.py
+++ b/tests/model_forms/base_manager_app/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class BaseManagerAppConfig(AppConfig):
+    name = 'tests.model_forms.base_manager_app'
+    label = 'model_forms_fk_validate'

--- a/tests/model_forms/base_manager_app/models.py
+++ b/tests/model_forms/base_manager_app/models.py
@@ -1,0 +1,24 @@
+from django.db import models
+
+
+class PublishedArticleManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().filter(is_archived=False)
+
+
+class Article(models.Model):
+    is_archived = models.BooleanField(default=False)
+
+    objects = PublishedArticleManager()
+    all_objects = models.Manager()
+
+    class Meta:
+        app_label = 'model_forms_fk_validate'
+        base_manager_name = 'all_objects'
+
+
+class FavoriteArticles(models.Model):
+    article = models.ForeignKey('model_forms_fk_validate.Article', models.CASCADE)
+
+    class Meta:
+        app_label = 'model_forms_fk_validate'

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -15,7 +15,8 @@ from django.forms.models import (
     modelform_factory,
 )
 from django.template import Context, Template
-from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
+from django.test import SimpleTestCase, TestCase, TransactionTestCase, skipUnlessDBFeature
+from django.test.utils import isolate_apps
 
 from .models import (
     Article, ArticleStatus, Author, Author1, Award, BetterWriter, BigInt, Book,
@@ -168,6 +169,54 @@ class CustomErrorMessageForm(forms.ModelForm):
     class Meta:
         fields = '__all__'
         model = CustomErrorMessage
+
+
+class ForeignKeyValidateBaseManagerTests(TransactionTestCase):
+    available_apps = []
+
+    def _teardown_models(self, *models):
+        with connection.schema_editor(atomic=False) as editor:
+            for model in models:
+                editor.delete_model(model)
+
+    def _setup_models(self, apps):
+        from tests.model_forms.base_manager_app import models as base_manager_models
+
+        apps.register_model('model_forms_fk_validate', base_manager_models.Article)
+        apps.register_model('model_forms_fk_validate', base_manager_models.FavoriteArticles)
+        Article = apps.get_model('model_forms_fk_validate', 'Article')
+        FavoriteArticles = apps.get_model('model_forms_fk_validate', 'FavoriteArticles')
+
+        class FavoriteArticlesForm(forms.ModelForm):
+            class Meta:
+                model = FavoriteArticles
+                fields = ['article']
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.fields['article'].queryset = Article._base_manager.all()
+
+        with connection.schema_editor(atomic=False) as editor:
+            editor.create_model(Article)
+            editor.create_model(FavoriteArticles)
+
+        self.addCleanup(self._teardown_models, FavoriteArticles, Article)
+
+        archived_article = Article._base_manager.create(is_archived=True)
+        return Article, FavoriteArticles, FavoriteArticlesForm, archived_article
+
+    @isolate_apps('tests.model_forms.base_manager_app', kwarg_name='apps')
+    def test_model_form_accepts_base_manager_queryset(self, apps):
+        Article, FavoriteArticles, FavoriteArticlesForm, archived_article = self._setup_models(apps)
+        form = FavoriteArticlesForm(data={'article': archived_article.pk})
+        self.assertTrue(form.is_valid())
+
+    @isolate_apps('tests.model_forms.base_manager_app', kwarg_name='apps')
+    def test_foreign_key_clean_uses_base_manager(self, apps):
+        Article, FavoriteArticles, FavoriteArticlesForm, archived_article = self._setup_models(apps)
+        field = FavoriteArticles._meta.get_field('article')
+        cleaned_value = field.clean(archived_article.pk, FavoriteArticles())
+        self.assertEqual(cleaned_value, archived_article.pk)
 
 
 class ModelFormBaseTest(TestCase):


### PR DESCRIPTION
Fixes #213

## Summary
- add regression tests covering ModelForm submission and direct field clean when a ForeignKey relies on `_base_manager`
- register a scoped test app with an archived-aware Article manager to reproduce the failure
- switch `ForeignKey.validate()` to query through `_base_manager` so validation matches database availability

## Reproduction Steps
1. python3 -m venv .venv
2. .venv/bin/pip install asgiref pytz sqlparse setuptools
3. PYTHONPATH=$PWD .venv/bin/python tests/runtests.py model_forms --parallel=1

### Observed Failure (before fix)
```text
ERROR: test_foreign_key_clean_uses_base_manager (model_forms.tests.ForeignKeyValidateBaseManagerTests.test_foreign_key_clean_uses_base_manager)
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/tests.py", line 218, in test_foreign_key_clean_uses_base_manager
    cleaned_value = field.clean(archived_article.pk, FavoriteArticles())
  File "/workspace/django/django/db/models/fields/__init__.py", line 651, in clean
    self.validate(value, model_instance)
  File "/workspace/django/django/db/models/fields/related.py", line 922, in validate
    raise exceptions.ValidationError(
django.core.exceptions.ValidationError: ['article instance with id 1 does not exist.']

FAIL: test_model_form_accepts_base_manager_queryset (model_forms.tests.ForeignKeyValidateBaseManagerTests.test_model_form_accepts_base_manager_queryset)
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/tests.py", line 212, in test_model_form_accepts_base_manager_queryset
    self.assertTrue(form.is_valid())
AssertionError: False is not true
```

## Rationale
Using `_base_manager` keeps model-level validation aligned with actual database rows even when a custom default manager filters archived objects. Form-level filtering remains explicit and separate.

## Testing
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py model_forms --parallel=1
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py model_forms.tests.ForeignKeyValidateBaseManagerTests --parallel=1