### PR TITLE
fix: swev-id: django__django-13363 respect tzinfo in trunc casts

### DIFF
--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -292,7 +292,7 @@ class TruncDate(TruncBase):
     def as_sql(self, compiler, connection):
         # Cast to date rather than truncate to date.
         lhs, lhs_params = compiler.compile(self.lhs)
-        tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
+        tzname = self.get_tzname()
         sql = connection.ops.datetime_cast_date_sql(lhs, tzname)
         return sql, lhs_params
 
@@ -305,7 +305,7 @@ class TruncTime(TruncBase):
     def as_sql(self, compiler, connection):
         # Cast to time rather than truncate to time.
         lhs, lhs_params = compiler.compile(self.lhs)
-        tzname = timezone.get_current_timezone_name() if settings.USE_TZ else None
+        tzname = self.get_tzname()
         sql = connection.ops.datetime_cast_time_sql(lhs, tzname)
         return sql, lhs_params
 

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -1,5 +1,11 @@
 from datetime import datetime, timedelta, timezone as datetime_timezone
 
+try:
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+except ImportError:  # pragma: no cover -- Python < 3.9
+    ZoneInfo = None
+    ZoneInfoNotFoundError = Exception
+
 import pytz
 
 from django.conf import settings
@@ -20,6 +26,15 @@ from django.test import (
 from django.utils import timezone
 
 from ..models import Author, DTModel, Fan
+
+
+def get_tz(name):
+    if ZoneInfo is not None:
+        try:
+            return ZoneInfo(name)
+        except ZoneInfoNotFoundError:
+            pass
+    return pytz.timezone(name)
 
 
 def truncate_to(value, kind, tzinfo=None):
@@ -1132,6 +1147,33 @@ class DateFunctionWithTimeZoneTests(DateFunctionTests):
         self.assertEqual(model.start_datetime.year, 2016)
         self.assertEqual(model.melb_year.year, 2016)
         self.assertEqual(model.pacific_year.year, 2015)
+
+    def test_trunc_date_respects_tzinfo_argument(self):
+        pacific = get_tz('US/Pacific')
+        aware = datetime(2016, 1, 1, 1, 30, tzinfo=timezone.utc)
+        self.create_model(aware, aware)
+
+        with timezone.override(timezone.utc):
+            model = DTModel.objects.annotate(
+                pacific_date=TruncDate('start_datetime', tzinfo=pacific),
+            ).get()
+
+        self.assertEqual(model.pacific_date, aware.astimezone(pacific).date())
+
+    def test_trunc_time_respects_tzinfo_argument(self):
+        pacific = get_tz('US/Pacific')
+        aware = datetime(2016, 1, 1, 1, 30, 45, tzinfo=timezone.utc)
+        self.create_model(aware, aware)
+
+        with timezone.override(timezone.utc):
+            model = DTModel.objects.annotate(
+                pacific_time=TruncTime('start_datetime', tzinfo=pacific),
+            ).get()
+
+        expected = aware.astimezone(pacific).time()
+        if expected.tzinfo is not None:
+            expected = expected.replace(tzinfo=None)
+        self.assertEqual(model.pacific_time, expected)
 
     def test_trunc_ambiguous_and_invalid_times(self):
         sao = pytz.timezone('America/Sao_Paulo')


### PR DESCRIPTION
## Summary
- ensure `TruncDate` and `TruncTime` respect explicit `tzinfo` overrides
- add regression coverage verifying the new `tzinfo` behaviour on aware datetimes

## Issue
- #248

## Reproduction Steps
1. source /workspace/.venv/bin/activate
2. cd tests
3. PYTHONPATH=/workspace/django ./runtests.py db_functions.datetime.test_extract_trunc --parallel=1

## Observed Failure
```
======================================================================
FAIL: test_trunc_date_respects_tzinfo_argument (db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_trunc_date_respects_tzinfo_argument)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/db_functions/datetime/test_extract_trunc.py", line 1161, in test_trunc_date_respects_tzinfo_argument
    self.assertEqual(model.pacific_date, aware.astimezone(pacific).date())
AssertionError: datetime.date(2016, 1, 1) != datetime.date(2015, 12, 31)

======================================================================
FAIL: test_trunc_time_respects_tzinfo_argument (db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_trunc_time_respects_tzinfo_argument)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/db_functions/datetime/test_extract_trunc.py", line 1176, in test_trunc_time_respects_tzinfo_argument
    self.assertEqual(model.pacific_time, expected)
AssertionError: datetime.time(1, 30, 45) != datetime.time(17, 30, 45)
```

## Summary of Fix
- delegate to `get_tzname()` in both casts so the provided `tzinfo` propagates to backend-specific SQL
- use a helper in tests to pick zoneinfo when available and fall back to pytz for compatibility

## Testing
- PYTHONPATH=/workspace/django ./runtests.py db_functions.datetime.test_extract_trunc --parallel=1
- flake8 tests/db_functions/datetime/test_extract_trunc.py
- flake8 django/db/models/functions/datetime.py --select=E9,F63,F7,F82