### PR TITLE
Add --skip-checks to runserver (swev-id: django__django-13809)

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -51,6 +51,10 @@ class Command(BaseCommand):
             '--noreload', action='store_false', dest='use_reloader',
             help='Tells Django to NOT use the auto-reloader.',
         )
+        parser.add_argument(
+            '--skip-checks', action='store_true',
+            help='Skip system checks.',
+        )
 
     def execute(self, *args, **options):
         if options['no_color']:
@@ -114,8 +118,9 @@ class Command(BaseCommand):
         shutdown_message = options.get('shutdown_message', '')
         quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
 
-        self.stdout.write("Performing system checks...\n\n")
-        self.check(display_num_errors=True)
+        if not options['skip_checks']:
+            self.stdout.write("Performing system checks...\n\n")
+            self.check(display_num_errors=True)
         # Need to check migrations here, so can't use the
         # requires_migrations_check attribute.
         self.check_migrations()

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -1001,6 +1001,14 @@ have already been loaded into memory.
 Disables use of threading in the development server. The server is
 multithreaded by default.
 
+.. django-admin-option:: --skip-checks
+
+Skips the system check framework when starting the server. This is intended
+for temporary local debugging when a known system check prevents the server
+from running. Combine with :option:`--noreload <django-admin runserver --noreload>`
+to avoid the autoreloader running the command twice. Always restore the checks
+before committing changes or deploying.
+
 .. django-admin-option:: --ipv6, -6
 
 Uses IPv6 for the development server. This changes the default IP address from

--- a/docs/topics/checks.txt
+++ b/docs/topics/checks.txt
@@ -19,6 +19,41 @@ running at all. Minor problems are reported to the console. If you have inspecte
 the cause of a warning and are happy to ignore it, you can hide specific warnings
 using the :setting:`SILENCED_SYSTEM_CHECKS` setting in your project settings file.
 
+Skipping checks during local debugging
+--------------------------------------
+
+When you need to inspect a problem that prevents :djadmin:`runserver` from
+starting, you can temporarily bypass the system checks by combining
+``runserver`` with the ``--skip-checks`` flag. This is useful when a blocking
+check (for example ``admin.E037``) is already understood and you still want to
+exercise other behavior locally.
+
+For example, first run ``runserver`` with ``--traceback`` to confirm the
+blocking check::
+
+    $ python manage.py runserver --traceback
+    ...
+    django.core.management.base.SystemCheckError: System check identified some
+    issues:
+    ... (admin.E037) ...
+
+Then rerun the development server while skipping the checks. Using ``--noreload``
+avoids the autoreloader running the command twice::
+
+    $ python manage.py runserver 127.0.0.1:8001 --skip-checks --noreload
+    You have 18 unapplied migration(s). Your project may not work properly
+    until you apply the migrations for app(s): admin, auth, contenttypes,
+    sessions.
+    Run 'python manage.py migrate' to apply them.
+    December 21, 2025 - 19:40:22
+    Django version 4.0, using settings 'demo.settings'
+    Starting development server at http://127.0.0.1:8001/
+    Quit the server with CONTROL-C.
+
+Only disable checks when you already understand the failure and need to move
+forward temporarily. Restore the checks before committing changes so that
+system check regressions are caught.
+
 A full list of all checks that can be raised by Django can be found in the
 :doc:`System check reference </ref/checks>`.
 

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import ExitStack
 from io import StringIO
 from unittest import mock
 
@@ -1312,6 +1313,98 @@ class ManageRunserver(SimpleTestCase):
             self.cmd.check_migrations()
         # You have # ...
         self.assertIn('unapplied migration(s)', self.output.getvalue())
+
+
+class ManageRunserverSkipChecks(SimpleTestCase):
+
+    def setUp(self):
+        self.stdout = StringIO()
+        self.command = RunserverCommand(stdout=self.stdout)
+        self.command.addr = '127.0.0.1'
+        self.command.port = '8000'
+        self.command.use_ipv6 = False
+        self.command._raw_ipv6 = False
+
+    def _run_inner(self, skip_checks):
+        options = {
+            'use_threading': True,
+            'shutdown_message': '',
+            'skip_checks': skip_checks,
+        }
+        runserver_module = 'django.core.management.commands.runserver'
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch(f'{runserver_module}.autoreload.raise_last_exception'))
+            mock_get_handler = stack.enter_context(
+                mock.patch.object(
+                    RunserverCommand,
+                    'get_handler',
+                    return_value=mock.sentinel.handler,
+                )
+            )
+            mock_check = stack.enter_context(mock.patch.object(RunserverCommand, 'check'))
+            mock_check_migrations = stack.enter_context(
+                mock.patch.object(RunserverCommand, 'check_migrations')
+            )
+            mock_run = stack.enter_context(mock.patch(f'{runserver_module}.run'))
+            self.command.inner_run(**options)
+        return {
+            'get_handler': mock_get_handler,
+            'check': mock_check,
+            'check_migrations': mock_check_migrations,
+            'run': mock_run,
+        }
+
+    def test_inner_run_performs_checks_by_default(self):
+        mocks = self._run_inner(skip_checks=False)
+        mocks['check'].assert_called_once_with(display_num_errors=True)
+        mocks['check_migrations'].assert_called_once_with()
+        mocks['get_handler'].assert_called_once()
+        mocks['run'].assert_called_once_with(
+            '127.0.0.1', 8000, mock.sentinel.handler,
+            ipv6=False, threading=True, server_cls=self.command.server_cls,
+        )
+        self.assertIn('Performing system checks...', self.stdout.getvalue())
+
+    def test_inner_run_skips_checks_when_requested(self):
+        mocks = self._run_inner(skip_checks=True)
+        mocks['check'].assert_not_called()
+        mocks['check_migrations'].assert_called_once_with()
+        mocks['get_handler'].assert_called_once()
+        mocks['run'].assert_called_once_with(
+            '127.0.0.1', 8000, mock.sentinel.handler,
+            ipv6=False, threading=True, server_cls=self.command.server_cls,
+        )
+        self.assertNotIn('Performing system checks...', self.stdout.getvalue())
+
+    def test_call_command_skip_checks_kwarg_bypasses_checks(self):
+        def fake_run_with_reloader(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        runserver_module = 'django.core.management.commands.runserver'
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch(f'{runserver_module}.autoreload.raise_last_exception'))
+            stack.enter_context(
+                mock.patch(
+                    f'{runserver_module}.autoreload.run_with_reloader',
+                    side_effect=fake_run_with_reloader,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    RunserverCommand,
+                    'get_handler',
+                    return_value=mock.sentinel.handler,
+                )
+            )
+            mock_check = stack.enter_context(mock.patch.object(RunserverCommand, 'check'))
+            mock_check_migrations = stack.enter_context(
+                mock.patch.object(RunserverCommand, 'check_migrations')
+            )
+            mock_run = stack.enter_context(mock.patch(f'{runserver_module}.run'))
+            call_command('runserver', skip_checks=True, stdout=StringIO())
+        mock_check.assert_not_called()
+        mock_check_migrations.assert_called_once_with()
+        mock_run.assert_called_once()
 
 
 class ManageRunserverMigrationWarning(TestCase):


### PR DESCRIPTION
## Summary
- add a --skip-checks flag to runserver so developers can bypass system checks intentionally
- expand admin_scripts coverage for the new flag, verifying the default and opt-out paths
- document the option and local debugging workflow in the system checks and django-admin references

## Rationale
- https://code.djangoproject.com/ticket/13809

## Observed Failure
Repro:
1. Create a `catalog.BookAdmin` with a broken `autocomplete_fields = ['nonexistent_field']` entry.
2. Run `python manage.py runserver --traceback`.

Stack trace:
```
Watching for file changes with StatReloader
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/usr/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/workspace/django/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/workspace/django/django/core/management/commands/runserver.py", line 123, in inner_run
    self.check(display_num_errors=True)
  File "/workspace/django/django/core/management/base.py", line 469, in check
    raise SystemCheckError(msg)
django.core.management.base.SystemCheckError: SystemCheckError: System check identified some issues:

ERRORS:
<class 'catalog.admin.BookAdmin'>: (admin.E037) The value of 'autocomplete_fields[0]' refers to 'nonexistent_field', which is not an attribute of 'catalog.Book'.

System check identified 1 issue (0 silenced).
```

## Behavior with `--skip-checks`
```
$ python manage.py runserver 127.0.0.1:8002 --skip-checks --noreload
You have 18 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, sessions.
Run 'python manage.py migrate' to apply them.
December 21, 2025 - 19:48:41
Django version 4.0, using settings 'demo.settings'
Starting development server at http://127.0.0.1:8002/
Quit the server with CONTROL-C.
```

## Testing
- flake8 django/core/management/commands/runserver.py tests/admin_scripts/tests.py
- python tests/runtests.py admin_scripts --parallel=1