### PR TITLE
swev-id: django__django-13807 Quote SQLite PRAGMA table names

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -327,13 +327,15 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                     violations = cursor.execute('PRAGMA foreign_key_check').fetchall()
                 else:
                     violations = chain.from_iterable(
-                        cursor.execute('PRAGMA foreign_key_check(%s)' % table_name).fetchall()
+                        cursor.execute(
+                            'PRAGMA foreign_key_check(%s)' % self.ops.quote_name(table_name)
+                        ).fetchall()
                         for table_name in table_names
                     )
                 # See https://www.sqlite.org/pragma.html#pragma_foreign_key_check
                 for table_name, rowid, referenced_table_name, foreign_key_index in violations:
                     foreign_key = cursor.execute(
-                        'PRAGMA foreign_key_list(%s)' % table_name
+                        'PRAGMA foreign_key_list(%s)' % self.ops.quote_name(table_name)
                     ).fetchall()[foreign_key_index]
                     column_name, referenced_column_name = foreign_key[3:5]
                     primary_key_column_name = self.introspection.get_primary_key_column(cursor, table_name)

--- a/tests/fixtures_regress/fixtures/order_keyword.json
+++ b/tests/fixtures_regress/fixtures/order_keyword.json
@@ -1,0 +1,4 @@
+[
+  {"model": "fixtures_regress.keywordorder", "pk": 1, "fields": {"name": "O1"}},
+  {"model": "fixtures_regress.keywordorderitem", "pk": 1, "fields": {"order": 1, "name": "I1"}}
+]

--- a/tests/fixtures_regress/models.py
+++ b/tests/fixtures_regress/models.py
@@ -334,3 +334,15 @@ class M2MComplexCircular2B(BaseNKModel):
 class M2MCircular2ThroughAB(BaseNKModel):
     a = models.ForeignKey(M2MComplexCircular2A, models.CASCADE)
     b = models.ForeignKey(M2MComplexCircular2B, models.CASCADE)
+
+
+class KeywordOrder(models.Model):
+    name = models.CharField(max_length=50)
+
+    class Meta:
+        db_table = 'order'
+
+
+class KeywordOrderItem(models.Model):
+    order = models.ForeignKey(KeywordOrder, models.CASCADE, related_name='items')
+    name = models.CharField(max_length=50)

--- a/tests/fixtures_regress/tests.py
+++ b/tests/fixtures_regress/tests.py
@@ -17,12 +17,13 @@ from django.test import (
 
 from .models import (
     Absolute, Animal, Article, Book, Child, Circle1, Circle2, Circle3,
-    ExternalDependency, M2MCircular1ThroughAB, M2MCircular1ThroughBC,
-    M2MCircular1ThroughCA, M2MCircular2ThroughAB, M2MComplexA, M2MComplexB,
-    M2MComplexCircular1A, M2MComplexCircular1B, M2MComplexCircular1C,
-    M2MComplexCircular2A, M2MComplexCircular2B, M2MSimpleA, M2MSimpleB,
-    M2MSimpleCircularA, M2MSimpleCircularB, M2MThroughAB, NKChild, Parent,
-    Person, RefToNKChild, Store, Stuff, Thingy, Widget,
+    ExternalDependency, KeywordOrder, KeywordOrderItem, M2MCircular1ThroughAB,
+    M2MCircular1ThroughBC, M2MCircular1ThroughCA, M2MCircular2ThroughAB,
+    M2MComplexA, M2MComplexB, M2MComplexCircular1A, M2MComplexCircular1B,
+    M2MComplexCircular1C, M2MComplexCircular2A, M2MComplexCircular2B,
+    M2MSimpleA, M2MSimpleB, M2MSimpleCircularA, M2MSimpleCircularB,
+    M2MThroughAB, NKChild, Parent, Person, RefToNKChild, Store, Stuff,
+    Thingy, Widget,
 )
 
 _cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -151,6 +152,22 @@ class TestFixtures(TestCase):
             verbosity=0,
         )
         self.assertEqual(Absolute.objects.count(), 1)
+
+    @skipUnlessDBFeature('supports_pragma_foreign_key_check')
+    def test_loaddata_sqlite_keyword_table_name(self):
+        management.call_command(
+            'loaddata',
+            'order_keyword.json',
+            verbosity=0,
+        )
+        self.assertEqual(KeywordOrder.objects.count(), 1)
+        self.assertEqual(KeywordOrderItem.objects.count(), 1)
+        item = KeywordOrderItem.objects.select_related('order').get()
+        order = KeywordOrder.objects.get()
+        self.assertEqual(item.order_id, order.pk)
+        self.assertEqual(order.name, 'O1')
+        self.assertEqual(item.name, 'I1')
+        self.assertEqual(order.items.get(pk=item.pk), item)
 
     def test_relative_path(self, path=['fixtures', 'absolute.json']):
         relative_path = os.path.join(*path)


### PR DESCRIPTION
## Summary
- quote SQLite PRAGMA foreign key lookups with `DatabaseOperations.quote_name()` so reserved identifiers like `order` load cleanly
- add `KeywordOrder`/`KeywordOrderItem` models, fixture, and regression test covering `loaddata` on a reserved table name

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py fixtures_regress.tests --parallel=1

## Observed failure & reproduction
- Command: PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py fixtures_regress.tests.TestFixtures.test_loaddata_sqlite_keyword_table_name --parallel=1
- Stack trace excerpt:
  ```
  File "django/db/backends/sqlite3/base.py", line 414, in execute
    return Database.Cursor.execute(self, query)
sqlite3.OperationalError: near "order": syntax error
...
  File "django/db/backends/sqlite3/base.py", line 330, in <genexpr>
    cursor.execute('PRAGMA foreign_key_check(%s)' % table_name).fetchall()
django.db.utils.OperationalError: Problem installing fixtures: near "order": syntax error
  ```
- Steps:
  1. git checkout django__django-13807
  2. PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py fixtures_regress.tests.TestFixtures.test_loaddata_sqlite_keyword_table_name --parallel=1

Fixes #272.