### PR TITLE
fix: swev-id: django__django-13820 allow migrations packages without __file__

### DIFF
--- a/django/db/migrations/loader.py
+++ b/django/db/migrations/loader.py
@@ -1,3 +1,5 @@
+import importlib.machinery
+import importlib.util
 import pkgutil
 import sys
 from importlib import import_module, reload
@@ -88,9 +90,22 @@ class MigrationLoader:
                     continue
                 raise
             else:
-                # Empty directories are namespaces.
-                # getattr() needed on PY36 and older (replace w/attribute access).
-                if getattr(module, '__file__', None) is None:
+                spec = getattr(module, '__spec__', None)
+                if spec is None:
+                    try:
+                        spec = importlib.util.find_spec(module.__name__)
+                    except (ImportError, AttributeError, ValueError):
+                        spec = None
+                if (
+                    spec is not None and
+                    spec.submodule_search_locations is not None and
+                    spec.origin is None and
+                    (
+                        spec.loader is None or
+                        isinstance(spec.loader, importlib.machinery.NamespaceLoader)
+                    )
+                ):
+                    # PEP 420 namespace packages aren't valid migrations packages.
                     self.unmigrated_apps.add(app_config.label)
                     continue
                 # Module is not a package (e.g. migrations.py).
@@ -100,9 +115,14 @@ class MigrationLoader:
                 # Force a reload if it's already loaded (tests need this)
                 if was_loaded:
                     reload(module)
+                search_locations = (
+                    spec.submodule_search_locations
+                    if spec is not None and spec.submodule_search_locations is not None
+                    else module.__path__
+                )
             self.migrated_apps.add(app_config.label)
             migration_names = {
-                name for _, name, is_pkg in pkgutil.iter_modules(module.__path__)
+                name for _, name, is_pkg in pkgutil.iter_modules(search_locations)
                 if not is_pkg and name[0] not in '_~'
             }
             # Load migrations

--- a/docs/ref/applications.txt
+++ b/docs/ref/applications.txt
@@ -349,6 +349,12 @@ following is true:
 If neither of these conditions is met, Django will raise
 :exc:`~django.core.exceptions.ImproperlyConfigured`.
 
+Regardless of how the application itself is provided, its ``migrations``
+subpackage must not be a :pep:`420` namespace package. Django relies on the
+module's :class:`importlib.machinery.ModuleSpec` loader to enumerate migration
+files and will treat the application as unmigrated if the migrations module is
+namespace-only.
+
 Application registry
 ====================
 

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -43,6 +43,23 @@ staging machines, and eventually your production machines.
     migrations on a per-app basis by modifying the :setting:`MIGRATION_MODULES`
     setting.
 
+Migration discovery and namespace packages
+==========================================
+
+Django discovers migrations by importing each application's migrations module
+and iterating over the module's submodule search locations. The migrations
+module must provide a loader through its
+:attr:`importlib.machinery.ModuleSpec.loader` so Django can enumerate its
+:attr:`importlib.machinery.ModuleSpec.submodule_search_locations`. Packages
+loaded by custom import hooks (for example, from zip files) may legitimately
+lack a ``__file__`` attribute; Django accepts those packages as long as a
+loader is present. True :pep:`420` namespace packages expose search locations
+without a loader, so Django cannot reliably list their contents. In that case
+the application is treated as unmigrated and its migrations are ignored. Ensure
+that an application's migrations package is implemented as a regular package
+(for example, by including an ``__init__.py`` or a custom loader) when using
+namespace packages elsewhere in your project.
+
 Migrations will run the same way on the same dataset and produce consistent
 results, meaning that what you see in development and staging is, under the
 same circumstances, exactly what will happen in production.

--- a/tests/migrations/test_loader.py
+++ b/tests/migrations/test_loader.py
@@ -1,5 +1,9 @@
 import compileall
+import importlib.abc
+import importlib.machinery
 import os
+import sys
+from contextlib import contextmanager
 
 from django.db import connection, connections
 from django.db.migrations.exceptions import (
@@ -10,6 +14,56 @@ from django.db.migrations.recorder import MigrationRecorder
 from django.test import TestCase, modify_settings, override_settings
 
 from .test_base import MigrationTestBase
+
+
+class _RemovingFileLoader(importlib.abc.Loader):
+    def __init__(self, wrapped_loader):
+        self.wrapped_loader = wrapped_loader
+
+    def create_module(self, spec):
+        create_module = getattr(self.wrapped_loader, 'create_module', None)
+        if create_module is None:
+            return None
+        return create_module(spec)
+
+    def exec_module(self, module):
+        self.wrapped_loader.exec_module(module)
+        module.__dict__.pop('__file__', None)
+
+    def __getattr__(self, attr):
+        return getattr(self.wrapped_loader, attr)
+
+
+class _RemovingFileFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, targets):
+        self.targets = set(targets)
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname not in self.targets:
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if spec is None or spec.loader is None:
+            return spec
+        spec.loader = _RemovingFileLoader(spec.loader)
+        return spec
+
+
+def _clear_modules(module_prefix):
+    for name in list(sys.modules):
+        if name == module_prefix or name.startswith('%s.' % module_prefix):
+            sys.modules.pop(name, None)
+
+
+@contextmanager
+def removing_module_file(module_prefix, targets):
+    _clear_modules(module_prefix)
+    finder = _RemovingFileFinder(targets)
+    sys.meta_path.insert(0, finder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+        _clear_modules(module_prefix)
 
 
 class RecorderTests(TestCase):
@@ -183,12 +237,33 @@ class LoaderTests(TestCase):
                 "App with migrations module file not in unmigrated apps."
             )
 
-    def test_load_empty_dir(self):
+    @override_settings(MIGRATION_MODULES={
+        "migrated_app": "migrations.migrations_test_apps.migrated_app.migrations",
+    })
+    @modify_settings(INSTALLED_APPS={'append': 'migrations.migrations_test_apps.migrated_app'})
+    def test_load_standard_package_with_file(self):
+        loader = MigrationLoader(connection)
+        self.assertIn('migrated_app', loader.migrated_apps)
+        self.assertNotIn('migrated_app', loader.unmigrated_apps)
+
+    @override_settings(MIGRATION_MODULES={
+        "migrated_app": "migrations.migrations_test_apps.migrated_app.migrations",
+    })
+    @modify_settings(INSTALLED_APPS={'append': 'migrations.migrations_test_apps.migrated_app'})
+    def test_load_package_without_file_via_import_hook(self):
+        module_prefix = 'migrations.migrations_test_apps.migrated_app'
+        migrations_module = f'{module_prefix}.migrations'
+        with removing_module_file(module_prefix, {migrations_module}):
+            loader = MigrationLoader(connection)
+        self.assertIn('migrated_app', loader.migrated_apps)
+        self.assertNotIn('migrated_app', loader.unmigrated_apps)
+
+    def test_load_namespace_package_rejected(self):
         with override_settings(MIGRATION_MODULES={"migrations": "migrations.faulty_migrations.namespace"}):
             loader = MigrationLoader(connection)
             self.assertIn(
                 "migrations", loader.unmigrated_apps,
-                "App missing __init__.py in migrations module not in unmigrated apps."
+                "Namespace migrations package unexpectedly treated as migrated."
             )
 
     @override_settings(


### PR DESCRIPTION
## Summary
- update `MigrationLoader` to use `ModuleSpec` metadata to distinguish PEP 420 namespaces from regular packages lacking `__file__`
- add regression coverage for standard packages, custom loaders that drop `__file__`, and true namespace packages
- document the namespace-package requirement for migrations modules in both the migrations and app reference guides

## Testing
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv311/bin/python tests/runtests.py migrations --parallel=1`
- `/workspace/.venv311/bin/flake8 django/db/migrations/loader.py tests/migrations/test_loader.py`

## Observed failure
```
ValueError: Dependency on app with no migrations: myapp
```

## Stack trace
```
File "django/db/migrations/loader.py", line ~177, in check_key
    raise ValueError("Dependency on app with no migrations: %s" % key[0])
```

## Reproduction steps
1. Create an app with `myapp/migrations/__init__.py` and a `0001_initial.py` migration.
2. Install a meta path loader that deletes `__file__` from `myapp` and `myapp.migrations` while preserving the loader and search locations.
3. Add the app to `INSTALLED_APPS` and construct a `MigrationLoader`.
4. Attempt to load the migration graph; the loader misclassifies the app as unmigrated, triggering the failure above.

Fixes #277

_Local verification:_ All commands above completed successfully.