### PR TITLE
swev-id: django__django-13794 fix add filter lazy string concatenation

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -10,7 +10,7 @@ from urllib.parse import quote
 
 from django.utils import formats
 from django.utils.dateformat import format, time_format
-from django.utils.encoding import iri_to_uri
+from django.utils.encoding import force_str, iri_to_uri
 from django.utils.html import (
     avoid_wrapping, conditional_escape, escape, escapejs,
     json_script as _json_script, linebreaks, strip_tags, urlize as _urlize,
@@ -680,7 +680,13 @@ def add(value, arg):
         try:
             return value + arg
         except Exception:
-            return ''
+            try:
+                return (
+                    force_str(value, strings_only=True) +
+                    force_str(arg, strings_only=True)
+                )
+            except Exception:
+                return ''
 
 
 @register.filter(is_safe=False)

--- a/tests/template_tests/filter_tests/test_add.py
+++ b/tests/template_tests/filter_tests/test_add.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 
 from django.template.defaultfilters import add
 from django.test import SimpleTestCase
+from django.utils.translation import gettext_lazy
 
 from ..utils import setup
 
@@ -45,6 +46,16 @@ class AddTests(SimpleTestCase):
     def test_add07(self):
         output = self.engine.render_to_string('add07', {'d': date(2000, 1, 1), 't': timedelta(10)})
         self.assertEqual(output, 'Jan. 11, 2000')
+
+    @setup({'add08': '{{ s|add:l }}'})
+    def test_add08_lazy_right_operand(self):
+        output = self.engine.render_to_string('add08', {'s': 'foo', 'l': gettext_lazy('bar')})
+        self.assertEqual(output, 'foobar')
+
+    @setup({'add09': '{{ l|add:s }}'})
+    def test_add09_lazy_left_operand(self):
+        output = self.engine.render_to_string('add09', {'l': gettext_lazy('foo'), 's': 'bar'})
+        self.assertEqual(output, 'foobar')
 
 
 class FunctionTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- retain the original non-integer addition attempt before coercing operands to preserve existing behavior
- coerce string-like operands with force_str(strings_only=True) when native addition fails so lazy translations concatenate
- add regression coverage for str + lazy and lazy + str template cases

Closes #271

## Reproduction
- Template: `"{{ val|add:arg }}"`
- Case 1 context: `{ "val": "foo", "arg": gettext_lazy("bar") }`
- Case 2 context: `{ "val": gettext_lazy("foo"), "arg": "bar" }`
- Current output on `django__django-13794`: both cases render to an empty string because the filter catches `TypeError`.

## Stack Trace
```
Traceback (most recent call last):
  File "<stdin>", line 7, in <module>
TypeError: can only concatenate str (not "__proxy__") to str
```

## Testing
- source /workspace/.venv/bin/activate && flake8 django/template/defaultfilters.py tests/template_tests/filter_tests/test_add.py
- source /workspace/.venv/bin/activate && PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite ./tests/runtests.py template_tests.filter_tests.test_add --parallel=1