### PR TITLE
feat: swev-id: django__django-13212 include value param in validator errors

### DIFF
--- a/django/contrib/postgres/validators.py
+++ b/django/contrib/postgres/validators.py
@@ -44,7 +44,7 @@ class KeysValidator:
             raise ValidationError(
                 self.messages['missing_keys'],
                 code='missing_keys',
-                params={'keys': ', '.join(missing_keys)},
+                params={'keys': ', '.join(missing_keys), 'value': value},
             )
         if self.strict:
             extra_keys = keys - self.keys
@@ -52,7 +52,7 @@ class KeysValidator:
                 raise ValidationError(
                     self.messages['extra_keys'],
                     code='extra_keys',
-                    params={'keys': ', '.join(extra_keys)},
+                    params={'keys': ', '.join(extra_keys), 'value': value},
                 )
 
     def __eq__(self, other):

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -48,7 +48,7 @@ class RegexValidator:
         regex_matches = self.regex.search(str(value))
         invalid_input = regex_matches if self.inverse_match else not regex_matches
         if invalid_input:
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
 
     def __eq__(self, other):
         return (
@@ -100,28 +100,35 @@ class URLValidator(RegexValidator):
 
     def __call__(self, value):
         if not isinstance(value, str):
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
         # Check if the scheme is valid.
         scheme = value.split('://')[0].lower()
         if scheme not in self.schemes:
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
 
         # Then check full URL
         try:
             super().__call__(value)
         except ValidationError as e:
+            for error in e.error_list:
+                error.params = {**(error.params or {}), 'value': value}
             # Trivial case failed. Try for possible IDN domain
             if value:
                 try:
                     scheme, netloc, path, query, fragment = urlsplit(value)
                 except ValueError:  # for example, "Invalid IPv6 URL"
-                    raise ValidationError(self.message, code=self.code)
+                    raise ValidationError(self.message, code=self.code, params={'value': value})
                 try:
                     netloc = punycode(netloc)  # IDN -> ACE
                 except UnicodeError:  # invalid domain part
                     raise e
                 url = urlunsplit((scheme, netloc, path, query, fragment))
-                super().__call__(url)
+                try:
+                    super().__call__(url)
+                except ValidationError as invalid_url_error:
+                    for error in invalid_url_error.error_list:
+                        error.params = {**(error.params or {}), 'value': value}
+                    raise invalid_url_error
             else:
                 raise
         else:
@@ -132,14 +139,14 @@ class URLValidator(RegexValidator):
                 try:
                     validate_ipv6_address(potential_ip)
                 except ValidationError:
-                    raise ValidationError(self.message, code=self.code)
+                    raise ValidationError(self.message, code=self.code, params={'value': value})
 
         # The maximum length of a full host name is 253 characters per RFC 1034
         # section 3.1. It's defined to be 255 bytes or less, but this includes
         # one byte for the length of the name and one byte for the trailing dot
         # that's used to indicate absolute names in DNS.
         if len(urlsplit(value).netloc) > 253:
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
 
 
 integer_validator = RegexValidator(
@@ -208,12 +215,12 @@ class EmailValidator:
 
     def __call__(self, value):
         if not value or '@' not in value:
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
 
         user_part, domain_part = value.rsplit('@', 1)
 
         if not self.user_regex.match(user_part):
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
 
         if (domain_part not in self.domain_allowlist and
                 not self.validate_domain_part(domain_part)):
@@ -225,7 +232,7 @@ class EmailValidator:
             else:
                 if self.validate_domain_part(domain_part):
                     return
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
 
     def validate_domain_part(self, domain_part):
         if self.domain_regex.match(domain_part):
@@ -272,12 +279,12 @@ def validate_ipv4_address(value):
     try:
         ipaddress.IPv4Address(value)
     except ValueError:
-        raise ValidationError(_('Enter a valid IPv4 address.'), code='invalid')
+        raise ValidationError(_('Enter a valid IPv4 address.'), code='invalid', params={'value': value})
 
 
 def validate_ipv6_address(value):
     if not is_valid_ipv6_address(value):
-        raise ValidationError(_('Enter a valid IPv6 address.'), code='invalid')
+        raise ValidationError(_('Enter a valid IPv6 address.'), code='invalid', params={'value': value})
 
 
 def validate_ipv46_address(value):
@@ -287,7 +294,7 @@ def validate_ipv46_address(value):
         try:
             validate_ipv6_address(value)
         except ValidationError:
-            raise ValidationError(_('Enter a valid IPv4 or IPv6 address.'), code='invalid')
+            raise ValidationError(_('Enter a valid IPv4 or IPv6 address.'), code='invalid', params={'value': value})
 
 
 ip_address_validator_map = {
@@ -460,20 +467,20 @@ class DecimalValidator:
             raise ValidationError(
                 self.messages['max_digits'],
                 code='max_digits',
-                params={'max': self.max_digits},
+                params={'max': self.max_digits, 'value': value},
             )
         if self.decimal_places is not None and decimals > self.decimal_places:
             raise ValidationError(
                 self.messages['max_decimal_places'],
                 code='max_decimal_places',
-                params={'max': self.decimal_places},
+                params={'max': self.decimal_places, 'value': value},
             )
         if (self.max_digits is not None and self.decimal_places is not None and
                 whole_digits > (self.max_digits - self.decimal_places)):
             raise ValidationError(
                 self.messages['max_whole_digits'],
                 code='max_whole_digits',
-                params={'max': (self.max_digits - self.decimal_places)},
+                params={'max': (self.max_digits - self.decimal_places), 'value': value},
             )
 
     def __eq__(self, other):
@@ -509,7 +516,8 @@ class FileExtensionValidator:
                 code=self.code,
                 params={
                     'extension': extension,
-                    'allowed_extensions': ', '.join(self.allowed_extensions)
+                    'allowed_extensions': ', '.join(self.allowed_extensions),
+                    'value': value,
                 }
             )
 
@@ -550,7 +558,7 @@ class ProhibitNullCharactersValidator:
 
     def __call__(self, value):
         if '\x00' in str(value):
-            raise ValidationError(self.message, code=self.code)
+            raise ValidationError(self.message, code=self.code, params={'value': value})
 
     def __eq__(self, other):
         return (

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -445,7 +445,7 @@ class DecimalValidator:
     def __call__(self, value):
         digit_tuple, exponent = value.as_tuple()[1:]
         if exponent in {'F', 'n', 'N'}:
-            raise ValidationError(self.messages['invalid'])
+            raise ValidationError(self.messages['invalid'], params={'value': value})
         if exponent >= 0:
             # A positive exponent adds that many trailing zeros.
             digits = len(digit_tuple) + exponent

--- a/django/utils/ipv6.py
+++ b/django/utils/ipv6.py
@@ -25,7 +25,7 @@ def clean_ipv6_address(ip_str, unpack_ipv4=False,
     try:
         addr = ipaddress.IPv6Address(int(ipaddress.IPv6Address(ip_str)))
     except ValueError:
-        raise ValidationError(error_message, code='invalid')
+        raise ValidationError(error_message, code='invalid', params={'value': ip_str})
 
     if unpack_ipv4 and addr.ipv4_mapped:
         return str(addr.ipv4_mapped)

--- a/tests/validators/test_value_params.py
+++ b/tests/validators/test_value_params.py
@@ -18,7 +18,9 @@ from django.core.validators import (
     validate_ipv46_address,
     validate_ipv6_address,
 )
+from django.db.models import GenericIPAddressField
 from django.test import SimpleTestCase
+from django.utils.ipv6 import clean_ipv6_address
 
 
 class ValidatorValueParamsTests(SimpleTestCase):
@@ -141,6 +143,16 @@ class ValidatorValueParamsTests(SimpleTestCase):
         self.assertEqual(params['max'], 3)
         self.assertEqual(cm.exception.messages, ['Too many whole digits 1234.5'])
 
+    def test_decimal_validator_invalid_number_includes_value(self):
+        validator = DecimalValidator(max_digits=4, decimal_places=2)
+        validator.messages = {**validator.messages, 'invalid': 'Invalid decimal %(value)s'}
+        value = Decimal('NaN')
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertTrue(params['value'].is_nan())
+        self.assertEqual(cm.exception.messages, ['Invalid decimal NaN'])
+
     def test_file_extension_validator_includes_value(self):
         validator = FileExtensionValidator(
             allowed_extensions=['jpg'],
@@ -217,3 +229,15 @@ class ValidatorValueParamsTests(SimpleTestCase):
     def test_validate_ipv46_address_includes_value(self):
         value = 'not-an-ip'
         self._assert_function_validator(validate_ipv46_address, value, 'IP %(value)s is invalid')
+
+    def test_clean_ipv6_address_invalid_includes_value(self):
+        value = 'not::an::ip'
+        with self.assertRaises(ValidationError) as cm:
+            clean_ipv6_address(value)
+        self.assertEqual(cm.exception.params['value'], value)
+        self.assertEqual(cm.exception.messages, ['This is not a valid IPv6 address.'])
+
+        field = GenericIPAddressField(error_messages={'invalid': 'Invalid IP: %(value)s'})
+        with self.assertRaises(ValidationError) as cm:
+            field.clean(value, None)
+        self.assertEqual(cm.exception.messages, ['Invalid IP: not::an::ip'])

--- a/tests/validators/test_value_params.py
+++ b/tests/validators/test_value_params.py
@@ -1,0 +1,219 @@
+from decimal import Decimal
+
+from django.contrib.auth.validators import UnicodeUsernameValidator
+from django.contrib.postgres.validators import KeysValidator
+from django.core.exceptions import ValidationError
+from django.core.validators import (
+    DecimalValidator,
+    EmailValidator,
+    FileExtensionValidator,
+    MaxLengthValidator,
+    MaxValueValidator,
+    MinLengthValidator,
+    MinValueValidator,
+    ProhibitNullCharactersValidator,
+    RegexValidator,
+    URLValidator,
+    validate_ipv4_address,
+    validate_ipv46_address,
+    validate_ipv6_address,
+)
+from django.test import SimpleTestCase
+
+
+class ValidatorValueParamsTests(SimpleTestCase):
+    def _assert_function_validator(self, validator, value, message_template):
+        with self.assertRaises(ValidationError) as cm:
+            try:
+                validator(value)
+            except ValidationError as error:
+                self.assertIsNotNone(error.params)
+                self.assertIn('value', error.params)
+                self.assertEqual(error.params['value'], value)
+                raise ValidationError(message_template, code=error.code, params=error.params)
+        self.assertEqual(cm.exception.params['value'], value)
+        self.assertEqual(cm.exception.messages, [message_template % {'value': value}])
+
+    def test_regex_validator_includes_value(self):
+        validator = RegexValidator(regex=r'^foo$', message='Invalid %(value)s')
+        value = 'bar'
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        self.assertEqual(cm.exception.params['value'], value)
+        self.assertEqual(cm.exception.messages, ['Invalid bar'])
+
+    def test_url_validator_includes_value(self):
+        validator = URLValidator(message='URL %(value)s is invalid')
+        value = 'http://例子.测试/ invalid'
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        self.assertEqual(cm.exception.params['value'], value)
+        self.assertEqual(cm.exception.messages, ['URL http://例子.测试/ invalid is invalid'])
+
+    def test_email_validator_includes_value(self):
+        validator = EmailValidator(message='Email %(value)s is invalid')
+        value = 'invalid'
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        self.assertEqual(cm.exception.params['value'], value)
+        self.assertEqual(cm.exception.messages, ['Email invalid is invalid'])
+
+    def test_min_value_validator_includes_value(self):
+        validator = MinValueValidator(5, message='Too small %(value)s')
+        value = 3
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['limit_value'], 5)
+        self.assertEqual(params['show_value'], value)
+        self.assertEqual(cm.exception.messages, ['Too small 3'])
+
+    def test_max_value_validator_includes_value(self):
+        validator = MaxValueValidator(5, message='Too large %(value)s')
+        value = 7
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['limit_value'], 5)
+        self.assertEqual(params['show_value'], value)
+        self.assertEqual(cm.exception.messages, ['Too large 7'])
+
+    def test_min_length_validator_includes_value(self):
+        validator = MinLengthValidator(3, message='Too short %(value)s')
+        value = 'ab'
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['limit_value'], 3)
+        self.assertEqual(params['show_value'], len(value))
+        self.assertEqual(cm.exception.messages, ['Too short ab'])
+
+    def test_max_length_validator_includes_value(self):
+        validator = MaxLengthValidator(3, message='Too long %(value)s')
+        value = 'abcd'
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['limit_value'], 3)
+        self.assertEqual(params['show_value'], len(value))
+        self.assertEqual(cm.exception.messages, ['Too long abcd'])
+
+    def test_decimal_validator_max_digits_includes_value(self):
+        validator = DecimalValidator(max_digits=4, decimal_places=2)
+        validator.messages = {**validator.messages, 'max_digits': 'Too many digits %(value)s'}
+        value = Decimal('12345')
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['max'], 4)
+        self.assertEqual(cm.exception.messages, ['Too many digits 12345'])
+
+    def test_decimal_validator_max_decimal_places_includes_value(self):
+        validator = DecimalValidator(max_digits=6, decimal_places=2)
+        validator.messages = {
+            **validator.messages,
+            'max_decimal_places': 'Too many decimals %(value)s',
+        }
+        value = Decimal('1.234')
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['max'], 2)
+        self.assertEqual(cm.exception.messages, ['Too many decimals 1.234'])
+
+    def test_decimal_validator_max_whole_digits_includes_value(self):
+        validator = DecimalValidator(max_digits=5, decimal_places=2)
+        validator.messages = {
+            **validator.messages,
+            'max_whole_digits': 'Too many whole digits %(value)s',
+        }
+        value = Decimal('1234.5')
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['max'], 3)
+        self.assertEqual(cm.exception.messages, ['Too many whole digits 1234.5'])
+
+    def test_file_extension_validator_includes_value(self):
+        validator = FileExtensionValidator(
+            allowed_extensions=['jpg'],
+            message='Disallowed for %(value)s',
+        )
+
+        class DummyFile:
+            def __init__(self, name):
+                self.name = name
+
+            def __str__(self):
+                return self.name
+
+        value = DummyFile('photo.txt')
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['extension'], 'txt')
+        self.assertEqual(params['allowed_extensions'], 'jpg')
+        self.assertEqual(cm.exception.messages, ['Disallowed for photo.txt'])
+
+    def test_prohibit_null_characters_validator_includes_value(self):
+        validator = ProhibitNullCharactersValidator(message='Nulls in %(value)s')
+        value = 'foo\x00bar'
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        self.assertEqual(cm.exception.params['value'], value)
+        self.assertEqual(cm.exception.messages, ['Nulls in foo\x00bar'])
+
+    def test_keys_validator_missing_keys_includes_value(self):
+        validator = KeysValidator(
+            keys={'required', 'present'},
+            messages={'missing_keys': 'Missing %(keys)s for %(value)s'},
+        )
+        value = {'present': 1}
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['keys'], 'required')
+        self.assertEqual(cm.exception.messages, ["Missing required for {'present': 1}"])
+
+    def test_keys_validator_extra_keys_includes_value(self):
+        validator = KeysValidator(
+            keys={'expected'},
+            strict=True,
+            messages={'extra_keys': 'Extra %(keys)s for %(value)s'},
+        )
+        value = {'expected': 1, 'extra': 2}
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        params = cm.exception.params
+        self.assertEqual(params['value'], value)
+        self.assertEqual(params['keys'], 'extra')
+        self.assertEqual(cm.exception.messages, ["Extra extra for {'expected': 1, 'extra': 2}"])
+
+    def test_username_validator_includes_value(self):
+        validator = UnicodeUsernameValidator(message='Invalid username %(value)s')
+        value = 'invalid user'
+        with self.assertRaises(ValidationError) as cm:
+            validator(value)
+        self.assertEqual(cm.exception.params['value'], value)
+        self.assertEqual(cm.exception.messages, ['Invalid username invalid user'])
+
+    def test_validate_ipv4_address_includes_value(self):
+        value = '999.0.0.1'
+        self._assert_function_validator(validate_ipv4_address, value, 'IPv4 %(value)s is invalid')
+
+    def test_validate_ipv6_address_includes_value(self):
+        value = '::zzz'
+        self._assert_function_validator(validate_ipv6_address, value, 'IPv6 %(value)s is invalid')
+
+    def test_validate_ipv46_address_includes_value(self):
+        value = 'not-an-ip'
+        self._assert_function_validator(validate_ipv46_address, value, 'IP %(value)s is invalid')


### PR DESCRIPTION
## Summary
- ensure core validators include the submitted value in ValidationError.params while preserving existing metadata
- propagate the value parameter to postgres KeysValidator and IPv6 cleaning utility
- add regression tests demonstrating %(value)s overrides for RegexValidator, Email/URL validators, BaseValidator derivatives, IP validators, file extension, null character, postgres keys, and username validators

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py validators.test_value_params --parallel=1
- .venv/bin/flake8 django/core/validators.py django/contrib/postgres/validators.py django/utils/ipv6.py tests/validators/test_value_params.py

## Reproduction
```python
from types import SimpleNamespace
from django.core.validators import FileExtensionValidator
from django.core.exceptions import ValidationError

validator = FileExtensionValidator(allowed_extensions=['jpg'], message='Disallowed for %(value)s')
value = SimpleNamespace(name='file.txt')

try:
    validator(value)
except ValidationError as e:
    # Rendering messages currently fails
    list(e)  # KeyError: 'value'
```

```
Traceback (most recent call last):
  File "/workspace/django/django/core/validators.py", line 507, in __call__
    raise ValidationError(
django.core.exceptions.ValidationError: <exception str() failed>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 17, in <module>
  File "/workspace/django/django/core/exceptions.py", line 174, in __iter__
    message %= error.params
KeyError: 'value'
```

Fixes #231