### PR TITLE
Dedup ModelChoiceField choices for limit_choices_to joins (swev-id: django__django-13315)

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -7,6 +7,7 @@ from itertools import chain
 
 from django.core.exceptions import (
     NON_FIELD_ERRORS, FieldError, ImproperlyConfigured, ValidationError,
+    MultipleObjectsReturned,
 )
 from django.forms.fields import ChoiceField, Field
 from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
@@ -1158,7 +1159,12 @@ class ModelChoiceIterator:
         # Can't use iterator() when queryset uses prefetch_related()
         if not queryset._prefetch_related_lookups:
             queryset = queryset.iterator()
+        seen = set()
         for obj in queryset:
+            key = str(self.field.prepare_value(obj))
+            if key in seen:
+                continue
+            seen.add(key)
             yield self.choice(obj)
 
     def __len__(self):
@@ -1272,11 +1278,15 @@ class ModelChoiceField(ChoiceField):
     def to_python(self, value):
         if value in self.empty_values:
             return None
+        key = self.to_field_name or 'pk'
+        if isinstance(value, self.queryset.model):
+            value = getattr(value, key)
         try:
-            key = self.to_field_name or 'pk'
-            if isinstance(value, self.queryset.model):
-                value = getattr(value, key)
             value = self.queryset.get(**{key: value})
+        except MultipleObjectsReturned:
+            value = self.queryset.filter(**{key: value}).first()
+            if value is None:
+                raise ValidationError(self.error_messages['invalid_choice'], code='invalid_choice')
         except (ValueError, TypeError, self.queryset.model.DoesNotExist):
             raise ValidationError(self.error_messages['invalid_choice'], code='invalid_choice')
         return value
@@ -1370,6 +1380,18 @@ class ModelMultipleChoiceField(ModelChoiceField):
                     code='invalid_choice',
                     params={'value': val},
                 )
+        if qs._result_cache is not None:
+            unique = []
+            seen = set()
+            prepare_value = super().prepare_value
+            for obj in qs._result_cache:
+                identifier = str(prepare_value(obj))
+                if identifier in seen:
+                    continue
+                seen.add(identifier)
+                unique.append(obj)
+            if len(unique) != len(qs._result_cache):
+                qs._result_cache = unique
         return qs
 
     def prepare_value(self, value):

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -7,7 +7,6 @@ from itertools import chain
 
 from django.core.exceptions import (
     NON_FIELD_ERRORS, FieldError, ImproperlyConfigured, ValidationError,
-    MultipleObjectsReturned,
 )
 from django.forms.fields import ChoiceField, Field
 from django.forms.forms import BaseForm, DeclarativeFieldsMetaclass
@@ -1283,10 +1282,11 @@ class ModelChoiceField(ChoiceField):
             value = getattr(value, key)
         try:
             value = self.queryset.get(**{key: value})
-        except MultipleObjectsReturned:
-            value = self.queryset.filter(**{key: value}).first()
-            if value is None:
-                raise ValidationError(self.error_messages['invalid_choice'], code='invalid_choice')
+        except self.queryset.model.MultipleObjectsReturned:
+            matches = list(self.queryset.filter(**{key: value}))
+            if matches and {obj.pk for obj in matches} == {matches[0].pk}:
+                return matches[0]
+            raise ValidationError(self.error_messages['invalid_choice'], code='invalid_choice')
         except (ValueError, TypeError, self.queryset.model.DoesNotExist):
             raise ValidationError(self.error_messages['invalid_choice'], code='invalid_choice')
         return value
@@ -1382,13 +1382,11 @@ class ModelMultipleChoiceField(ModelChoiceField):
                 )
         if qs._result_cache is not None:
             unique = []
-            seen = set()
-            prepare_value = super().prepare_value
+            seen_pks = set()
             for obj in qs._result_cache:
-                identifier = str(prepare_value(obj))
-                if identifier in seen:
+                if obj.pk in seen_pks:
                     continue
-                seen.add(identifier)
+                seen_pks.add(obj.pk)
                 unique.append(obj)
             if len(unique) != len(qs._result_cache):
                 qs._result_cache = unique

--- a/tests/model_forms/models.py
+++ b/tests/model_forms/models.py
@@ -7,6 +7,7 @@ from django.core import validators
 from django.core.exceptions import ValidationError
 from django.core.files.storage import FileSystemStorage
 from django.db import models
+from django.db.models import Q
 
 temp_storage_dir = tempfile.mkdtemp()
 temp_storage = FileSystemStorage(temp_storage_dir)
@@ -154,6 +155,30 @@ class CustomFF(models.Model):
 
 class FilePathModel(models.Model):
     path = models.FilePathField(path=os.path.dirname(__file__), match='models.py', blank=True)
+
+
+class Staff(models.Model):
+    name = models.CharField(max_length=50)
+    code = models.CharField(max_length=20, unique=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Department(models.Model):
+    name = models.CharField(max_length=50)
+    staff = models.ForeignKey(Staff, models.CASCADE)
+
+    def __str__(self):
+        return self.name
+
+
+class Assignment(models.Model):
+    staff = models.ForeignKey(
+        Staff,
+        models.CASCADE,
+        limit_choices_to=Q(department__name='HR'),
+    )
 
 
 try:

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -421,6 +421,16 @@ class ModelChoiceFieldLimitChoicesToJoinTests(TestCase):
         ])
         self.assertEqual(field.clean(self.alice.code), self.alice)
 
+    def test_to_field_name_non_unique_raises_invalid_choice(self):
+        other_alice = Staff.objects.create(name='Alice', code='ALICE-DUP')
+        Department.objects.create(name='HR', staff=other_alice)
+        field = forms.ModelChoiceField(
+            Staff.objects.filter(department__name='HR'),
+            to_field_name='name',
+        )
+        with self.assertRaises(ValidationError):
+            field.clean('Alice')
+
     def test_modelmultiplechoicefield_dedup_parity(self):
         field = forms.ModelMultipleChoiceField(
             Staff.objects.filter(department__name='HR'),

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -7,7 +7,7 @@ from django.forms.widgets import CheckboxSelectMultiple
 from django.template import Context, Template
 from django.test import TestCase
 
-from .models import Article, Author, Book, Category, Writer
+from .models import Assignment, Article, Author, Book, Category, Department, Staff, Writer
 
 
 class ModelChoiceFieldTests(TestCase):
@@ -373,3 +373,65 @@ class ModelChoiceFieldTests(TestCase):
         )
         with self.assertNumQueries(2):
             template.render(Context({'form': CategoriesForm()}))
+
+
+class ModelChoiceFieldLimitChoicesToJoinTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.alice = Staff.objects.create(name='Alice', code='ALICE')
+        cls.bruno = Staff.objects.create(name='Bruno', code='BRUNO')
+        cls.cara = Staff.objects.create(name='Cara', code='CARA')
+        cls.alice_hr_primary = Department.objects.create(name='HR', staff=cls.alice)
+        cls.alice_hr_secondary = Department.objects.create(name='HR', staff=cls.alice)
+        cls.bruno_hr = Department.objects.create(name='HR', staff=cls.bruno)
+        cls.cara_engineering = Department.objects.create(name='Engineering', staff=cls.cara)
+
+    def test_limit_choices_to_join_deduplicates_choices(self):
+        class AssignmentForm(forms.ModelForm):
+            class Meta:
+                model = Assignment
+                fields = ['staff']
+
+        choices = list(AssignmentForm().fields['staff'].choices)
+        self.assertEqual(choices[0], ('', '---------'))
+        self.assertEqual(choices[1:], [
+            (self.alice.pk, 'Alice'),
+            (self.bruno.pk, 'Bruno'),
+        ])
+
+    def test_clean_accepts_selected_pk_after_dedup(self):
+        class AssignmentForm(forms.ModelForm):
+            class Meta:
+                model = Assignment
+                fields = ['staff']
+
+        field = AssignmentForm().fields['staff']
+        self.assertEqual(field.clean(str(self.alice.pk)), self.alice)
+
+    def test_to_field_name_dedup_and_clean(self):
+        field = forms.ModelChoiceField(
+            Staff.objects.filter(department__name='HR'),
+            to_field_name='code',
+        )
+        choices = list(field.choices)
+        self.assertEqual(choices[0], ('', '---------'))
+        self.assertEqual(choices[1:], [
+            (self.alice.code, 'Alice'),
+            (self.bruno.code, 'Bruno'),
+        ])
+        self.assertEqual(field.clean(self.alice.code), self.alice)
+
+    def test_modelmultiplechoicefield_dedup_parity(self):
+        field = forms.ModelMultipleChoiceField(
+            Staff.objects.filter(department__name='HR'),
+        )
+        self.assertEqual(list(field.choices), [
+            (self.alice.pk, 'Alice'),
+            (self.bruno.pk, 'Bruno'),
+        ])
+        cleaned = field.clean([
+            str(self.alice.pk),
+            str(self.alice.pk),
+            str(self.bruno.pk),
+        ])
+        self.assertCountEqual([obj.pk for obj in cleaned], [self.alice.pk, self.bruno.pk])


### PR DESCRIPTION
## Summary
- add regression models and tests covering ForeignKey choices filtered via joins in `limit_choices_to`
- deduplicate `ModelChoiceIterator` output by tracking `prepare_value()` keys while preserving the empty label and order
- ensure `ModelChoiceField.clean()` and `ModelMultipleChoiceField.clean()` tolerate duplicate join rows for the same object while surfacing `invalid_choice` for genuinely ambiguous to_field values

## Issue
- Closes #235

## Reproduction Steps
1. Checkout the base branch with the regression tests applied
2. PYTHONPATH=$PWD python tests/runtests.py model_forms.test_modelchoicefield.ModelChoiceFieldLimitChoicesToJoinTests --parallel=1

### Observed Failure
```text
Creating test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
System check identified no issues (0 silenced).
EFFF
======================================================================
ERROR: test_clean_accepts_selected_pk_after_dedup (model_forms.test_modelchoicefield.ModelChoiceFieldLimitChoicesToJoinTests.test_clean_accepts_selected_pk_after_dedup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/test_modelchoicefield.py", line 409, in test_clean_accepts_selected_pk_after_dedup
    self.assertEqual(field.clean(str(self.alice.pk)), self.alice)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/forms/fields.py", line 149, in clean
    value = self.to_python(value)
            ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/forms/models.py", line 1279, in to_python
    value = self.queryset.get(**{key: value})
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/models/query.py", line 439, in get
    raise self.model.MultipleObjectsReturned(
model_forms.models.Staff.MultipleObjectsReturned: get() returned more than one Staff -- it returned 2!

======================================================================
FAIL: test_limit_choices_to_join_deduplicates_choices (model_forms.test_modelchoicefield.ModelChoiceFieldLimitChoicesToJoinTests.test_limit_choices_to_join_deduplicates_choices)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/test_modelchoicefield.py", line 397, in test_limit_choices_to_join_deduplicates_choices
    self.assertEqual(choices[1:], [
AssertionError: Lists differ: [(<django.forms.models.ModelChoiceIteratorV[204 chars]no')] != [(1, 'Alice'), (2, 'Bruno')]

First differing element 1:
(<django.forms.models.ModelChoiceIteratorV[35 chars]ice')
(2, 'Bruno')

First list contains 1 additional elements.
First extra element 2:
(<django.forms.models.ModelChoiceIteratorValue object at 0xffff819ab1d0>, 'Bruno')

+ [(1, 'Alice'), (2, 'Bruno')]
- [(<django.forms.models.ModelChoiceIteratorValue object at 0xffff819ab050>,
-   'Alice'),
-  (<django.forms.models.ModelChoiceIteratorValue object at 0xffff819ab110>,
-   'Alice'),
-  (<django.forms.models.ModelChoiceIteratorValue object at 0xffff819ab1d0>,
-   'Bruno')]

======================================================================
FAIL: test_modelmultiplechoicefield_dedup_parity (model_forms.test_modelchoicefield.ModelChoiceFieldLimitChoicesToJoinTests.test_modelmultiplechoicefield_dedup_parity)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/test_modelchoicefield.py", line 428, in test_modelmultiplechoicefield_dedup_parity
    self.assertEqual(list(field.choices), [
AssertionError: Lists differ: [(<django.forms.models.ModelChoiceIteratorV[204 chars]no')] != [(1, 'Alice'), (2, 'Bruno')]

======================================================================
FAIL: test_to_field_name_dedup_and_clean (model_forms.test_modelchoicefield.ModelChoiceFieldLimitChoicesToJoinTests.test_to_field_name_dedup_and_clean)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/test_modelchoicefield.py", line 418, in test_to_field_name_deduplicates_choices
    self.assertEqual(choices[1:], [
AssertionError: Lists differ: [(<django.forms.models.ModelChoiceIteratorV[204 chars]no')] != [('ALICE', 'Alice'), ('BRUNO', 'Bruno')]

----------------------------------------------------------------------
Ran 4 tests in 0.004s

FAILED (failures=3, errors=1)
Destroying test database for alias 'default'...
```

## Testing
- PYTHONPATH=$PWD python tests/runtests.py model_forms.test_modelchoicefield --parallel=1
- flake8 django/forms/models.py tests/model_forms/models.py tests/model_forms/test_modelchoicefield.py

Python-side dedup preserves validation behaviour and avoids adding `distinct()` or other queryset changes.