### PR TITLE
Fix SessionBase.encode for sha1 legacy compatibility — swev-id: django__django-13279

### DIFF
--- a/django/contrib/sessions/backends/base.py
+++ b/django/contrib/sessions/backends/base.py
@@ -108,6 +108,13 @@ class SessionBase:
 
     def encode(self, session_dict):
         "Return the given session dictionary serialized and encoded as a string."
+        default_algorithm = getattr(settings, 'DEFAULT_HASHING_ALGORITHM', 'sha256')
+        if default_algorithm == 'sha1':
+            serializer = self.serializer()
+            serialized = serializer.dumps(session_dict)
+            legacy_hash = self._hash(serialized)
+            encoded = base64.b64encode(legacy_hash.encode() + b":" + serialized)
+            return encoded.decode('ascii')
         return signing.dumps(
             session_dict, salt=self.key_salt, serializer=self.serializer,
             compress=True,

--- a/tests/sessions_tests/tests.py
+++ b/tests/sessions_tests/tests.py
@@ -34,6 +34,7 @@ from django.test import (
     RequestFactory, TestCase, ignore_warnings, override_settings,
 )
 from django.utils import timezone
+from django.utils.deprecation import RemovedInDjango40Warning
 
 from .models import SessionStore as CustomDatabaseSession
 
@@ -310,6 +311,17 @@ class SessionTestsMixin:
         data = {'a test key': 'a test value'}
         encoded = self.session.encode(data)
         self.assertEqual(self.session.decode(encoded), data)
+
+    @ignore_warnings(category=RemovedInDjango40Warning)
+    @override_settings(DEFAULT_HASHING_ALGORITHM='sha1')
+    def test_encode_legacy_format_with_sha1(self):
+        session = self.backend()
+        data = {'a test key': 'a test value'}
+        serializer = session.serializer()
+        serialized = serializer.dumps(data)
+        expected_hash = session._hash(serialized)
+        expected = base64.b64encode(expected_hash.encode() + b":" + serialized).decode('ascii')
+        self.assertEqual(session.encode(data), expected)
 
     @override_settings(SECRET_KEY='django_tests_secret_key')
     def test_decode_legacy(self):


### PR DESCRIPTION
## Summary
- make `SessionBase.encode()` fallback to legacy base64 payload when `DEFAULT_HASHING_ALGORITHM` is `sha1`
- cover the legacy branch with `SessionTestsMixin.test_encode_legacy_format_with_sha1`

## Issue
Closes #228

## Reproduction
1. In a Django 3.2 environment configured with `SESSION_ENGINE = 'django.contrib.sessions.backends.db'`, `SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'`, and `DEFAULT_HASHING_ALGORITHM = 'sha1'`, create a session using `SessionStore().save()` (pre-fix builds encode with `signing.dumps`).
2. Copy the resulting row into a Django 3.0 deployment using the same database.
3. Attempt to read the session via `SessionStore(session_key).load()`.

## Observed failure
```
Traceback (most recent call last):
  File "/workspace/repro/read_session_pickle.py", line 40, in main
    data = store.load()
  File "/workspace/venv30/lib/python3.8/site-packages/django/contrib/sessions/backends/db.py", line 44, in load
    return self.decode(s.session_data) if s else {}
  File "/workspace/venv30/lib/python3.8/site-packages/django/contrib/sessions/backends/base.py", line 110, in decode
    encoded_data = base64.b64decode(session_data.encode('ascii'))
  File "/usr/lib/python3.8/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Incorrect padding
```

## Validation
- `PYTHONPATH=/workspace/django /workspace/venv31/bin/python tests/runtests.py sessions_tests --parallel=1`
- `/workspace/venv31/bin/flake8 django/contrib/sessions/backends/base.py tests/sessions_tests/tests.py`
- Manual verification: session created under Django 3.2 with `DEFAULT_HASHING_ALGORITHM='sha1'` now decodes successfully under Django 3.0.

_No GitHub Actions run requested._