### PR TITLE
swev-id: django__django-13512 fix JSONField unicode display

### DIFF
--- a/django/contrib/admin/utils.py
+++ b/django/contrib/admin/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import json
 from collections import defaultdict
 
 from django.core.exceptions import FieldDoesNotExist
@@ -400,7 +401,8 @@ def display_for_field(value, field, empty_value_display):
         return format_html('<a href="{}">{}</a>', value.url, value)
     elif isinstance(field, models.JSONField) and value:
         try:
-            return field.get_prep_value(value)
+            encoder = getattr(field, 'encoder', None)
+            return json.dumps(value, cls=encoder, ensure_ascii=False)
         except TypeError:
             return display_for_value(value, empty_value_display)
     else:

--- a/django/forms/fields.py
+++ b/django/forms/fields.py
@@ -1258,7 +1258,7 @@ class JSONField(CharField):
     def prepare_value(self, value):
         if isinstance(value, InvalidJSONInput):
             return value
-        return json.dumps(value, cls=self.encoder)
+        return json.dumps(value, cls=self.encoder, ensure_ascii=False)
 
     def has_changed(self, initial, data):
         if super().has_changed(initial, data):

--- a/tests/admin_utils/tests.py
+++ b/tests/admin_utils/tests.py
@@ -195,6 +195,12 @@ class UtilsTests(SimpleTestCase):
                     display_value,
                 )
 
+    def test_json_display_for_field_unicode(self):
+        value = ["中国", "España", "😀"]
+        display_value = display_for_field(value, models.JSONField(), self.empty_value)
+        self.assertEqual(display_value, '["中国", "España", "😀"]')
+        self.assertNotIn('\\u', display_value)
+
     def test_number_formats_display_for_field(self):
         display_value = display_for_field(12345.6789, models.FloatField(), self.empty_value)
         self.assertEqual(display_value, '12345.6789')

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -30,7 +30,7 @@ from .models import (
     EmptyModelHidden, EmptyModelMixin, EmptyModelVisible, ExplicitlyProvidedPK,
     ExternalSubscriber, Fabric, FancyDoodad, FieldOverridePost,
     FilteredManager, FooAccount, FoodDelivery, FunkyTag, Gadget, Gallery,
-    GenRelReference, Grommet, ImplicitlyGeneratedPK, Ingredient,
+    GenRelReference, Grommet, ImplicitlyGeneratedPK, Ingredient, JSONHolder,
     InlineReference, InlineReferer, Inquisition, Language, Link,
     MainPrepopulated, ModelWithStringPrimaryKey, NotReferenced, OldSubscriber,
     OtherStory, Paper, Parent, ParentWithDependentChildren, ParentWithUUIDPK,
@@ -198,6 +198,10 @@ class CustomArticleAdmin(admin.ModelAdmin):
 
 class ThingAdmin(admin.ModelAdmin):
     list_filter = ('color', 'color__warm', 'color__value', 'pub_date')
+
+
+class JSONHolderAdmin(admin.ModelAdmin):
+    pass
 
 
 class InquisitionAdmin(admin.ModelAdmin):
@@ -1005,6 +1009,7 @@ site.register(
 site.register(ModelWithStringPrimaryKey)
 site.register(Color)
 site.register(Thing, ThingAdmin)
+site.register(JSONHolder, JSONHolderAdmin)
 site.register(Actor)
 site.register(Inquisition, InquisitionAdmin)
 site.register(Sketch, SketchAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -156,6 +156,13 @@ class Thing(models.Model):
         return self.title
 
 
+class JSONHolder(models.Model):
+    data = models.JSONField()
+
+    def __str__(self):
+        return str(self.pk)
+
+
 class Actor(models.Model):
     name = models.CharField(max_length=50)
     age = models.IntegerField()

--- a/tests/admin_views/test_jsonfield_unicode.py
+++ b/tests/admin_views/test_jsonfield_unicode.py
@@ -1,0 +1,50 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from .models import JSONHolder
+
+
+UNICODE_JSON = ["中国", "España", "😀"]
+UNICODE_JSON_TEXT = '["中国", "España", "😀"]'
+
+
+@override_settings(
+    ROOT_URLCONF='admin_views.urls',
+    USE_I18N=True,
+    USE_L10N=False,
+    LANGUAGE_CODE='en',
+)
+class JSONFieldUnicodeAdminTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username='super',
+            email='super@example.com',
+            password='secret',
+        )
+        cls.instance = JSONHolder.objects.create(data=UNICODE_JSON)
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_change_form_displays_unicode(self):
+        url = reverse('admin:admin_views_jsonholder_change', args=(self.instance.pk,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        bound_field = response.context['adminform'].form['data']
+        rendered_value = bound_field.value()
+        self.assertEqual(rendered_value, UNICODE_JSON_TEXT)
+        self.assertNotIn('\\u', rendered_value)
+        page = response.content.decode()
+        self.assertIn('中国', page)
+        self.assertIn('España', page)
+        self.assertIn('😀', page)
+
+    def test_save_preserves_unicode(self):
+        url = reverse('admin:admin_views_jsonholder_change', args=(self.instance.pk,))
+        response = self.client.post(url, {'data': UNICODE_JSON_TEXT, '_save': 'Save'}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.instance.refresh_from_db()
+        self.assertEqual(self.instance.data, UNICODE_JSON)

--- a/tests/forms_tests/field_tests/test_jsonfield.py
+++ b/tests/forms_tests/field_tests/test_jsonfield.py
@@ -30,6 +30,12 @@ class JSONFieldTest(SimpleTestCase):
         self.assertEqual(field.prepare_value(None), 'null')
         self.assertEqual(field.prepare_value('foo'), '"foo"')
 
+    def test_prepare_value_unicode(self):
+        field = JSONField()
+        prepared = field.prepare_value(["中国", "España", "😀"])
+        self.assertEqual(prepared, '["中国", "España", "😀"]')
+        self.assertNotIn('\\u', prepared)
+
     def test_widget(self):
         field = JSONField()
         self.assertIsInstance(field.widget, Textarea)


### PR DESCRIPTION
## Summary
- add regression coverage for Unicode JSONField rendering in forms, admin utils, and admin integration
- render JSONField values with `ensure_ascii=False` for prepare_value and admin display to avoid escape sequences
- wire up a JSONHolder admin model to exercise the end-to-end admin change form (display-only, storage unchanged)

## Reproduction Steps
1. Checkout `django__django-13512`
2. Apply the new tests from this change
3. Run:
   ```
   PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv/bin/python tests/runtests.py forms_tests.field_tests.test_jsonfield.JSONFieldTest.test_prepare_value_unicode admin_utils.tests.UtilsTests.test_json_display_for_field_unicode admin_views.test_jsonfield_unicode --parallel=1
   ```

## Observed Failure
```
Creating test database for alias 'default'...
F.FF
======================================================================
FAIL: test_change_form_displays_unicode (admin_views.test_jsonfield_unicode.JSONFieldUnicodeAdminTests.test_change_form_displays_unicode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/admin_views/test_jsonfield_unicode.py", line 38, in test_change_form_displays_unicode
    self.assertEqual(rendered_value, UNICODE_JSON_TEXT)
AssertionError: '["\\u4e2d\\u56fd", "Espa\\u00f1a", "\\ud83d\\ude00"]' != '["中国", "España", "😀"]'
- ["\u4e2d\u56fd", "Espa\u00f1a", "\ud83d\ude00"]
+ ["中国", "España", "😀"]

======================================================================
FAIL: test_prepare_value_unicode (forms_tests.field_tests.test_jsonfield.JSONFieldTest.test_prepare_value_unicode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/forms_tests/field_tests/test_jsonfield.py", line 36, in test_prepare_value_unicode
    self.assertEqual(prepared, '["中国", "España", "😀"]')
AssertionError: '["\\u4e2d\\u56fd", "Espa\\u00f1a", "\\ud83d\\ude00"]' != '["中国", "España", "😀"]'
- ["\u4e2d\u56fd", "Espa\u00f1a", "\ud83d\ude00"]
+ ["中国", "España", "😀"]

======================================================================
FAIL: test_json_display_for_field_unicode (admin_utils.tests.UtilsTests.test_json_display_for_field_unicode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/admin_utils/tests.py", line 201, in test_json_display_for_field_unicode
    self.assertEqual(display_value, '["中国", "España", "😀"]')
AssertionError: '["\\u4e2d\\u56fd", "Espa\\u00f1a", "\\ud83d\\ude00"]' != '["中国", "España", "😀"]'
- ["\u4e2d\u56fd", "Espa\u00f1a", "\ud83d\ude00"]
+ ["中国", "España", "😀"]

----------------------------------------------------------------------
Ran 4 tests in 0.254s

FAILED (failures=3)
Destroying test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
System check identified no issues (0 silenced).
```

## Testing
- `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv/bin/python tests/runtests.py forms_tests.field_tests.test_jsonfield.JSONFieldTest.test_prepare_value_unicode admin_utils.tests.UtilsTests.test_json_display_for_field_unicode admin_views.test_jsonfield_unicode --parallel=1`