### PR TITLE
fix: OutputWrapper.flush forwards to stream (swev-id: django__django-13516)

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -150,6 +150,10 @@ class OutputWrapper(TextIOBase):
         style_func = style_func or self.style_func
         self._out.write(style_func(msg))
 
+    def flush(self):
+        if hasattr(self._out, 'flush'):
+            return self._out.flush()
+
 
 class BaseCommand:
     """

--- a/tests/management/tests.py
+++ b/tests/management/tests.py
@@ -1,0 +1,26 @@
+from django.core.management.base import OutputWrapper
+from django.test import SimpleTestCase
+
+
+class RecordingStream:
+    def __init__(self):
+        self.writes = []
+        self.flushed = False
+
+    def write(self, s):
+        self.writes.append(s)
+
+    def flush(self):
+        self.flushed = True
+
+
+class OutputWrapperTests(SimpleTestCase):
+    def test_flush_forwards_to_underlying_stream(self):
+        stream = RecordingStream()
+        wrapper = OutputWrapper(stream)
+
+        wrapper.write("tick 0...", ending="")
+        wrapper.flush()
+
+        self.assertEqual(stream.writes, ["tick 0..."])
+        self.assertTrue(stream.flushed)


### PR DESCRIPTION
Fixes flush semantics for management commands by adding OutputWrapper.flush that forwards to the underlying stream.

# Issue
https://github.com/agyn-sandbox/django/issues/262

# Root cause
OutputWrapper inherits io.TextIOBase, which defines a no-op flush(). Without overriding flush(), calls to self.stdout.flush()/self.stderr.flush() resolve to TextIOBase.flush and never reach the wrapped stream.

# Reproduction
1. Demo command writing without newline and calling flush between iterations:
```python
from django.core.management.base import BaseCommand
import time

class Command(BaseCommand):
    help = "Flush demo to test incremental output"
    def handle(self, *args, **opts):
        for i in range(3):
            self.stdout.write(f"tick {i}...", ending="")
            self.stdout.flush()
            time.sleep(1)
            self.stdout.write(" done")
```
2. Run with non-TTY sink: `python manage.py flush_demo | cat`
3. Observed failure (pre-fix): Messages do not appear incrementally; they only show at the end. No stack trace; flush was a no-op masked by TextIOBase.

After the fix, running the same command shows each iteration immediately after calling flush().

# Fix
Implement OutputWrapper.flush() that forwards to the underlying stream's flush if present.

# Tests
- flake8 django/core/management/base.py tests/management/tests.py
- PYTHONPATH=/workspace/django /workspace/.venv/bin/python tests/runtests.py management --parallel=1

# Notes
- We will not run CI and will not merge this PR.
- Target base branch: django__django-13516.