### PR TITLE
swev-id: django__django-13343 - preserve FileField storage callables

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -227,14 +227,17 @@ class FileField(Field):
     def __init__(self, verbose_name=None, name=None, upload_to='', storage=None, **kwargs):
         self._primary_key_set_explicitly = 'primary_key' in kwargs
 
-        self.storage = storage or default_storage
-        if callable(self.storage):
-            self.storage = self.storage()
-            if not isinstance(self.storage, Storage):
+        self._storage_arg = storage if storage is not None else None
+
+        configured_storage = storage or default_storage
+        if callable(configured_storage):
+            configured_storage = configured_storage()
+            if not isinstance(configured_storage, Storage):
                 raise TypeError(
                     "%s.storage must be a subclass/instance of %s.%s"
                     % (self.__class__.__qualname__, Storage.__module__, Storage.__qualname__)
                 )
+        self.storage = configured_storage
         self.upload_to = upload_to
 
         kwargs.setdefault('max_length', 100)
@@ -278,8 +281,8 @@ class FileField(Field):
         if kwargs.get("max_length") == 100:
             del kwargs["max_length"]
         kwargs['upload_to'] = self.upload_to
-        if self.storage is not default_storage:
-            kwargs['storage'] = self.storage
+        if self._storage_arg is not None:
+            kwargs['storage'] = self._storage_arg
         return name, path, args, kwargs
 
     def get_internal_type(self):
@@ -441,7 +444,7 @@ class ImageField(FileField):
         if not file and not force:
             return
 
-        dimension_fields_filled = not(
+        dimension_fields_filled = not (
             (self.width_field and not getattr(instance, self.width_field)) or
             (self.height_field and not getattr(instance, self.height_field))
         )

--- a/tests/field_deconstruction/tests.py
+++ b/tests/field_deconstruction/tests.py
@@ -1,7 +1,20 @@
 from django.apps import apps
+from django.core.files.storage import Storage
 from django.db import models
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import isolate_lru_cache
+
+
+class DummyStorage(Storage):
+    def _open(self, name, mode='rb'):
+        raise NotImplementedError
+
+    def _save(self, name, content):
+        return name
+
+
+def dummy_storage_callable():
+    return DummyStorage()
 
 
 class FieldDeconstructionTests(SimpleTestCase):
@@ -173,6 +186,22 @@ class FieldDeconstructionTests(SimpleTestCase):
         self.assertEqual(path, "django.db.models.FileField")
         self.assertEqual(args, [])
         self.assertEqual(kwargs, {"upload_to": "foo/bar", "max_length": 200})
+
+    def test_file_field_storage_callable_deconstruct(self):
+        field = models.FileField(storage=dummy_storage_callable)
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.FileField")
+        self.assertEqual(args, [])
+        self.assertIs(kwargs["storage"], dummy_storage_callable)
+        self.assertIsInstance(field.storage, DummyStorage)
+
+    def test_file_field_storage_class_callable_deconstruct(self):
+        field = models.FileField(storage=DummyStorage)
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(path, "django.db.models.FileField")
+        self.assertEqual(args, [])
+        self.assertIs(kwargs["storage"], DummyStorage)
+        self.assertIsInstance(field.storage, DummyStorage)
 
     def test_file_path_field(self):
         field = models.FilePathField(match=r".*\.txt$")

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -15,6 +15,7 @@ import custom_migration_operations.operations
 
 from django import get_version
 from django.conf import SettingsReference, settings
+from django.core.files.storage import Storage
 from django.core.validators import EmailValidator, RegexValidator
 from django.db import migrations, models
 from django.db.migrations.serializer import BaseSerializer
@@ -46,6 +47,19 @@ class TestModel1:
     def upload_to(self):
         return '/somewhere/dynamic/'
     thing = models.FileField(upload_to=upload_to)
+
+
+class DummyMigrationStorage(Storage):
+
+    def _open(self, name, mode='rb'):
+        raise NotImplementedError
+
+    def _save(self, name, content):
+        return name
+
+
+def file_field_storage_callable():
+    return DummyMigrationStorage()
 
 
 class TextEnum(enum.Enum):
@@ -613,6 +627,25 @@ class WriterTests(SimpleTestCase):
 
         with self.assertRaisesMessage(ValueError, 'Could not find function upload_to in migrations.test_writer'):
             self.serialize_round_trip(TestModel2.thing)
+
+    def test_serialize_file_field_with_storage_callable(self):
+        field = models.FileField(storage=file_field_storage_callable)
+        string, imports = MigrationWriter.serialize(field)
+        self.assertTrue(string.startswith('models.FileField('))
+        self.assertIn(
+            'storage=migrations.test_writer.file_field_storage_callable',
+            string,
+        )
+        self.assertIn("upload_to=''", string)
+        self.assertNotIn('DummyMigrationStorage(', string)
+        self.assertIn('from django.db import models', imports)
+        self.assertIn('import migrations.test_writer', imports)
+        self.assertIsInstance(field.storage, DummyMigrationStorage)
+
+    def test_serialize_file_field_with_storage_lambda_errors(self):
+        field = models.FileField(storage=lambda: DummyMigrationStorage())
+        with self.assertRaisesMessage(ValueError, 'Cannot serialize function: lambda'):
+            MigrationWriter.serialize(field)
 
     def test_serialize_managers(self):
         self.assertSerializedEqual(models.Manager())


### PR DESCRIPTION
## Summary
- retain the original FileField storage argument for deconstruction while keeping runtime evaluation unchanged
- emit the stored storage argument in deconstruct() only when explicitly provided
- add tests covering FileField deconstruction and migration serialization for callable storage values

## Issue
Closes #236

## Reproduction (from #236)
1. Use the branch `django__django-13343` of this repository.
2. Create a minimal Django project and app, define a callable `storage` returning a non-deconstructible instance:

```python
# storageapp/models.py
from django.db import models
from django.core.files.storage import Storage

class MyStorage(Storage):
    def _open(self, name, mode='rb'):
        raise NotImplementedError
    def _save(self, name, content):
        raise NotImplementedError
    def exists(self, name):
        return False

_instance = MyStorage()

def produce_storage():
    return _instance

class Doc(models.Model):
    file = models.FileField(storage=produce_storage, upload_to='docs')
```

3. Run `makemigrations`:

```sh
python manage.py makemigrations storageapp
```

### Observed failure
```
Traceback (most recent call last):
  File "/workspace/repro/demo/manage.py", line 22, in <module>
    main()
  File "/workspace/repro/demo/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/workspace/django/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/workspace/django/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/workspace/django/django/core/management/base.py", line 350, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/workspace/django/django/core/management/base.py", line 394, in execute
    output = self.handle(*args, **options)
  File "/workspace/django/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/workspace/django/django/core/management/commands/makemigrations.py", line 190, in handle
    self.write_migration_files(changes)
  File "/workspace/django/django/core/management/commands/makemigrations.py", line 227, in write_migration_files
    migration_string = writer.as_string()
  File "/workspace/django/django/db/migrations/writer.py", line 141, in as_string
    operation_string, operation_imports = OperationWriter(operation).serialize()
  File "/workspace/django/django/db/migrations/writer.py", line 99, in serialize
    _write(arg_name, arg_value)
  File "/workspace/django/django/db/migrations/writer.py", line 51, in _write
    arg_string, arg_imports = MigrationWriter.serialize(item)
  File "/workspace/django/django/db/migrations/writer.py", line 271, in serialize
    return serializer_factory(value).serialize()
  File "/workspace/django/django/db/migrations/serializer.py", line 39, in serialize
    item_string, item_imports = serializer_factory(item).serialize()
  File "/workspace/django/django/db/migrations/serializer.py", line 201, in serialize
    return self.serialize_deconstructed(path, args, kwargs)
  File "/workspace/django/django/db/migrations/serializer.py", line 88, in serialize_deconstructed
    arg_string, arg_imports = serializer_factory(arg).serialize()
  File "/workspace/django/django/db/migrations/serializer.py", line 353, in serializer_factory
    raise ValueError(
ValueError: Cannot serialize: <storageapp.models.MyStorage object at 0xffff9da67cd0>
There are some values Django cannot serialize into migration files.
For more, see https://docs.djangoproject.com/en/dev/topics/migrations/#migration-serializing
```

### Expected behavior
`FileField.deconstruct()` should preserve the original callable for `storage` so migrations serialize a dotted-path callable reference, consistent with `upload_to`.

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py field_deconstruction migrations.test_writer --parallel=1
- flake8 django/db/models/fields/files.py tests/field_deconstruction/tests.py tests/migrations/test_writer.py
