### PR TITLE
Respect __suppress_context__ in debug error view (PEP 415) – swev-id: django__django-13513

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -397,9 +397,11 @@ class ExceptionReporter:
     def get_traceback_frames(self):
         def explicit_or_implicit_cause(exc_value):
             explicit = getattr(exc_value, '__cause__', None)
-            suppress_context = getattr(exc_value, '__suppress_context__', None)
-            implicit = getattr(exc_value, '__context__', None)
-            return explicit or (None if suppress_context else implicit)
+            if explicit is not None:
+                return explicit
+            if getattr(exc_value, '__suppress_context__', None):
+                return None
+            return getattr(exc_value, '__context__', None)
 
         # Get the exception and all its causes
         exceptions = []
@@ -446,7 +448,7 @@ class ExceptionReporter:
                 post_context = []
             frames.append({
                 'exc_cause': explicit_or_implicit_cause(exc_value),
-                'exc_cause_explicit': getattr(exc_value, '__cause__', True),
+                'exc_cause_explicit': bool(getattr(exc_value, '__cause__', None)),
                 'tb': tb,
                 'type': 'django' if module_name.startswith('django.') else 'user',
                 'filename': filename,

--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -448,7 +448,7 @@ class ExceptionReporter:
                 post_context = []
             frames.append({
                 'exc_cause': explicit_or_implicit_cause(exc_value),
-                'exc_cause_explicit': bool(getattr(exc_value, '__cause__', None)),
+                'exc_cause_explicit': getattr(exc_value, '__cause__', None) is not None,
                 'tb': tb,
                 'type': 'django' if module_name.startswith('django.') else 'user',
                 'filename': filename,

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -360,12 +360,15 @@ class ExceptionReporterTests(SimpleTestCase):
     rf = RequestFactory()
 
     def _frames_for_tb_chain(self, tb, frames):
-        chain = set()
+        chain_ids = set()
         current = tb
         while current is not None:
-            chain.add(current)
+            chain_ids.add(id(current))
             current = current.tb_next
-        return [frame for frame in frames if frame['tb'] in chain]
+        return [
+            frame for frame in frames
+            if frame['tb'] is not None and id(frame['tb']) in chain_ids
+        ]
 
     def test_request_and_exception(self):
         "A simple exception report can be generated"

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -359,6 +359,14 @@ class NonDjangoTemplatesDebugViewTests(SimpleTestCase):
 class ExceptionReporterTests(SimpleTestCase):
     rf = RequestFactory()
 
+    def _frames_for_tb_chain(self, tb, frames):
+        chain = set()
+        current = tb
+        while current is not None:
+            chain.add(current)
+            current = current.tb_next
+        return [frame for frame in frames if frame['tb'] in chain]
+
     def test_request_and_exception(self):
         "A simple exception report can be generated"
         try:
@@ -466,6 +474,54 @@ class ExceptionReporterTests(SimpleTestCase):
         self.assertIn('<h2>Request information</h2>', html)
         self.assertIn('<p>Request data not supplied</p>', html)
         self.assertNotIn('During handling of the above exception', html)
+
+        frames = reporter.get_traceback_frames()
+        outer_frames = self._frames_for_tb_chain(tb, frames)
+        self.assertTrue(outer_frames)
+        self.assertEqual({frame['exc_cause'] for frame in outer_frames}, {None})
+        self.assertEqual({frame['exc_cause_explicit'] for frame in outer_frames}, {False})
+
+    def test_traceback_frames_prefer_explicit_cause(self):
+        try:
+            try:
+                raise RuntimeError('inner')
+            except RuntimeError as explicit:
+                raise ValueError('outer') from explicit
+        except ValueError:
+            exc_type, exc_value, tb = sys.exc_info()
+
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertIn('was the direct cause of the following exception', html)
+
+        frames = reporter.get_traceback_frames()
+        outer_frames = self._frames_for_tb_chain(tb, frames)
+        self.assertTrue(outer_frames)
+        explicit_cause = exc_value.__cause__
+        self.assertIsNotNone(explicit_cause)
+        self.assertTrue(all(frame['exc_cause'] is explicit_cause for frame in outer_frames))
+        self.assertEqual({frame['exc_cause_explicit'] for frame in outer_frames}, {True})
+
+    def test_traceback_frames_include_unsuppressed_context(self):
+        try:
+            try:
+                raise RuntimeError('inner')
+            except RuntimeError:
+                raise ValueError('outer')
+        except ValueError:
+            exc_type, exc_value, tb = sys.exc_info()
+
+        reporter = ExceptionReporter(None, exc_type, exc_value, tb)
+        html = reporter.get_traceback_html()
+        self.assertIn('During handling of the above exception', html)
+
+        frames = reporter.get_traceback_frames()
+        outer_frames = self._frames_for_tb_chain(tb, frames)
+        self.assertTrue(outer_frames)
+        implicit_context = exc_value.__context__
+        self.assertIsNotNone(implicit_context)
+        self.assertTrue(all(frame['exc_cause'] is implicit_context for frame in outer_frames))
+        self.assertEqual({frame['exc_cause_explicit'] for frame in outer_frames}, {False})
 
     def test_reporting_of_nested_exceptions(self):
         request = self.rf.get('/test_view/')


### PR DESCRIPTION
## Summary
- add regression coverage for suppressed context, explicit causes, and unsuppressed implicit contexts in `tests/view_tests/tests/test_debug.py`
- ensure `ExceptionReporter.get_traceback_frames()` prefers explicit causes and respects `__suppress_context__` while marking `exc_cause_explicit` as a boolean

## Observed failure
On a non-compliant build the debug page incorrectly shows:
```
During handling of the above exception (inner), another exception occurred:
```
even for `raise ValueError("outer") from None`.

## Reproduction
1. Ensure Python 3.11 with `asgiref`, `sqlparse`, and `tzdata` installed.
2. Run the targeted suite:
   ```
   PYTHONPATH=$(pwd) python tests/runtests.py view_tests.tests.test_debug --parallel=1
   ```
3. Use the manual snippet to inspect the rendered HTML:
   ```python
   try:
       try:
           raise RuntimeError("inner")
       except RuntimeError:
           raise ValueError("outer") from None
   except Exception:
       import sys
       from django.views.debug import ExceptionReporter
       et, ev, tb = sys.exc_info()
       html = ExceptionReporter(None, et, ev, tb).get_traceback_html()
       print(html)
   ```

## Testing
- `PYTHONPATH=$(pwd) python tests/runtests.py view_tests.tests.test_debug --parallel=1`
- `flake8 django/views/debug.py tests/view_tests/tests/test_debug.py`

Refs #257