### PR TITLE
ASGI: prevent async handler leakage on MiddlewareNotUsed (swev-id: django__django-13810)

### DIFF
--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -50,12 +50,13 @@ class BaseHandler:
             else:
                 middleware_is_async = middleware_can_async
             try:
-                # Adapt handler, if needed.
-                handler = self.adapt_method_mode(
+                # Adapt handler, if needed, but don't leak adaptations when
+                # middleware decides not to run.
+                adapted_handler = self.adapt_method_mode(
                     middleware_is_async, handler, handler_is_async,
                     debug=settings.DEBUG, name='middleware %s' % middleware_path,
                 )
-                mw_instance = middleware(handler)
+                mw_instance = middleware(adapted_handler)
             except MiddlewareNotUsed as exc:
                 if settings.DEBUG:
                     if str(exc):

--- a/tests/middleware_exceptions/middleware.py
+++ b/tests/middleware_exceptions/middleware.py
@@ -1,3 +1,6 @@
+import asyncio
+
+from django.core.exceptions import MiddlewareNotUsed
 from django.http import Http404, HttpResponse
 from django.template import engines
 from django.template.response import TemplateResponse
@@ -6,6 +9,13 @@ from django.utils.decorators import (
 )
 
 log = []
+
+
+def _is_async_callable(callback):
+    if asyncio.iscoroutinefunction(callback):
+        return True
+    call = getattr(callback, '__call__', None)
+    return asyncio.iscoroutinefunction(call)
 
 
 class BaseMiddleware:
@@ -130,3 +140,38 @@ class NotSyncOrAsyncMiddleware(BaseMiddleware):
 
     def __call__(self, request):
         return self.get_response(request)
+
+
+@sync_only_middleware
+class NotUsedSyncMiddleware:
+
+    def __init__(self, get_response):
+        raise MiddlewareNotUsed
+
+
+@async_only_middleware
+class AsyncProbeMiddleware(BaseMiddleware):
+
+    init_is_async = None
+
+    def __init__(self, get_response):
+        super().__init__(get_response)
+        is_async = _is_async_callable(get_response)
+        self.init_is_async = is_async
+        AsyncProbeMiddleware.init_is_async = is_async
+
+    async def __call__(self, request):
+        response = await self.get_response(request)
+        return response
+
+
+@sync_only_middleware
+class ToolbarSyncMiddleware(BaseMiddleware):
+
+    init_is_async = None
+
+    def __init__(self, get_response):
+        super().__init__(get_response)
+        is_async = _is_async_callable(get_response)
+        self.init_is_async = is_async
+        ToolbarSyncMiddleware.init_is_async = is_async

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -1,5 +1,10 @@
+import os
+from importlib import import_module
+
+from asgiref.sync import async_to_sync
 from django.conf import settings
-from django.core.exceptions import MiddlewareNotUsed
+from django.core.asgi import get_asgi_application
+from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
@@ -187,6 +192,13 @@ class MiddlewareNotUsedTests(SimpleTestCase):
     ROOT_URLCONF='middleware_exceptions.urls',
 )
 class MiddlewareSyncAsyncTests(SimpleTestCase):
+
+    def tearDown(self):
+        mw.log = []
+        mw.AsyncProbeMiddleware.init_is_async = None
+        mw.ToolbarSyncMiddleware.init_is_async = None
+        super().tearDown()
+
     @override_settings(MIDDLEWARE=[
         'middleware_exceptions.middleware.PaymentMiddleware',
     ])
@@ -282,6 +294,28 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
         self.assertEqual(response.content, b'OK')
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(MIDDLEWARE=[
+        'middleware_exceptions.middleware.NotUsedSyncMiddleware',
+        'middleware_exceptions.middleware.AsyncProbeMiddleware',
+    ])
+    async def test_not_used_sync_middleware_does_not_leak_async_handler(self):
+        mw.AsyncProbeMiddleware.init_is_async = None
+        response = await self.async_client.get('/middleware_exceptions/view/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(mw.AsyncProbeMiddleware.init_is_async)
+
+    @override_settings(MIDDLEWARE=[
+        'middleware_exceptions.middleware.ToolbarSyncMiddleware',
+        'middleware_exceptions.middleware.AsyncProbeMiddleware',
+    ])
+    async def test_mixed_sync_async_middleware_preserves_handler_modes(self):
+        mw.AsyncProbeMiddleware.init_is_async = None
+        mw.ToolbarSyncMiddleware.init_is_async = None
+        response = await self.async_client.get('/middleware_exceptions/view/')
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(mw.ToolbarSyncMiddleware.init_is_async)
+        self.assertTrue(mw.AsyncProbeMiddleware.init_is_async)
+
 
 @override_settings(ROOT_URLCONF='middleware_exceptions.urls')
 class AsyncMiddlewareTests(SimpleTestCase):
@@ -339,3 +373,64 @@ class AsyncMiddlewareTests(SimpleTestCase):
     async def test_process_view_return_response(self):
         response = await self.async_client.get('/middleware_exceptions/view/')
         self.assertEqual(response.content, b'Processed view normal_view')
+
+
+@override_settings(ROOT_URLCONF='middleware_exceptions.urls')
+class ASGIMiddlewareExceptionTests(SimpleTestCase):
+
+    def tearDown(self):
+        mw.log = []
+        mw.AsyncProbeMiddleware.init_is_async = None
+        mw.ToolbarSyncMiddleware.init_is_async = None
+        super().tearDown()
+
+    def test_get_asgi_application_surfaces_improperly_configured(self):
+        session_dir = os.path.join(os.path.dirname(__file__), 'nonexistent_sessions_dir')
+        if os.path.exists(session_dir):
+            session_dir = os.path.join(session_dir, 'missing')
+        with self.settings(
+            DEBUG=True,
+            SESSION_ENGINE='django.contrib.sessions.backends.file',
+            SESSION_FILE_PATH=session_dir,
+            MIDDLEWARE=['django.contrib.sessions.middleware.SessionMiddleware'],
+        ):
+            engine = import_module(settings.SESSION_ENGINE)
+            if hasattr(engine.SessionStore, '_storage_path'):
+                del engine.SessionStore._storage_path
+            with self.assertRaises(ImproperlyConfigured):
+                engine.SessionStore()
+            application = get_asgi_application()
+            scope = {
+                'type': 'http',
+                'http_version': '1.1',
+                'method': 'GET',
+                'path': '/',
+                'raw_path': b'/',
+                'headers': [],
+                'query_string': b'',
+                'client': ('127.0.0.1', 0),
+                'server': ('testserver', 80),
+            }
+
+            async def receive():
+                return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+            sent_messages = []
+
+            async def send(message):
+                sent_messages.append(message)
+
+            async_to_sync(application)(scope, receive, send)
+
+            self.assertTrue(sent_messages)
+            response_start = next(
+                message for message in sent_messages
+                if message['type'] == 'http.response.start'
+            )
+            self.assertEqual(response_start['status'], 500)
+            body = b''.join(
+                message.get('body', b'')
+                for message in sent_messages
+                if message['type'] == 'http.response.body'
+            )
+            self.assertIn(b'The session storage path', body)

--- a/tests/middleware_exceptions/tests.py
+++ b/tests/middleware_exceptions/tests.py
@@ -313,7 +313,7 @@ class MiddlewareSyncAsyncTests(SimpleTestCase):
         mw.ToolbarSyncMiddleware.init_is_async = None
         response = await self.async_client.get('/middleware_exceptions/view/')
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(mw.ToolbarSyncMiddleware.init_is_async)
+        self.assertIs(mw.ToolbarSyncMiddleware.init_is_async, False)
         self.assertTrue(mw.AsyncProbeMiddleware.init_is_async)
 
 


### PR DESCRIPTION
## Summary
- guard BaseHandler.load_middleware() from mutating the shared handler when a middleware raises `MiddlewareNotUsed`
- add async/sync probe middleware used by regression coverage
- extend middleware_exceptions suite to cover the reported ASGI regressions

## Reproduction
1. Configure `settings.MIDDLEWARE` to contain a sync-only toolbar-style middleware followed by an async-only middleware, e.g.
   ```python
   MIDDLEWARE = [
       "middleware_exceptions.middleware.NotUsedSyncMiddleware",
       "middleware_exceptions.middleware.AsyncProbeMiddleware",
       "django.contrib.sessions.middleware.SessionMiddleware",
   ]
   ```
2. Call `django.core.asgi.get_asgi_application()` and dispatch an ASGI request to `/middleware_exceptions/view/`.

## Observed failure
```
Traceback (most recent call last):
  File "django/core/handlers/exception.py", line 47, in inner
    response = await get_response(request)
  File "django/utils/deprecation.py", line 126, in __acall__
    response = await sync_to_async(self.get_response, thread_sensitive=True)(request)
  File "tests/middleware_exceptions/middleware.py", line 170, in __call__
    response = await self.get_response(request)
TypeError: HttpResponse can't be awaited
```

## Fix
- adapt the handler into a local variable while instantiating a middleware and only promote it to the shared handler after the middleware is accepted
- add `NotUsedSyncMiddleware`, `AsyncProbeMiddleware`, and `ToolbarSyncMiddleware` fixtures that record the handler mode they receive
- add regression tests covering the `MiddlewareNotUsed` ASGI path, mixed sync/async ordering, and propagation of `ImproperlyConfigured` for invalid file session storage

## Testing
- `PYTHONPATH=$PWD ./tests/runtests.py middleware_exceptions --parallel=1`
- `flake8 tests/middleware_exceptions/middleware.py tests/middleware_exceptions/tests.py`

Local tests pass.

Fixes #276.