### PR TITLE
Infer DurationField for temporal subtraction without ExpressionWrapper (swev-id: django__django-13128)

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -430,6 +430,17 @@ class CombinedExpression(SQLiteNumericMixin, Expression):
         self.lhs = lhs
         self.rhs = rhs
 
+    def _resolve_output_field(self):
+        if self.connector == self.SUB:
+            lhs_field, rhs_field = self.get_source_fields()
+            if lhs_field is not None and rhs_field is not None:
+                temporal_types = {'DateField', 'DateTimeField', 'TimeField'}
+                lhs_type = lhs_field.get_internal_type()
+                rhs_type = rhs_field.get_internal_type()
+                if lhs_type == rhs_type and lhs_type in temporal_types:
+                    return fields.DurationField()
+        return super()._resolve_output_field()
+
     def __repr__(self):
         return "<{}: {}>".format(self.__class__.__name__, self)
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1491,6 +1491,21 @@ class FTimeDeltaTests(TestCase):
                 self.assertEqual(obj.duration, obj.estimated_time + delta)
 
     @skipUnlessDBFeature('supports_temporal_subtraction')
+    def test_datetime_subtraction_annotation_infers_duration(self):
+        queryset = Experiment.objects.annotate(delta=F('end') - F('start'))
+        for experiment in queryset:
+            self.assertEqual(experiment.delta, experiment.end - experiment.start)
+
+    @skipUnlessDBFeature('supports_temporal_subtraction')
+    def test_datetime_subtraction_plus_duration_value(self):
+        zero = datetime.timedelta()
+        queryset = Experiment.objects.annotate(
+            delta=F('end') - F('start') + Value(zero, output_field=DurationField())
+        )
+        for experiment in queryset:
+            self.assertEqual(experiment.delta, experiment.end - experiment.start + zero)
+
+    @skipUnlessDBFeature('supports_temporal_subtraction')
     def test_date_subtraction(self):
         queryset = Experiment.objects.annotate(
             completion_duration=ExpressionWrapper(


### PR DESCRIPTION
### Issue
- Implements https://github.com/agyn-sandbox/django/issues/229

### Observed failure (pre-fix)
```
Traceback (most recent call last):
  File "<stdin>", line 32, in <module>
  File "/workspace/django/django/db/models/query.py", line 287, in __iter__
    self._fetch_all()
  File "/workspace/django/django/db/models/query.py", line 1305, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/workspace/django/django/db/models/query.py", line 53, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/workspace/django/django/db/models/sql/compiler.py", line 1148, in execute_sql
    sql, params = self.as_sql()
  File "/workspace/django/django/db/models/sql/compiler.py", line 498, in as_sql
    extra_select, order_by, group_by = self.pre_sql_setup()
  File "/workspace/django/django/db/models/sql/compiler.py", line 55, in pre_sql_setup
    self.setup_query()
  File "/workspace/django/django/db/models/sql/compiler.py", line 46, in setup_query
    self.select, self.klass_info, self.annotation_col_map = self.get_select()
  File "/workspace/django/django/db/models/sql/compiler.py", line 267, in get_select
    sql, params = col.select_format(self, sql, params)
  File "/workspace/django/django/db/models/expressions.py", line 388, in select_format
    if hasattr(self.output_field, 'select_format'):
  File "/workspace/django/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/workspace/django/django/db/models/expressions.py", line 269, in output_field
    output_field = self._resolve_output_field()
  File "/workspace/django/django/db/models/expressions.py", line 305, in _resolve_output_field
    raise FieldError(
django.core.exceptions.FieldError: Expression contains mixed types: DateTimeField, DurationField. You must set output_field.
```

### Reproduction steps
1. Checkout branch `django__django-13128`.
2. Configure a minimal in-memory SQLite settings module.
3. Define model `Experiment(start=DateTimeField, end=DateTimeField)`.
4. Run:
```python
Experiment.objects.annotate(
  delta=F('end') - F('start') + Value(datetime.timedelta(), output_field=DurationField())
)
```
5. Observe error: mixed types FieldError.

### Fix
- Teach `CombinedExpression._resolve_output_field()` to infer `DurationField` when subtracting matching temporal types so `DateTimeField - DateTimeField` automatically promotes to a duration.
- Existing backend logic already handles temporal subtraction SQL; no backend changes required.

### Tests
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py expressions --parallel=1