### PR TITLE
fix(sqlite): swev-id: django__django-13821 require SQLite 3.9.0+

### DIFF
--- a/django/db/backends/sqlite3/base.py
+++ b/django/db/backends/sqlite3/base.py
@@ -33,6 +33,7 @@ from .features import DatabaseFeatures
 from .introspection import DatabaseIntrospection
 from .operations import DatabaseOperations
 from .schema import DatabaseSchemaEditor
+from .validation import DatabaseValidation
 
 
 def decoder(conv_func):
@@ -64,8 +65,8 @@ def list_aggregate(function):
 
 
 def check_sqlite_version():
-    if Database.sqlite_version_info < (3, 8, 3):
-        raise ImproperlyConfigured('SQLite 3.8.3 or later is required (found %s).' % Database.sqlite_version)
+    if Database.sqlite_version_info < (3, 9, 0):
+        raise ImproperlyConfigured('SQLite 3.9.0 or later is required (found %s).' % Database.sqlite_version)
 
 
 check_sqlite_version()
@@ -165,6 +166,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     Database = Database
     SchemaEditorClass = DatabaseSchemaEditor
+    validation_class = DatabaseValidation
     # Classes instantiated in __init__().
     client_class = DatabaseClient
     creation_class = DatabaseCreation

--- a/django/db/backends/sqlite3/validation.py
+++ b/django/db/backends/sqlite3/validation.py
@@ -1,0 +1,22 @@
+from sqlite3 import dbapi2 as Database
+
+from django.core import checks
+from django.db.backends.base.validation import BaseDatabaseValidation
+
+
+class DatabaseValidation(BaseDatabaseValidation):
+    def check(self, **kwargs):
+        issues = super().check(**kwargs)
+        issues.extend(self._check_sqlite_version())
+        return issues
+
+    def _check_sqlite_version(self):
+        if Database.sqlite_version_info < (3, 9, 0):
+            return [checks.Error(
+                "SQLite 3.9.0 or later is required (found %s)." % Database.sqlite_version,
+                hint=(
+                    "Upgrade SQLite to ≥ 3.9.0 or switch to a supported database backend."
+                ),
+                id='sqlite.E001',
+            )]
+        return []

--- a/docs/ref/contrib/gis/install/index.txt
+++ b/docs/ref/contrib/gis/install/index.txt
@@ -61,7 +61,7 @@ Database            Library Requirements            Supported Versions  Notes
 PostgreSQL          GEOS, GDAL, PROJ, PostGIS       9.6+                Requires PostGIS.
 MySQL               GEOS, GDAL                      5.7+                :ref:`Limited functionality <mysql-spatial-limitations>`.
 Oracle              GEOS, GDAL                      12.2+               XE not supported.
-SQLite              GEOS, GDAL, PROJ, SpatiaLite    3.8.3+              Requires SpatiaLite 4.3+
+SQLite              GEOS, GDAL, PROJ, SpatiaLite    3.9.0+              Requires SpatiaLite 4.3+
 ==================  ==============================  ==================  =========================================
 
 See also `this comparison matrix`__ on the OSGeo Wiki for

--- a/docs/ref/databases.txt
+++ b/docs/ref/databases.txt
@@ -679,7 +679,7 @@ appropriate typecasting.
 SQLite notes
 ============
 
-Django supports SQLite 3.8.3 and later.
+Django supports SQLite 3.9.0 and later.
 
 SQLite_ provides an excellent development alternative for applications that
 are predominantly read-only or require a smaller installation footprint. As

--- a/docs/releases/3.2.txt
+++ b/docs/releases/3.2.txt
@@ -605,6 +605,13 @@ Dropped support for MySQL 5.6
 The end of upstream support for MySQL 5.6 is April 2021. Django 3.2 supports
 MySQL 5.7 and higher.
 
+Dropped support for SQLite 3.8
+------------------------------
+
+SQLite 3.9.0 or later is now required. Earlier versions fail fast with the
+new ``sqlite.E001`` system check that reports the detected SQLite version and
+recommends upgrading SQLite or switching to a supported database backend.
+
 Miscellaneous
 -------------
 

--- a/tests/backends/sqlite/test_validation.py
+++ b/tests/backends/sqlite/test_validation.py
@@ -1,0 +1,32 @@
+import unittest
+from sqlite3 import dbapi2
+from unittest import mock
+
+from django.core import checks
+from django.db import connection
+from django.test import SimpleTestCase
+
+
+@unittest.skipUnless(connection.vendor == 'sqlite', 'SQLite tests')
+class ValidationTests(SimpleTestCase):
+    def test_sqlite_version_too_old(self):
+        with mock.patch.object(dbapi2, 'sqlite_version_info', (3, 8, 2)), \
+                mock.patch.object(dbapi2, 'sqlite_version', '3.8.2'):
+            self.assertEqual(
+                connection.validation.check(),
+                [
+                    checks.Error(
+                        'SQLite 3.9.0 or later is required (found 3.8.2).',
+                        hint=(
+                            'Upgrade SQLite to ≥ 3.9.0 or switch to a supported '
+                            'database backend.'
+                        ),
+                        id='sqlite.E001',
+                    )
+                ],
+            )
+
+    def test_sqlite_version_supported(self):
+        with mock.patch.object(dbapi2, 'sqlite_version_info', (3, 9, 0)), \
+                mock.patch.object(dbapi2, 'sqlite_version', '3.9.0'):
+            self.assertEqual(connection.validation.check(), [])

--- a/tests/backends/sqlite/tests.py
+++ b/tests/backends/sqlite/tests.py
@@ -30,7 +30,7 @@ class Tests(TestCase):
     longMessage = True
 
     def test_check_sqlite_version(self):
-        msg = 'SQLite 3.8.3 or later is required (found 3.8.2).'
+        msg = 'SQLite 3.9.0 or later is required (found 3.8.2).'
         with mock.patch.object(dbapi2, 'sqlite_version_info', (3, 8, 2)), \
                 mock.patch.object(dbapi2, 'sqlite_version', '3.8.2'), \
                 self.assertRaisesMessage(ImproperlyConfigured, msg):


### PR DESCRIPTION
## Summary
- enforce SQLite 3.9.0+ at import time and via the sqlite.E001 system check (Fixes #282)
- add sqlite backend validation coverage for both error and supported versions
- update database and GIS documentation to reflect the new minimum SQLite requirement

## Testing
- .venv/bin/python tests/runtests.py backends.sqlite --parallel=1
- .venv/bin/python -m flake8 django/db/backends/sqlite3/base.py django/db/backends/sqlite3/validation.py tests/backends/sqlite/tests.py tests/backends/sqlite/test_validation.py

## Observed failure and reproduction
Simulated libsqlite3 3.8.2 by monkeypatching sqlite3.dbapi2 before importing the backend (directly reproduces the import-time guard when using an older SQLite runtime):
```
cd /workspace/django && .venv/bin/python - <<'SQLITE'
from unittest import mock
from sqlite3 import dbapi2

with mock.patch.object(dbapi2, 'sqlite_version_info', (3, 8, 2)), \
        mock.patch.object(dbapi2, 'sqlite_version', '3.8.2'):
    from django.db.backends.sqlite3 import base
SQLITE
```
Output:
```
Traceback (most recent call last):
  File "<stdin>", line 6, in <module>
  File "/workspace/django/django/db/backends/sqlite3/base.py", line 72, in <module>
    check_sqlite_version()
  File "/workspace/django/django/db/backends/sqlite3/base.py", line 69, in check_sqlite_version
    raise ImproperlyConfigured('SQLite 3.9.0 or later is required (found %s).' % Database.sqlite_version)
django.core.exceptions.ImproperlyConfigured: SQLite 3.9.0 or later is required (found 3.8.2).
```
