### PR TITLE
fix: swev-id: django__django-13449 sqlite decimal window cast

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1332,6 +1332,45 @@ class Window(Expression):
             'window': ''.join(window_sql).strip()
         }, params
 
+    def as_sqlite(self, compiler, connection, template=None):
+        connection.ops.check_expression_support(self)
+        if not connection.features.supports_over_clause:
+            raise NotSupportedError('This backend does not support window expressions.')
+
+        expr_sql, params = self.source_expression.as_sql(compiler, connection)
+        window_sql, window_params = [], []
+
+        if self.partition_by is not None:
+            sql_expr, sql_params = self.partition_by.as_sql(
+                compiler=compiler, connection=connection,
+                template='PARTITION BY %(expressions)s',
+            )
+            window_sql.extend(sql_expr)
+            window_params.extend(sql_params)
+
+        if self.order_by is not None:
+            window_sql.append(' ORDER BY ')
+            order_sql, order_params = compiler.compile(self.order_by)
+            window_sql.extend(order_sql)
+            window_params.extend(order_params)
+
+        if self.frame:
+            frame_sql, frame_params = compiler.compile(self.frame)
+            window_sql.append(' ' + frame_sql)
+            window_params.extend(frame_params)
+
+        params = list(params)
+        params.extend(window_params)
+        template = template or self.template
+        sql = template % {
+            'expression': expr_sql,
+            'window': ''.join(window_sql).strip(),
+        }
+        output_field = self._output_field_or_none
+        if isinstance(output_field, fields.DecimalField):
+            sql = 'CAST(%s AS NUMERIC)' % sql
+        return sql, params
+
     def __str__(self):
         return '{} OVER ({}{}{})'.format(
             str(self.source_expression),

--- a/tests/expressions_window/models.py
+++ b/tests/expressions_window/models.py
@@ -12,3 +12,11 @@ class Employee(models.Model):
     hire_date = models.DateField(blank=False, null=False)
     age = models.IntegerField(blank=False, null=False)
     classification = models.ForeignKey('Classification', on_delete=models.CASCADE, null=True)
+
+
+class EmployeeDecimal(models.Model):
+    name = models.CharField(max_length=40, blank=False, null=False)
+    salary = models.DecimalField(max_digits=10, decimal_places=2)
+    bonus = models.FloatField()
+    department = models.CharField(max_length=40, blank=False, null=False)
+    hire_date = models.DateField(blank=False, null=False)

--- a/tests/expressions_window/tests.py
+++ b/tests/expressions_window/tests.py
@@ -1,5 +1,6 @@
 import datetime
-from unittest import mock, skipIf
+from decimal import Decimal
+from unittest import mock, skipIf, skipUnless
 
 from django.core.exceptions import FieldError
 from django.db import NotSupportedError, connection
@@ -13,7 +14,7 @@ from django.db.models.functions import (
 )
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
 
-from .models import Employee
+from .models import Employee, EmployeeDecimal
 
 
 @skipUnlessDBFeature('supports_over_clause')
@@ -785,6 +786,88 @@ class WindowFunctionTests(TestCase):
                 order_by=F('hire_date').asc(),
                 frame=RowRange(start='a'),
             )))
+
+
+@skipUnless(connection.vendor == 'sqlite', 'SQLite specific tests.')
+@skipUnlessDBFeature('supports_over_clause')
+class DecimalWindowFunctionTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        EmployeeDecimal.objects.bulk_create([
+            EmployeeDecimal(
+                name='Alice',
+                salary=Decimal('1000.00'),
+                bonus=1.5,
+                department='IT',
+                hire_date=datetime.date(2020, 1, 1),
+            ),
+            EmployeeDecimal(
+                name='Bob',
+                salary=Decimal('1250.50'),
+                bonus=1.7,
+                department='IT',
+                hire_date=datetime.date(2020, 6, 1),
+            ),
+            EmployeeDecimal(
+                name='Carol',
+                salary=Decimal('1500.75'),
+                bonus=2.5,
+                department='Sales',
+                hire_date=datetime.date(2019, 9, 1),
+            ),
+            EmployeeDecimal(
+                name='Dave',
+                salary=Decimal('1600.25'),
+                bonus=2.8,
+                department='Sales',
+                hire_date=datetime.date(2020, 2, 1),
+            ),
+        ])
+
+    def test_lag_decimal_field(self):
+        qs = EmployeeDecimal.objects.annotate(
+            previous_salary=Window(
+                expression=Lag('salary'),
+                partition_by=F('department'),
+                order_by=F('hire_date').asc(),
+            ),
+        ).order_by('department', 'hire_date')
+        self.assertEqual(list(qs.values_list('name', 'previous_salary')), [
+            ('Alice', None),
+            ('Bob', Decimal('1000.00')),
+            ('Carol', None),
+            ('Dave', Decimal('1500.75')),
+        ])
+
+    def test_lag_float_field(self):
+        qs = EmployeeDecimal.objects.annotate(
+            previous_bonus=Window(
+                expression=Lag('bonus'),
+                partition_by=F('department'),
+                order_by=F('hire_date').asc(),
+            ),
+        ).order_by('department', 'hire_date')
+        self.assertEqual(list(qs.values_list('name', 'previous_bonus')), [
+            ('Alice', None),
+            ('Bob', 1.5),
+            ('Carol', None),
+            ('Dave', 2.5),
+        ])
+
+    def test_sum_decimal_field(self):
+        qs = EmployeeDecimal.objects.annotate(
+            department_total=Window(
+                expression=Sum('salary'),
+                partition_by=F('department'),
+                order_by=F('hire_date').asc(),
+            ),
+        ).order_by('department', 'hire_date')
+        self.assertEqual(list(qs.values_list('name', 'department_total')), [
+            ('Alice', Decimal('1000.00')),
+            ('Bob', Decimal('2250.50')),
+            ('Carol', Decimal('1500.75')),
+            ('Dave', Decimal('3101.00')),
+        ])
 
 
 class WindowUnsupportedTests(TestCase):


### PR DESCRIPTION
## Summary
- wrap SQLite window expressions so Decimal casts enclose the entire OVER clause (#254)
- add an `EmployeeDecimal` model and regression tests covering Lag/Sum on decimal salaries
- guard SQLite behavior without affecting other backends via targeted test skips

## Reproduction
1. Activate the project venv and run the following snippet against SQLite:
   ```
   PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite \
   /workspace/.venv/bin/python - <<'PY'
   import importlib
   import django
   from django.core.management import call_command
   settings = importlib.import_module('tests.test_sqlite')
   settings.DATABASES['default']['NAME'] = ':memory:'
   settings.DATABASES['other']['NAME'] = ':memory:'
   settings.INSTALLED_APPS = [
       'django.contrib.auth',
       'django.contrib.contenttypes',
       'tests.expressions_window',
   ]
   settings.MIGRATION_MODULES = {'expressions_window': None}
   django.setup()
   call_command('migrate', run_syncdb=True, verbosity=0)

   from tests.expressions_window.models import Classification, Employee
   from django.db.models import F, Window
   from django.db.models.functions import Lag
   from django.db import models

   Classification.objects.all().delete()
   Employee.objects.all().delete()
   cls = Classification.objects.create(code='A')
   Employee.objects.bulk_create([
       Employee(name='Alice', salary=1000, department='IT', hire_date='2020-01-01', age=30, classification=cls),
       Employee(name='Bob', salary=1200, department='IT', hire_date='2021-01-01', age=35, classification=cls),
   ])

   qs = Employee.objects.annotate(
       prev_salary=Window(
           expression=Lag('salary', output_field=models.DecimalField(max_digits=10, decimal_places=2)),
           partition_by=[F('department')],
           order_by=F('hire_date').asc(),
       )
   ).values_list('name', 'prev_salary')
   print(list(qs))
   PY
   ```
2. Observed failure:
   ```
   django.db.utils.OperationalError: near "OVER": syntax error
   SQL: SELECT "expressions_window_employee"."name", CAST(LAG("expressions_window_employee"."salary", 1) AS NUMERIC) OVER (PARTITION BY "expressions_window_employee"."department" ORDER BY "expressions_window_employee"."hire_date" ASC) AS "prev_salary" FROM "expressions_window_employee"
   ```

## Fix
- add `Window.as_sqlite()` to compile the window clause first and apply the NUMERIC cast only after the full `<expr OVER (...)>` is assembled
- ensure the decimal-specific cast checks rely on the expression's `output_field`, leaving non-decimal windows untouched
- add SQLite-only regression coverage for decimal lag/sum alongside a control case on float data

## Testing
- tox -e py3 -- tests/expressions_window/