### PR TITLE
fix: swev-id: django__django-13410 ensure POSIX locks return booleans

### DIFF
--- a/django/core/files/locks.py
+++ b/django/core/files/locks.py
@@ -107,9 +107,15 @@ else:
             return True
     else:
         def lock(f, flags):
-            ret = fcntl.flock(_fd(f), flags)
-            return ret == 0
+            try:
+                fcntl.flock(_fd(f), flags)
+            except OSError:
+                return False
+            return True
 
         def unlock(f):
-            ret = fcntl.flock(_fd(f), fcntl.LOCK_UN)
-            return ret == 0
+            try:
+                fcntl.flock(_fd(f), fcntl.LOCK_UN)
+            except OSError:
+                return False
+            return True

--- a/tests/files/test_locks_posix.py
+++ b/tests/files/test_locks_posix.py
@@ -1,0 +1,53 @@
+import os
+import tempfile
+import unittest
+
+from django.core.files import locks
+
+try:
+    import fcntl  # noqa: F401
+except ImportError:  # pragma: no cover - platform dependent
+    fcntl = None
+
+
+def _tempfile_path():
+    temp = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        return temp.name
+    finally:
+        temp.close()
+
+
+@unittest.skipIf(os.name == 'nt', 'POSIX only')
+@unittest.skipUnless(fcntl, 'fcntl unavailable')
+class PosixLockTests(unittest.TestCase):
+
+    def test_exclusive_lock_and_unlock_return_true(self):
+        path = _tempfile_path()
+        self.addCleanup(lambda: os.unlink(path))
+        with open(path, 'w+') as handler:
+            self.assertTrue(locks.lock(handler, locks.LOCK_EX))
+            self.assertTrue(locks.unlock(handler))
+
+    def test_shared_lock_and_unlock_return_true(self):
+        path = _tempfile_path()
+        self.addCleanup(lambda: os.unlink(path))
+        with open(path, 'w+') as handler:
+            self.assertTrue(locks.lock(handler, locks.LOCK_SH))
+            self.assertTrue(locks.unlock(handler))
+
+    def test_non_blocking_exclusive_conflict_returns_false(self):
+        path = _tempfile_path()
+        self.addCleanup(lambda: os.unlink(path))
+        with open(path, 'w+') as first, open(path, 'r+') as second:
+            self.assertTrue(locks.lock(first, locks.LOCK_EX))
+            try:
+                self.assertFalse(
+                    locks.lock(second, locks.LOCK_EX | locks.LOCK_NB)
+                )
+            finally:
+                self.assertTrue(locks.unlock(first))
+
+        with open(path, 'r+') as second:
+            self.assertTrue(locks.lock(second, locks.LOCK_EX))
+            self.assertTrue(locks.unlock(second))


### PR DESCRIPTION
## Summary
- wrap POSIX flock operations to return booleans on success and OSError failure
- add POSIX-only tests covering exclusive, shared, and non-blocking lock scenarios

Fixes #247

## Observed failure output and stack trace
```
FFF
======================================================================
FAIL: test_exclusive_lock_and_unlock_return_true (files.test_locks_posix.PosixLockTests.test_exclusive_lock_and_unlock_return_true)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/files/test_locks_posix.py", line 29, in test_exclusive_lock_and_unlock_return_true
    self.assertTrue(locks.lock(handler, locks.LOCK_EX))
AssertionError: False is not true

======================================================================
FAIL: test_non_blocking_exclusive_conflict_returns_false (files.test_locks_posix.PosixLockTests.test_non_blocking_exclusive_conflict_returns_false)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/files/test_locks_posix.py", line 43, in test_non_blocking_exclusive_conflict_returns_false
    self.assertTrue(locks.lock(first, locks.LOCK_EX))
AssertionError: False is not true

======================================================================
FAIL: test_shared_lock_and_unlock_return_true (files.test_locks_posix.PosixLockTests.test_shared_lock_and_unlock_return_true)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/files/test_locks_posix.py", line 36, in test_shared_lock_and_unlock_return_true
    self.assertTrue(locks.lock(handler, locks.LOCK_SH))
AssertionError: False is not true

----------------------------------------------------------------------
Ran 3 tests in 0.001s

FAILED (failures=3)
```

## Minimal reproduction steps
1. Ensure dependencies are installed and activate a virtualenv.
2. From the project root, run:
   ```bash
   PYTHONPATH="$PWD/tests:$PWD" DJANGO_SETTINGS_MODULE=tests.test_sqlite \
     python tests/runtests.py files.test_locks_posix --parallel=1
   ```

## Explanation of the fix and added tests
- Catch `OSError` around POSIX `fcntl.flock()` to return `True` on success and `False` on errors for both `lock()` and `unlock()`.
- Added POSIX-only regression tests asserting successful exclusive/shared locks and the non-blocking conflict behavior.
