### PR TITLE
Respect QuerySet.none() for combined queries; swev-id: django__django-13158

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -431,6 +431,8 @@ class SQLCompiler:
         return sql, params
 
     def get_combinator_sql(self, combinator, all):
+        if self.query.is_empty():
+            raise EmptyResultSet
         features = self.connection.features
         compilers = [
             query.get_compiler(self.using, self.connection)

--- a/tests/model_forms/test_modelmultiplechoicefield.py
+++ b/tests/model_forms/test_modelmultiplechoicefield.py
@@ -1,0 +1,48 @@
+from django import forms
+from django.test import TestCase, skipUnlessDBFeature
+
+from .models import Article, Category, Writer
+
+
+@skipUnlessDBFeature('supports_select_union')
+class ModelMultipleChoiceFieldUnionQuerysetTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.category_one = Category.objects.create(
+            name='Entertainment',
+            slug='entertainment',
+            url='entertainment',
+        )
+        cls.category_two = Category.objects.create(
+            name='A test',
+            slug='a-test',
+            url='test',
+        )
+        cls.writer = Writer.objects.create(name='Reporter')
+
+    def test_empty_submission_uses_none_queryset(self):
+        union_queryset = Category.objects.filter(pk=self.category_one.pk).union(
+            Category.objects.filter(pk=self.category_two.pk),
+        )
+
+        class ArticleCategoriesForm(forms.ModelForm):
+            categories = forms.ModelMultipleChoiceField(
+                queryset=union_queryset,
+                required=False,
+            )
+
+            class Meta:
+                model = Article
+                fields = ['headline', 'slug', 'pub_date', 'writer', 'article', 'categories']
+
+        form = ArticleCategoriesForm(data={
+            'headline': 'Union article',
+            'slug': 'union-article',
+            'pub_date': '2024-01-01',
+            'writer': self.writer.pk,
+            'article': 'Content',
+            'categories': [],
+        })
+        self.assertTrue(form.is_valid())
+        article = form.save()
+        self.assertEqual(article.categories.count(), 0)

--- a/tests/queries/test_qs_combinators.py
+++ b/tests/queries/test_qs_combinators.py
@@ -51,6 +51,14 @@ class QuerySetSetOperationTests(TestCase):
         self.assertEqual(len(list(qs1.union(qs2, all=True))), 20)
         self.assertEqual(len(list(qs1.union(qs2))), 10)
 
+    def test_union_none(self):
+        qs1 = Number.objects.filter(num__lte=1)
+        qs2 = Number.objects.filter(num__gte=8)
+        combined = qs1.union(qs2)
+        empty = combined.none()
+        self.assertEqual(empty.count(), 0)
+        self.assertEqual(list(empty), [])
+
     @skipUnlessDBFeature('supports_select_intersection')
     def test_intersection_with_empty_qs(self):
         qs1 = Number.objects.all()
@@ -63,6 +71,15 @@ class QuerySetSetOperationTests(TestCase):
         self.assertEqual(len(qs2.intersection(qs2)), 0)
         self.assertEqual(len(qs3.intersection(qs3)), 0)
 
+    @skipUnlessDBFeature('supports_select_intersection')
+    def test_intersection_none(self):
+        qs1 = Number.objects.filter(num__lte=5)
+        qs2 = Number.objects.filter(num__gte=8)
+        combined = qs1.intersection(qs2)
+        empty = combined.none()
+        self.assertEqual(empty.count(), 0)
+        self.assertEqual(list(empty), [])
+
     @skipUnlessDBFeature('supports_select_difference')
     def test_difference_with_empty_qs(self):
         qs1 = Number.objects.all()
@@ -74,6 +91,15 @@ class QuerySetSetOperationTests(TestCase):
         self.assertEqual(len(qs3.difference(qs1)), 0)
         self.assertEqual(len(qs2.difference(qs2)), 0)
         self.assertEqual(len(qs3.difference(qs3)), 0)
+
+    @skipUnlessDBFeature('supports_select_difference')
+    def test_difference_none(self):
+        qs1 = Number.objects.filter(num__lte=5)
+        qs2 = Number.objects.filter(num__lte=4)
+        combined = qs1.difference(qs2)
+        empty = combined.none()
+        self.assertEqual(empty.count(), 0)
+        self.assertEqual(list(empty), [])
 
     @skipUnlessDBFeature('supports_select_difference')
     def test_difference_with_values(self):


### PR DESCRIPTION
## Summary
- fix combined queryset compilations to short-circuit when `.none()` sets the query empty, matching Django's standard queryset behavior
- add coverage for `.none()` across `union`, `intersection`, and `difference` set combinators
- add a ModelMultipleChoiceField integration test ensuring empty submissions with a union queryset do not create relations

## Testing
- PYTHONPATH=$PWD:/nix/store/rc2bs7x39whj4qdg7qjcp24syhwcnvfk-python3.11-asgiref-3.9.1/lib/python3.11/site-packages:/nix/store/a140xg0rk6qzfsz71civ1pawk868aqlr-python3.11-sqlparse-0.5.3/lib/python3.11/site-packages:/nix/store/4l22mwwz62pn6rpa9v0m9h1x1y8apydj-python3.11-pytz-2025.2/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py queries.test_qs_combinators.QuerySetSetOperationTests --parallel=1
- PYTHONPATH=$PWD:/nix/store/rc2bs7x39whj4qdg7qjcp24syhwcnvfk-python3.11-asgiref-3.9.1/lib/python3.11/site-packages:/nix/store/a140xg0rk6qzfsz71civ1pawk868aqlr-python3.11-sqlparse-0.5.3/lib/python3.11/site-packages:/nix/store/4l22mwwz62pn6rpa9v0m9h1x1y8apydj-python3.11-pytz-2025.2/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py model_forms.test_modelmultiplechoicefield --parallel=1
- flake8 django/db/models/sql/compiler.py tests/queries/test_qs_combinators.py tests/model_forms/test_modelmultiplechoicefield.py

## Issue
https://github.com/agyn-sandbox/django/issues/233

## Reproduction Steps
1. Build two compatible querysets (e.g., `Number.objects.filter(num__lte=1)` and `Number.objects.filter(num__gte=8)`) and combine them with `union`.
2. Call `.none()` on the combined queryset and evaluate it (`list(union.none())` or `.count()`).
3. Observe that results from the combined query are still returned instead of an empty set.

## Observed Failure
Combined querysets using `.none()` continue to yield rows, causing downstream APIs (e.g., ModelMultipleChoiceField) to treat empty selections as populated.

### Pre-fix Failing Test Output
```
Creating test database for alias 'default'...
F
======================================================================
FAIL: test_union_none (queries.test_qs_combinators.QuerySetSetOperationTests.test_union_none)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/queries/test_qs_combinators.py", line 59, in test_union_none
    self.assertEqual(empty.count(), 0)
AssertionError: 4 != 0

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (failures=1)
Destroying test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
System check identified no issues (1 silenced).
```

## Fix Details
- `django/db/models/sql/compiler.py`: raise `EmptyResultSet` immediately when `self.query.is_empty()` inside `get_combinator_sql`, ensuring downstream combinators respect `.none()`.
- `tests/queries/test_qs_combinators.py`: add regression coverage for `.none()` on `union`, `intersection`, and `difference`.
- `tests/model_forms/test_modelmultiplechoicefield.py`: new integration test covering `ModelMultipleChoiceField` with a union queryset to guarantee empty submissions stay empty.

CI intentionally not run; all relevant tests executed locally.