### PR TITLE
swev-id: django__django-13590 - Fix namedtuple handling in Query.resolve_lookup_value for __range; add regression tests

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -1076,11 +1076,18 @@ class Query(BaseExpression):
             )
         elif isinstance(value, (list, tuple)):
             # The items of the iterable may be expressions and therefore need
-            # to be resolved independently.
-            return type(value)(
+            # to be resolved independently. Preserve the input type when
+            # reconstructing the sequence. For namedtuples, expand the
+            # resolved items as positional arguments to avoid passing a single
+            # iterable to the namedtuple constructor (which expects positional
+            # args).
+            iterable = (
                 self.resolve_lookup_value(sub_value, can_reuse, allow_joins)
                 for sub_value in value
             )
+            if isinstance(value, tuple) and hasattr(value, '_fields'):
+                return type(value)(*iterable)
+            return type(value)(iterable)
         return value
 
     def solve_lookup_type(self, lookup):

--- a/tests/queries/test_namedtuple_range.py
+++ b/tests/queries/test_namedtuple_range.py
@@ -1,0 +1,27 @@
+from collections import namedtuple
+
+from django.test import TestCase
+
+from .models import Number
+
+
+class NamedTupleRangeLookupTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Number.objects.bulk_create([
+            Number(num=v) for v in [1, 2, 3, 4, 5]
+        ])
+
+    def test_range_with_namedtuple_matches_tuple(self):
+        Range = namedtuple('Range', ['start', 'end'])
+        nt = Range(2, 4)
+        # Namedtuple should not raise and should match tuple behavior.
+        qs_named = Number.objects.filter(num__range=nt).order_by('id')
+        qs_tuple = Number.objects.filter(num__range=(2, 4)).order_by('id')
+        self.assertEqual(list(qs_named.values_list('id', flat=True)), list(qs_tuple.values_list('id', flat=True)))
+
+    def test_range_with_namedtuple_no_typeerror(self):
+        Range = namedtuple('Range', ['start', 'end'])
+        nt = Range(1, 3)
+        # Assert no exception is thrown by filter evaluation.
+        list(Number.objects.filter(num__range=nt))


### PR DESCRIPTION

Fixes regression described in #265.

Summary
- When upgrading 2.2→3.0, passing a namedtuple to `__range` raises `TypeError` because `Query.resolve_lookup_value()` reconstructs sequences via `type(value)(<iterable>)`. For namedtuples, this calls the constructor with a single iterable instead of positional arguments.
- This PR detects namedtuple instances (via `_fields`) and expands the resolved iterator: `type(value)(*iterable)`. Other lists/tuples are unchanged.

Tests
- Added `queries.test_namedtuple_range.NamedTupleRangeLookupTests`:
  - `test_range_with_namedtuple_no_typeerror`
  - `test_range_with_namedtuple_matches_tuple`

Observed failure (pre-fix)
```
TypeError: Range.__new__() missing 1 required positional argument: 'end'
  at django/db/models/sql/query.py:1080 in resolve_lookup_value
```

Behavior after fix
- No exception for namedtuple input to `__range`.
- Results match behavior when using a plain 2-tuple (consistent with Django 2.2).

