### PR TITLE
swev-id: django__django-13417 fix QuerySet.ordered with group by

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1224,10 +1224,12 @@ class QuerySet:
             return True
         if self.query.extra_order_by or self.query.order_by:
             return True
-        elif self.query.default_ordering and self.query.get_meta().ordering:
+        has_default_ordering = (
+            self.query.default_ordering and self.query.get_meta().ordering
+        )
+        if has_default_ordering and not self.query.group_by:
             return True
-        else:
-            return False
+        return False
 
     @property
     def db(self):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -2084,6 +2084,38 @@ class QuerysetOrderedTests(unittest.TestCase):
         self.assertIs(qs.ordered, False)
         self.assertIs(qs.order_by('num_notes').ordered, True)
 
+    def test_default_ordering_with_group_by_annotation(self):
+        qs = Tag.objects.annotate(num_children=Count('children'))
+        self.assertIsNotNone(qs.query.group_by)
+        self.assertIs(qs.ordered, False)
+        self.assertNotIn('ORDER BY', str(qs.query))
+
+    def test_annotation_with_explicit_ordering(self):
+        qs = Tag.objects.annotate(num_children=Count('children')).order_by('num_children')
+        self.assertIs(qs.ordered, True)
+        self.assertIn('ORDER BY', str(qs.query))
+
+    def test_values_annotation_default_and_explicit_ordering(self):
+        qs = Tag.objects.annotate(num_children=Count('children')).values('name', 'num_children')
+        self.assertIs(qs.ordered, False)
+        self.assertNotIn('ORDER BY', str(qs.query))
+        ordered_qs = qs.order_by('name')
+        self.assertIs(ordered_qs.ordered, True)
+        self.assertIn('ORDER BY', str(ordered_qs.query))
+
+    def test_values_list_annotation_default_and_explicit_ordering(self):
+        qs = Tag.objects.values_list('name').annotate(num_children=Count('children'))
+        self.assertIs(qs.ordered, False)
+        self.assertNotIn('ORDER BY', str(qs.query))
+        ordered_qs = qs.order_by('name')
+        self.assertIs(ordered_qs.ordered, True)
+        self.assertIn('ORDER BY', str(ordered_qs.query))
+
+    def test_annotation_with_cleared_ordering(self):
+        qs = Tag.objects.annotate(num_children=Count('children')).order_by()
+        self.assertIs(qs.ordered, False)
+        self.assertNotIn('ORDER BY', str(qs.query))
+
 
 @skipUnlessDBFeature('allow_sliced_subqueries_with_in')
 class SubqueryTests(TestCase):


### PR DESCRIPTION
## Issue
- #249

## Reproduction Steps
```bash
PYTHONPATH=$PWD ./tests/runtests.py queries.tests.QuerysetOrderedTests --parallel=1
```

## Observed Failure (pre-fix)
```text
======================================================================
FAIL: test_default_ordering_with_group_by_annotation (queries.tests.QuerysetOrderedTests.test_default_ordering_with_group_by_annotation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/queries/tests.py", line 2090, in test_default_ordering_with_group_by_annotation
    self.assertIs(qs.ordered, False)
AssertionError: True is not False

======================================================================
FAIL: test_values_annotation_default_and_explicit_ordering (queries.tests.QuerysetOrderedTests.test_values_annotation_default_and_explicit_ordering)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/queries/tests.py", line 2100, in test_values_annotation_default_and_explicit_ordering
    self.assertIs(qs.ordered, False)
AssertionError: True is not False
```

## Fix
- Ignore Meta.default ordering in `QuerySet.ordered` when the underlying query has a `GROUP BY`, keeping explicit `order_by()` / `extra(order_by=...)` semantics intact while leaving `EmptyQuerySet` behavior unchanged.

## Edge Cases Covered
- Annotation-generated `GROUP BY` without explicit ordering
- Annotation plus explicit `order_by()`
- `values()`/`values_list()` queries with annotations
- Manual `order_by()` clearing after annotation
- Baseline regressions for unordered models and empty querysets

## Verification
- `PYTHONPATH=$PWD ./tests/runtests.py queries.tests.QuerysetOrderedTests --parallel=1`
- `flake8 django/db/models/query.py tests/queries/tests.py`