### PR TITLE
fix: swev-id: django__django-13346 handle JSONField key __in lookup

### DIFF
--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -378,6 +378,30 @@ class KeyTransformIsNull(lookups.IsNull):
         return super().as_sql(compiler, connection)
 
 
+class KeyTransformIn(lookups.In):
+    def process_rhs(self, compiler, connection):
+        rhs, rhs_params = super().process_rhs(compiler, connection)
+        if not connection.features.has_native_json_field:
+            func = ()
+            if connection.vendor == 'oracle':
+                func = []
+                for value in rhs_params:
+                    value = json.loads(value)
+                    function = 'JSON_QUERY' if isinstance(value, (list, dict)) else 'JSON_VALUE'
+                    func.append("%s('%s', '$.value')" % (
+                        function,
+                        json.dumps({'value': value}),
+                    ))
+                func = tuple(func)
+                rhs_params = ()
+            elif connection.vendor == 'mysql' and connection.mysql_is_mariadb:
+                func = ("JSON_UNQUOTE(JSON_EXTRACT(%s, '$'))",) * len(rhs_params)
+            elif connection.vendor in {'sqlite', 'mysql'}:
+                func = ("JSON_EXTRACT(%s, '$')",) * len(rhs_params)
+            rhs = rhs % func
+        return rhs, rhs_params
+
+
 class KeyTransformExact(JSONExact):
     def process_lhs(self, compiler, connection):
         lhs, lhs_params = super().process_lhs(compiler, connection)
@@ -479,6 +503,7 @@ class KeyTransformGte(KeyTransformNumericLookupMixin, lookups.GreaterThanOrEqual
     pass
 
 
+KeyTransform.register_lookup(KeyTransformIn)
 KeyTransform.register_lookup(KeyTransformExact)
 KeyTransform.register_lookup(KeyTransformIExact)
 KeyTransform.register_lookup(KeyTransformIsNull)

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -627,6 +627,25 @@ class TestQuerying(TestCase):
         self.assertIs(NullableJSONModel.objects.filter(value__foo__iexact='BaR').exists(), True)
         self.assertIs(NullableJSONModel.objects.filter(value__foo__iexact='"BaR"').exists(), False)
 
+    def test_key_in(self):
+        tests = [
+            ('value__c__in', [14], self.objs[3:5]),
+            ('value__c__in', [14, 15], self.objs[3:5]),
+            ('value__0__in', [1], [self.objs[5]]),
+            ('value__0__in', [1, 3], [self.objs[5]]),
+            ('value__foo__in', ['bar'], [self.objs[7]]),
+            ('value__foo__in', ['bar', 'baz'], [self.objs[7]]),
+            ('value__bar__in', [['foo', 'bar']], [self.objs[7]]),
+            ('value__bar__in', [['foo', 'bar'], ['a']], [self.objs[7]]),
+            ('value__bax__in', [{'foo': 'bar'}, {'a': 'b'}], [self.objs[7]]),
+        ]
+        for lookup, value, expected in tests:
+            with self.subTest(lookup=lookup, value=value):
+                self.assertSequenceEqual(
+                    NullableJSONModel.objects.filter(**{lookup: value}),
+                    expected,
+                )
+
     @skipUnlessDBFeature('supports_json_field_contains')
     def test_key_contains(self):
         self.assertIs(NullableJSONModel.objects.filter(value__foo__contains='ar').exists(), False)

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -637,6 +637,7 @@ class TestQuerying(TestCase):
             ('value__foo__in', ['bar', 'baz'], [self.objs[7]]),
             ('value__bar__in', [['foo', 'bar']], [self.objs[7]]),
             ('value__bar__in', [['foo', 'bar'], ['a']], [self.objs[7]]),
+            ('value__bax__in', [{'foo': 'bar'}], [self.objs[7]]),
             ('value__bax__in', [{'foo': 'bar'}, {'a': 'b'}], [self.objs[7]]),
         ]
         for lookup, value, expected in tests:


### PR DESCRIPTION
## Summary
- add KeyTransformIn to wrap JSON __in RHS when the backend lacks native JSON support
- inline Oracle JSON_QUERY/JSON_VALUE arguments and adjust MySQL/MariaDB/SQLite RHS extraction
- add regression coverage for key __in lookups on JSONField transforms

## Reproduction Steps
1. Checkout `django__django-13346`
2. Run `PYTHONPATH=/workspace/django ./runtests.py model_fields.test_jsonfield --parallel=1`

## Observed Failure and Logs (pre-fix)
The new regression test fails across all subcases, e.g.:
```
FAIL: test_key_in (model_fields.test_jsonfield.TestQuerying.test_key_in) (lookup='value__c__in', value=[14])
Traceback (most recent call last):
  File "/workspace/django/tests/model_fields/test_jsonfield.py", line 644, in test_key_in
    self.assertSequenceEqual(
AssertionError: Sequences differ: <QuerySet []> != [<NullableJSONModel: NullableJSONModel object (4)>, <NullableJSONModel: NullableJSONModel object (5)>]
```

## After Fix
- SQLite: `PYTHONPATH=/workspace/django ./runtests.py model_fields.test_jsonfield --parallel=1`
- Lint: `flake8 django/db/models/fields/json.py tests/model_fields/test_jsonfield.py`

Closes #238.