### PR TITLE
swev-id: django__django-13401 | Field comparison considers owning model; regression tests

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -513,20 +513,47 @@ class Field(RegisterLookupMixin):
         name, path, args, kwargs = self.deconstruct()
         return self.__class__(*args, **kwargs)
 
+    def _concrete_model(self):
+        model = getattr(self, 'model', None)
+        if model is None:
+            return None
+        return model._meta.concrete_model
+
+    def _model_sort_key(self):
+        concrete_model = self._concrete_model()
+        if concrete_model is None:
+            return ''
+        return concrete_model._meta.label_lower
+
     def __eq__(self, other):
         # Needed for @total_ordering
         if isinstance(other, Field):
-            return self.creation_counter == other.creation_counter
+            if self.creation_counter != other.creation_counter:
+                return False
+            self_model = self._concrete_model()
+            other_model = other._concrete_model()
+            if self_model is None or other_model is None:
+                return self_model is None and other_model is None
+            return self_model is other_model
         return NotImplemented
 
     def __lt__(self, other):
         # This is needed because bisect does not take a comparison function.
         if isinstance(other, Field):
-            return self.creation_counter < other.creation_counter
+            return (
+                self.creation_counter,
+                self._model_sort_key(),
+            ) < (
+                other.creation_counter,
+                other._model_sort_key(),
+            )
         return NotImplemented
 
     def __hash__(self):
-        return hash(self.creation_counter)
+        model = self._concrete_model()
+        if model is None:
+            return hash(self.creation_counter)
+        return hash((model, self.creation_counter))
 
     def __deepcopy__(self, memodict):
         # We don't have to deepcopy very much here, since most things are not

--- a/tests/model_meta/test_field_comparison.py
+++ b/tests/model_meta/test_field_comparison.py
@@ -1,0 +1,95 @@
+from copy import deepcopy
+
+from django.db import models
+from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
+
+
+@isolate_apps('model_meta')
+class FieldComparisonTests(SimpleTestCase):
+
+    def test_abstract_model_fields_are_distinct(self):
+        class AbstractBase(models.Model):
+            name = models.CharField(max_length=50)
+
+            class Meta:
+                abstract = True
+
+        class ConcreteAlpha(AbstractBase):
+            class Meta:
+                app_label = 'model_meta'
+
+        class ConcreteBeta(AbstractBase):
+            class Meta:
+                app_label = 'model_meta'
+
+        alpha_name = ConcreteAlpha._meta.get_field('name')
+        beta_name = ConcreteBeta._meta.get_field('name')
+
+        self.assertNotEqual(alpha_name, beta_name)
+        self.assertEqual(len({alpha_name, beta_name}), 2)
+        self.assertEqual(
+            [f.model._meta.label_lower for f in sorted([beta_name, alpha_name])],
+            ['model_meta.concretealpha', 'model_meta.concretebeta'],
+        )
+
+    def test_same_model_fields_remain_distinct(self):
+        class Article(models.Model):
+            name = models.CharField(max_length=50)
+            title = models.CharField(max_length=50)
+
+            class Meta:
+                app_label = 'model_meta'
+
+        name_field = Article._meta.get_field('name')
+        title_field = Article._meta.get_field('title')
+
+        self.assertNotEqual(name_field, title_field)
+        self.assertLess(name_field, title_field)
+
+    def test_same_model_field_identity(self):
+        class Book(models.Model):
+            name = models.CharField(max_length=50)
+
+            class Meta:
+                app_label = 'model_meta'
+
+        first = Book._meta.get_field('name')
+        second = Book._meta.get_field('name')
+
+        self.assertEqual(first, second)
+        self.assertEqual(len({first, second}), 1)
+
+    def test_proxy_model_field_matches_concrete(self):
+        class Person(models.Model):
+            name = models.CharField(max_length=50)
+
+            class Meta:
+                app_label = 'model_meta'
+
+        class PersonProxy(Person):
+            class Meta:
+                app_label = 'model_meta'
+                proxy = True
+
+        base_field = Person._meta.get_field('name')
+        proxy_field = PersonProxy._meta.get_field('name')
+
+        self.assertEqual(base_field, proxy_field)
+        self.assertEqual(len({base_field, proxy_field}), 1)
+
+    def test_unbound_fields(self):
+        class Story(models.Model):
+            title = models.CharField(max_length=50)
+
+            class Meta:
+                app_label = 'model_meta'
+
+        bound_field = Story._meta.get_field('title')
+
+        unbound_field = models.CharField(max_length=50)
+        copied_field = deepcopy(unbound_field)
+
+        self.assertEqual(unbound_field, copied_field)
+        self.assertNotEqual(bound_field, unbound_field)
+        self.assertEqual(len({unbound_field, copied_field}), 1)


### PR DESCRIPTION
Fixes: #250

Summary
- Adjust Field.__eq__, __hash__, and __lt__ to take the owning concrete model into account while preserving creation_counter ordering.
- Add regression coverage for abstract inheritance, same-model comparisons, proxy models, and unbound field scenarios.

Reproduction steps
1) Before this change, run:
   PYTHONPATH=/workspace/django/tests:/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py model_meta.test_field_comparison -v 2
2) Observed failures (pre-fix):
```
test_abstract_model_fields_are_distinct (model_meta.test_field_comparison.FieldComparisonTests.test_abstract_model_fields_are_distinct) ... FAIL
test_proxy_model_field_matches_concrete (model_meta.test_field_comparison.FieldComparisonTests.test_proxy_model_field_matches_concrete) ... ok
test_same_model_field_identity (model_meta.test_field_comparison.FieldComparisonTests.test_same_model_field_identity) ... ok
test_same_model_fields_remain_distinct (model_meta.test_field_comparison.FieldComparisonTests.test_same_model_fields_remain_distinct) ... ok
test_unbound_fields (model_meta.test_field_comparison.FieldComparisonTests.test_unbound_fields) ... ok

======================================================================
FAIL: test_abstract_model_fields_are_distinct (model_meta.test_field_comparison.FieldComparisonTests.test_abstract_model_fields_are_distinct)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_meta/test_field_comparison.py", line 29, in test_abstract_model_fields_are_distinct
    self.assertNotEqual(alpha_name, beta_name)
AssertionError: <django.db.models.fields.CharField: name> == <django.db.models.fields.CharField: name>

----------------------------------------------------------------------
Ran 5 tests in 0.002s

FAILED (failures=1)
Testing against Django installed in '/workspace/django/django' with up to 16 processes
Importing application model_meta
Skipping setup of unused database(s): default, other.
System check identified no issues (0 silenced).
```

Notes
- Equality now aligns on concrete model identity; unbound fields remain equal only when both unbound and sharing a creation counter.
- Ordering still prioritizes creation counter, falling back to concrete label on ties for deterministic sorting.