### PR TITLE
Fix duration-only arithmetic on SQLite/MySQL (swev-id: django__django-13121)

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -550,6 +550,10 @@ def _sqlite_format_dtdelta(conn, lhs, rhs):
     - An integer number of microseconds
     - A string representing a datetime
     """
+    if isinstance(lhs, int) and isinstance(rhs, int):
+        if conn.strip() == '+':
+            return lhs + rhs
+        return lhs - rhs
     try:
         real_lhs = datetime.timedelta(0, 0, lhs) if isinstance(lhs, int) else backend_utils.typecast_timestamp(lhs)
         real_rhs = datetime.timedelta(0, 0, rhs) if isinstance(rhs, int) else backend_utils.typecast_timestamp(rhs)

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -9,6 +9,7 @@ from django.db.models import fields
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import Q
 from django.utils.deconstruct import deconstructible
+from django.utils.duration import duration_microseconds
 from django.utils.functional import cached_property
 from django.utils.hashable import make_hashable
 
@@ -479,6 +480,25 @@ class CombinedExpression(SQLiteNumericMixin, Expression):
 
 
 class DurationExpression(CombinedExpression):
+    def _is_duration_operand(self, expr):
+        if isinstance(expr, DurationValue):
+            return True
+        try:
+            output = expr.output_field
+        except (AttributeError, FieldError):
+            return False
+        if output is None:
+            return False
+        try:
+            internal_type = output.get_internal_type()
+        except FieldError:
+            return False
+        if internal_type != 'DurationField':
+            return False
+        if isinstance(expr, Value) and getattr(expr, 'value', None) is None:
+            return False
+        return True
+
     def compile(self, side, compiler, connection):
         if not isinstance(side, DurationValue):
             try:
@@ -491,8 +511,40 @@ class DurationExpression(CombinedExpression):
                     return connection.ops.format_for_duration_arithmetic(sql), params
         return compiler.compile(side)
 
+    def _compile_duration_operand(self, expression, compiler, connection):
+        if isinstance(expression, DurationValue):
+            return str(duration_microseconds(expression.value)), []
+        if isinstance(expression, Value):
+            try:
+                output = expression.output_field
+            except (AttributeError, FieldError):
+                output = None
+            if output is not None:
+                try:
+                    internal_type = output.get_internal_type()
+                except FieldError:
+                    internal_type = None
+                else:
+                    if internal_type == 'DurationField':
+                        value = expression.value
+                        if value is not None:
+                            return str(duration_microseconds(value)), []
+        return compiler.compile(expression)
+
     def as_sql(self, compiler, connection):
         connection.ops.check_expression_support(self)
+        if (
+            self.connector in {'+', '-'} and
+            not connection.features.has_native_duration_field and
+            self._is_duration_operand(self.lhs) and
+            self._is_duration_operand(self.rhs)
+        ):
+            if connection.vendor in {'sqlite', 'mysql', 'mariadb'}:
+                lhs_sql, lhs_params = self._compile_duration_operand(self.lhs, compiler, connection)
+                rhs_sql, rhs_params = self._compile_duration_operand(self.rhs, compiler, connection)
+                sql = connection.ops.combine_expression(self.connector, [lhs_sql, rhs_sql])
+                params = (*lhs_params, *rhs_params)
+                return f'({sql})', params
         expressions = []
         expression_params = []
         sql, params = self.compile(self.lhs, compiler, connection)

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1445,6 +1445,31 @@ class FTimeDeltaTests(TestCase):
             self.assertEqual(expected_ends, new_ends)
             self.assertEqual(expected_durations, new_durations)
 
+    def test_duration_only_arithmetic(self):
+        large_delta = datetime.timedelta(days=10000)
+        negative_offset = datetime.timedelta(days=120)
+        queryset = Experiment.objects.order_by('name').annotate(
+            doubled=F('estimated_time') + F('estimated_time'),
+            with_large=F('estimated_time') + large_delta,
+            negative=F('estimated_time') - negative_offset,
+        ).values_list('doubled', 'with_large', 'negative')
+        experiments = list(Experiment.objects.order_by('name'))
+        for experiment, (doubled, with_large, negative) in zip(experiments, queryset):
+            self.assertIsInstance(doubled, datetime.timedelta)
+            self.assertIsInstance(with_large, datetime.timedelta)
+            self.assertIsInstance(negative, datetime.timedelta)
+            self.assertEqual(doubled, experiment.estimated_time + experiment.estimated_time)
+            self.assertEqual(with_large, experiment.estimated_time + large_delta)
+            self.assertEqual(negative, experiment.estimated_time - negative_offset)
+
+    @unittest.skipUnless(connection.vendor == 'sqlite', 'SQLite-specific SQL assertion.')
+    def test_sqlite_duration_only_uses_numeric_sql(self):
+        query = Experiment.objects.annotate(
+            summed=F('estimated_time') + F('estimated_time'),
+            shifted=F('estimated_time') - datetime.timedelta(days=1),
+        ).query
+        self.assertNotIn('django_format_dtdelta', str(query))
+
     def test_invalid_operator(self):
         with self.assertRaises(DatabaseError):
             list(Experiment.objects.filter(start=F('start') * datetime.timedelta(0)))


### PR DESCRIPTION
## Summary
This PR fixes DurationField-only arithmetic on SQLite/MySQL by treating it as numeric microseconds addition/subtraction on backends without native duration support. Mixed temporal arithmetic (datetime/time +/- duration) remains unchanged.

- Update `DurationExpression.as_sql()` to detect duration-only context and emit numeric microseconds arithmetic for SQLite/MySQL.
- Harden SQLite UDF `_sqlite_format_dtdelta` to return integer microseconds when both inputs are integers.
- Add regression tests for duration-only annotations, including negative and large durations.

## Reproduction Steps
Using agyn-sandbox/django, branch `django__django-13121`:

```python
class Experiment(models.Model):
    estimated_time = models.DurationField()

list(Experiment.objects.annotate(duration=F('estimated_time') + datetime.timedelta(1)))
```

## Observed Failure
```
Traceback (most recent call last):
  File "/home/sergey/dev/django/tests/expressions/tests.py", line 1218, in test_duration_expressions
    list(Experiment.objects.annotate(duration=F('estimated_time') + delta))
  File "/home/sergey/dev/django/django/db/models/query.py", line 269, in __iter__
    self._fetch_all()
  File "/home/sergey/dev/django/django/db/models/query.py", line 1172, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/home/sergey/dev/django/django/db/models/query.py", line 63, in __iter__
    for row in compiler.results_iter(results):
  File "/home/sergey/dev/django/django/db/models/sql/compiler.py", line 998, in apply_converters
    value = converter(value, expression, connection)
  File "/home/sergey/dev/django/django/db/backends/base/operations.py", line 571, in convert_durationfield_value
    value = str(decimal.Decimal(value) / decimal.Decimal(1000000))
decimal.InvalidOperation: [<class 'decimal.ConversionSyntax'>]
```

## Linked Issue
Fixes #232
Issue link: https://github.com/agyn-sandbox/django/issues/232

## Implementation Details
- SQLite: Avoid `django_format_dtdelta` for duration-only arithmetic, perform `(col + microseconds)` numerically. UDF returns integer microseconds for int-int cases as a safety net.
- MySQL: Compile DurationField as BIGINT and DurationValue as integer microseconds; combine numerically. INTERVAL usage retained only for mixed temporal arithmetic.

## Notes
- Do not run CI manually for this PR.
- Base branch: `django__django-13121`.
- Task reference: swev-id: django__django-13121