### PR TITLE
Fix ASGI coroutine leaking into first middleware's process_response via missing super().__init__ (swev-id: django__django-13344)

### DIFF
--- a/django/middleware/cache.py
+++ b/django/middleware/cache.py
@@ -64,13 +64,12 @@ class UpdateCacheMiddleware(MiddlewareMixin):
     # RemovedInDjango40Warning: when the deprecation ends, replace with:
     #   def __init__(self, get_response):
     def __init__(self, get_response=None):
-        self._get_response_none_deprecation(get_response)
+        super().__init__(get_response)
         self.cache_timeout = settings.CACHE_MIDDLEWARE_SECONDS
         self.page_timeout = None
         self.key_prefix = settings.CACHE_MIDDLEWARE_KEY_PREFIX
         self.cache_alias = settings.CACHE_MIDDLEWARE_ALIAS
         self.cache = caches[self.cache_alias]
-        self.get_response = get_response
 
     def _should_update_cache(self, request, response):
         return hasattr(request, '_cache_update_cache') and request._cache_update_cache
@@ -128,11 +127,10 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
     # RemovedInDjango40Warning: when the deprecation ends, replace with:
     #   def __init__(self, get_response):
     def __init__(self, get_response=None):
-        self._get_response_none_deprecation(get_response)
+        super().__init__(get_response)
         self.key_prefix = settings.CACHE_MIDDLEWARE_KEY_PREFIX
         self.cache_alias = settings.CACHE_MIDDLEWARE_ALIAS
         self.cache = caches[self.cache_alias]
-        self.get_response = get_response
 
     def process_request(self, request):
         """
@@ -173,8 +171,7 @@ class CacheMiddleware(UpdateCacheMiddleware, FetchFromCacheMiddleware):
     # RemovedInDjango40Warning: when the deprecation ends, replace with:
     #   def __init__(self, get_response, cache_timeout=None, page_timeout=None, **kwargs):
     def __init__(self, get_response=None, cache_timeout=None, page_timeout=None, **kwargs):
-        self._get_response_none_deprecation(get_response)
-        self.get_response = get_response
+        super().__init__(get_response)
         # We need to differentiate between "provided, but using default value",
         # and "not provided". If the value is provided using a default, then
         # we fall back to system defaults. If it is not provided at all,

--- a/django/middleware/security.py
+++ b/django/middleware/security.py
@@ -9,7 +9,7 @@ class SecurityMiddleware(MiddlewareMixin):
     # RemovedInDjango40Warning: when the deprecation ends, replace with:
     #   def __init__(self, get_response):
     def __init__(self, get_response=None):
-        self._get_response_none_deprecation(get_response)
+        super().__init__(get_response)
         self.sts_seconds = settings.SECURE_HSTS_SECONDS
         self.sts_include_subdomains = settings.SECURE_HSTS_INCLUDE_SUBDOMAINS
         self.sts_preload = settings.SECURE_HSTS_PRELOAD
@@ -19,7 +19,6 @@ class SecurityMiddleware(MiddlewareMixin):
         self.redirect_host = settings.SECURE_SSL_HOST
         self.redirect_exempt = [re.compile(r) for r in settings.SECURE_REDIRECT_EXEMPT]
         self.referrer_policy = settings.SECURE_REFERRER_POLICY
-        self.get_response = get_response
 
     def process_request(self, request):
         path = request.path.lstrip("/")

--- a/tests/middleware/test_async_middleware.py
+++ b/tests/middleware/test_async_middleware.py
@@ -1,0 +1,85 @@
+import asyncio
+from unittest.mock import patch
+
+from asgiref.testing import ApplicationCommunicator
+
+from django.conf import settings
+from django.core.asgi import get_asgi_application
+from django.core.cache import caches
+from django.http import HttpResponse
+from django.http.response import HttpResponseBase
+from django.middleware.cache import CacheMiddleware, UpdateCacheMiddleware
+from django.middleware.security import SecurityMiddleware
+from django.test import AsyncRequestFactory, SimpleTestCase, override_settings
+from django.urls import path
+
+
+async def async_ok_view(request):
+    return HttpResponse('ok')
+
+
+urlpatterns = [
+    path('', async_ok_view),
+]
+
+
+class AsyncMiddlewareProcessResponseTests(SimpleTestCase):
+    async_request_factory = AsyncRequestFactory()
+
+    async def _communicate_via_asgi(self):
+        application = get_asgi_application()
+        scope = self.async_request_factory._base_scope(path='/')
+        communicator = ApplicationCommunicator(application, scope)
+        await communicator.send_input({'type': 'http.request'})
+        response_start = await communicator.receive_output()
+        self.assertEqual(response_start['type'], 'http.response.start')
+        self.assertEqual(response_start['status'], 200)
+        response_body = await communicator.receive_output()
+        self.assertEqual(response_body['type'], 'http.response.body')
+        self.assertEqual(response_body['body'], b'ok')
+        await communicator.wait()
+
+    async def _assert_process_response_receives_http_response(self, middleware, middleware_class):
+        caches[settings.CACHE_MIDDLEWARE_ALIAS].clear()
+        original = middleware_class.process_response
+
+        def assert_wrapper(middleware_self, request, response):
+            self.assertIsInstance(response, HttpResponseBase)
+            self.assertFalse(asyncio.iscoroutine(response))
+            result = original(middleware_self, request, response)
+            stream = getattr(request, '_stream', None)
+            if stream is not None:
+                stream.close()
+            return result
+
+        with override_settings(MIDDLEWARE=middleware, ROOT_URLCONF='tests.middleware.test_async_middleware'):
+            with patch.object(
+                middleware_class,
+                'process_response',
+                autospec=True,
+                side_effect=assert_wrapper,
+            ) as mocked:
+                await self._communicate_via_asgi()
+                self.assertEqual(mocked.call_count, 1)
+
+    async def test_security_middleware_process_response_receives_http_response(self):
+        await self._assert_process_response_receives_http_response(
+            ['django.middleware.security.SecurityMiddleware'],
+            SecurityMiddleware,
+        )
+
+    async def test_update_cache_middleware_process_response_receives_http_response(self):
+        await self._assert_process_response_receives_http_response(
+            [
+                'django.middleware.cache.UpdateCacheMiddleware',
+                'django.middleware.common.CommonMiddleware',
+                'django.middleware.cache.FetchFromCacheMiddleware',
+            ],
+            UpdateCacheMiddleware,
+        )
+
+    async def test_cache_middleware_process_response_receives_http_response(self):
+        await self._assert_process_response_receives_http_response(
+            ['django.middleware.cache.CacheMiddleware'],
+            CacheMiddleware,
+        )


### PR DESCRIPTION
## Summary
- call super().__init__(get_response) in SecurityMiddleware and cache middlewares so MiddlewareMixin._async_check() marks them async-capable under ASGI
- rely on MiddlewareMixin to manage get_response instead of direct assignments, ensuring the async response wrapper is engaged
- add ASGI regression tests covering SecurityMiddleware, UpdateCacheMiddleware/CommonMiddleware/FetchFromCacheMiddleware, and CacheMiddleware as the first middleware in the chain

## Issue
Fixes #239

## Reproduction steps
1. Configure settings with the first middleware set to `django.middleware.security.SecurityMiddleware` (or the cache middlewares) and an async view returning `HttpResponse('ok')`.
2. Map the view via the URLconf and obtain an ASGI application with `django.core.asgi.get_asgi_application()`.
3. Drive a request using `asgiref.testing.ApplicationCommunicator`.
4. Observe the first middleware's `process_response()` receiving an un-awaited coroutine instead of an `HttpResponse`.

### Observed failure
- `SecurityMiddleware.process_response()` receives a coroutine and raises `TypeError` when accessing headers.
- `UpdateCacheMiddleware.process_response()` receives a coroutine and raises `AttributeError` when reading `streaming` or `status_code`.

### Representative stack traces
SecurityMiddleware first:
```
File "django/utils/deprecation.py", line <__call__>, in __call__
    response = response or self.get_response(request)  # returns coroutine
    return self.process_response(request, response)    # response is coroutine
File "django/middleware/security.py", line 36, in process_response
    'Strict-Transport-Security' not in response
TypeError: argument of type 'coroutine' is not iterable
```

UpdateCacheMiddleware first:
```
File "django/utils/deprecation.py", line <__call__>, in __call__
    response = response or self.get_response(request)
    return self.process_response(request, response)
File "django/middleware/cache.py", line 84, in process_response
    if response.streaming or response.status_code not in (200, 304):
AttributeError: 'coroutine' object has no attribute 'streaming'
```

## Testing
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py middleware.test_async_middleware --parallel=1`
- `.venv/bin/flake8 django/middleware/security.py django/middleware/cache.py tests/middleware/test_async_middleware.py`