### PR TITLE
swev-id: django__django-13033 — Fix self-referential FK ordering by _id (avoid fallback to related Meta.ordering)

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -727,7 +727,7 @@ class SQLCompiler:
         # If we get to this point and the field is a relation to another model,
         # append the default ordering for that model unless it is the pk
         # shortcut or the attribute name of the field that is specified.
-        if field.is_relation and opts.ordering and getattr(field, 'attname', None) != name and name != 'pk':
+        if field.is_relation and opts.ordering and getattr(field, 'attname', None) != pieces[-1] and name != 'pk':
             # Firstly, avoid infinite loops.
             already_seen = already_seen or set()
             join_tuple = tuple(getattr(self.query.alias_map[j], 'join_cols', None) for j in joins)

--- a/tests/ordering/models.py
+++ b/tests/ordering/models.py
@@ -59,3 +59,19 @@ class Reference(models.Model):
 
     class Meta:
         ordering = ('article',)
+
+
+class OneModel(models.Model):
+
+    class Meta:
+        ordering = ('-id',)
+
+    id = models.BigAutoField(primary_key=True)
+    root = models.ForeignKey('self', models.CASCADE, null=True)
+    oneval = models.BigIntegerField(null=True)
+
+
+class TwoModel(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    record = models.ForeignKey(OneModel, models.CASCADE)
+    twoval = models.BigIntegerField(null=True)

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from operator import attrgetter
 
@@ -505,36 +506,43 @@ class SelfReferentialFKOrderingTests(TestCase):
         sql = str(queryset.query)
         start = sql.upper().find('ORDER BY')
         self.assertNotEqual(start, -1, 'ORDER BY clause not found in generated SQL.')
-        return sql[start:]
+        fragment = sql[start:]
+        fragment = fragment.upper()
+        return re.sub(r'["`\[\]]', '', fragment)
+
+    def first_ordering_term(self, fragment):
+        return fragment[len('ORDER BY '):].split(',', 1)[0].strip()
 
     def test_order_by_record_root_id(self):
         qs = TwoModel.objects.order_by('record__root_id')
         records = list(qs)
-        fragment = self.order_by_fragment(qs).upper()
+        fragment = self.order_by_fragment(qs)
+        first_term = self.first_ordering_term(fragment)
         self.assertSequenceEqual(records, [self.low_record, self.high_record], msg=fragment)
-        self.assertIn('ROOT_ID', fragment)
-        self.assertIn(' ASC', fragment.split('ROOT_ID', 1)[-1])
+        self.assertIn('ROOT_ID', first_term)
+        self.assertTrue(first_term.endswith('ASC'), msg=fragment)
 
     def test_order_by_record_root_relation(self):
         qs = TwoModel.objects.order_by('record__root')
         records = list(qs)
-        fragment = self.order_by_fragment(qs).upper()
+        fragment = self.order_by_fragment(qs)
+        first_term = self.first_ordering_term(fragment)
         self.assertSequenceEqual(records, [self.high_record, self.low_record], msg=fragment)
-        self.assertIn('"ID" DESC', fragment)
+        self.assertTrue(first_term.endswith('ID DESC'), msg=fragment)
 
     def test_order_by_record_root_pk(self):
         qs = TwoModel.objects.order_by('record__root__id')
         self.assertSequenceEqual(list(qs), [self.low_record, self.high_record])
-        fragment = self.order_by_fragment(qs).upper()
-        self.assertIn('ROOT_ID', fragment)
-        tail = fragment.split('ROOT_ID', 1)[-1]
-        self.assertIn(' ASC', tail)
-        self.assertNotIn(' DESC', tail)
+        fragment = self.order_by_fragment(qs)
+        first_term = self.first_ordering_term(fragment)
+        self.assertTrue(first_term.endswith('ID ASC'), msg=fragment)
+        self.assertNotIn('ID DESC', first_term)
 
     def test_order_by_record_root_id_descending(self):
         qs = TwoModel.objects.order_by('-record__root_id')
         records = list(qs)
-        fragment = self.order_by_fragment(qs).upper()
+        fragment = self.order_by_fragment(qs)
+        first_term = self.first_ordering_term(fragment)
         self.assertSequenceEqual(records, [self.high_record, self.low_record], msg=fragment)
-        self.assertIn('ROOT_ID', fragment)
-        self.assertIn(' DESC', fragment.split('ROOT_ID', 1)[-1])
+        self.assertIn('ROOT_ID', first_term)
+        self.assertTrue(first_term.endswith('DESC'), msg=fragment)

--- a/tests/ordering/tests.py
+++ b/tests/ordering/tests.py
@@ -8,7 +8,15 @@ from django.db.models import (
 from django.db.models.functions import Upper
 from django.test import TestCase
 
-from .models import Article, Author, ChildArticle, OrderedByFArticle, Reference
+from .models import (
+    Article,
+    Author,
+    ChildArticle,
+    OneModel,
+    OrderedByFArticle,
+    Reference,
+    TwoModel,
+)
 
 
 class OrderingTests(TestCase):
@@ -480,3 +488,53 @@ class OrderingTests(TestCase):
         ca4 = ChildArticle.objects.create(headline='h1', pub_date=datetime(2005, 7, 28))
         articles = ChildArticle.objects.order_by('article_ptr')
         self.assertSequenceEqual(articles, [ca4, ca2, ca1, ca3])
+
+
+class SelfReferentialFKOrderingTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.root_low = OneModel.objects.create(oneval=1)
+        cls.root_high = OneModel.objects.create(oneval=2)
+        cls.child_low = OneModel.objects.create(root=cls.root_low, oneval=3)
+        cls.child_high = OneModel.objects.create(root=cls.root_high, oneval=4)
+        cls.low_record = TwoModel.objects.create(record=cls.child_low, twoval=10)
+        cls.high_record = TwoModel.objects.create(record=cls.child_high, twoval=20)
+
+    def order_by_fragment(self, queryset):
+        sql = str(queryset.query)
+        start = sql.upper().find('ORDER BY')
+        self.assertNotEqual(start, -1, 'ORDER BY clause not found in generated SQL.')
+        return sql[start:]
+
+    def test_order_by_record_root_id(self):
+        qs = TwoModel.objects.order_by('record__root_id')
+        records = list(qs)
+        fragment = self.order_by_fragment(qs).upper()
+        self.assertSequenceEqual(records, [self.low_record, self.high_record], msg=fragment)
+        self.assertIn('ROOT_ID', fragment)
+        self.assertIn(' ASC', fragment.split('ROOT_ID', 1)[-1])
+
+    def test_order_by_record_root_relation(self):
+        qs = TwoModel.objects.order_by('record__root')
+        records = list(qs)
+        fragment = self.order_by_fragment(qs).upper()
+        self.assertSequenceEqual(records, [self.high_record, self.low_record], msg=fragment)
+        self.assertIn('"ID" DESC', fragment)
+
+    def test_order_by_record_root_pk(self):
+        qs = TwoModel.objects.order_by('record__root__id')
+        self.assertSequenceEqual(list(qs), [self.low_record, self.high_record])
+        fragment = self.order_by_fragment(qs).upper()
+        self.assertIn('ROOT_ID', fragment)
+        tail = fragment.split('ROOT_ID', 1)[-1]
+        self.assertIn(' ASC', tail)
+        self.assertNotIn(' DESC', tail)
+
+    def test_order_by_record_root_id_descending(self):
+        qs = TwoModel.objects.order_by('-record__root_id')
+        records = list(qs)
+        fragment = self.order_by_fragment(qs).upper()
+        self.assertSequenceEqual(records, [self.high_record, self.low_record], msg=fragment)
+        self.assertIn('ROOT_ID', fragment)
+        self.assertIn(' DESC', fragment.split('ROOT_ID', 1)[-1])


### PR DESCRIPTION
## Summary
- Resolves #214 by ensuring `SQLCompiler.find_ordering_name()` compares the FK attname against the terminal lookup segment so `_id` orderings respect the requested direction.
- Adds self-referential fixtures (`OneModel`, `TwoModel`) and regression coverage for ordering by `_id`, relation, relation `__id`, and descending `_id` paths.

## Reproduction
```
PYTHONPATH=/workspace/django python tests/runtests.py ordering --parallel=1
```
Failure excerpt (pre-fix):
```
FAIL: test_order_by_record_root_id (ordering.tests.SelfReferentialFKOrderingTests)
AssertionError: ... ORDER BY T3."ID" DESC
```
The fallback also forces `ORDER BY T3."ID" ASC` for the descending `_id` variant, showing the guard in `django/db/models/sql/compiler.py:find_ordering_name()` ignored the FK attname segment.

## Fix Details
- Guard against default Meta ordering when `field.attname` matches the last lookup piece (e.g., `root_id`).
- Keep fallback for pure relation orderings (e.g., `record__root`).
- Regression tests assert both queryset ordering and generated `ORDER BY` fragments.

## Testing
```
PYTHONPATH=/workspace/django python tests/runtests.py ordering --parallel=1
```
Result (post-fix):
```
Ran 30 tests in 0.041s

OK
```
CI not manually triggered.