### PR TITLE
fix: handle __main__ spec parent (swev-id: django__django-13837)

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -220,9 +220,17 @@ def get_child_arguments():
 
     main_module = sys.modules.get('__main__')
     main_spec = getattr(main_module, '__spec__', None)
-    module_parent = getattr(main_spec, 'parent', None)
-    if module_parent:
-        return [*args, '-m', module_parent, *sys.argv[1:]]
+    if main_spec is not None:
+        spec_parent = getattr(main_spec, 'parent', None)
+        if spec_parent != '':
+            spec_name = getattr(main_spec, 'name', None)
+            if spec_name:
+                module_target = spec_name
+                if spec_parent and spec_name == '%s.__main__' % spec_parent:
+                    module_target = spec_parent
+                return [*args, '-m', module_target, *sys.argv[1:]]
+            if spec_parent:
+                return [*args, '-m', spec_parent, *sys.argv[1:]]
 
     py_script = Path(sys.argv[0])
     if not py_script.exists():

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -216,16 +216,16 @@ def get_child_arguments():
     executable is reported to not have the .exe extension which can cause bugs
     on reloading.
     """
-    import django.__main__
-    django_main_path = Path(django.__main__.__file__)
-    py_script = Path(sys.argv[0])
-
     args = [sys.executable] + ['-W%s' % o for o in sys.warnoptions]
-    if py_script == django_main_path:
-        # The server was started with `python -m django runserver`.
-        args += ['-m', 'django']
-        args += sys.argv[1:]
-    elif not py_script.exists():
+
+    main_module = sys.modules.get('__main__')
+    main_spec = getattr(main_module, '__spec__', None)
+    module_parent = getattr(main_spec, 'parent', None)
+    if module_parent:
+        return [*args, '-m', module_parent, *sys.argv[1:]]
+
+    py_script = Path(sys.argv[0])
+    if not py_script.exists():
         # sys.argv[0] may not exist for several reasons on Windows.
         # It may exist with a .exe extension or have a -script.py suffix.
         exe_entrypoint = py_script.with_suffix('.exe')
@@ -241,9 +241,8 @@ def get_child_arguments():
             # args parameter accepts path-like on Windows from Python 3.8.
             return [*args, str(script_entrypoint), *sys.argv[1:]]
         raise RuntimeError('Script %s does not exist.' % py_script)
-    else:
-        args += sys.argv
-    return args
+
+    return [*args, *sys.argv]
 
 
 def trigger_reload(filename):

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -25,8 +25,11 @@ from django.utils.autoreload import WatchmanUnavailable
 from .utils import on_macos_with_hfs
 
 
-def patch_main_spec(parent):
-    spec = types.SimpleNamespace(parent=parent) if parent is not None else None
+def patch_main_spec(parent, name=None):
+    if parent is None:
+        spec = None
+    else:
+        spec = types.SimpleNamespace(parent=parent, name=name)
     return mock.patch.object(sys.modules['__main__'], '__spec__', spec, create=True)
 
 
@@ -164,7 +167,7 @@ class TestChildArguments(SimpleTestCase):
     @mock.patch('sys.argv', ['django/__main__.py', 'runserver'])
     @mock.patch('sys.warnoptions', [])
     def test_run_as_module(self):
-        with patch_main_spec('django'):
+        with patch_main_spec('django', 'django.__main__'):
             self.assertEqual(
                 autoreload.get_child_arguments(),
                 [sys.executable, '-m', 'django', 'runserver']
@@ -173,10 +176,19 @@ class TestChildArguments(SimpleTestCase):
     @mock.patch('sys.argv', ['otherpkg/__main__.py', 'serve'])
     @mock.patch('sys.warnoptions', [])
     def test_run_as_other_module(self):
-        with patch_main_spec('otherpkg'):
+        with patch_main_spec('otherpkg', 'otherpkg.__main__'):
             self.assertEqual(
                 autoreload.get_child_arguments(),
                 [sys.executable, '-m', 'otherpkg', 'serve']
+            )
+
+    @mock.patch('sys.argv', ['pkg/module.py', 'serve'])
+    @mock.patch('sys.warnoptions', [])
+    def test_run_as_submodule(self):
+        with patch_main_spec('pkg', 'pkg.module'):
+            self.assertEqual(
+                autoreload.get_child_arguments(),
+                [sys.executable, '-m', 'pkg.module', 'serve']
             )
 
     @mock.patch('sys.warnoptions', [])
@@ -186,7 +198,7 @@ class TestChildArguments(SimpleTestCase):
             script_path.touch()
             argv = [str(script_path), 'runserver']
             with mock.patch('sys.argv', argv):
-                with patch_main_spec(''):
+                with patch_main_spec('', '__main__'):
                     self.assertEqual(
                         autoreload.get_child_arguments(),
                         [sys.executable, *argv]
@@ -476,7 +488,7 @@ class RestartWithReloaderTests(SimpleTestCase):
         main = '/usr/lib/pythonX.Y/site-packages/django/__main__.py'
         argv = [main, 'runserver']
         mock_call = self.patch_autoreload(argv)
-        with patch_main_spec('django'):
+        with patch_main_spec('django', 'django.__main__'):
             autoreload.restart_with_reloader()
             self.assertEqual(mock_call.call_count, 1)
             self.assertEqual(mock_call.call_args[0][0], [self.executable, '-Wall', '-m', 'django'] + argv[1:])

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -16,7 +16,6 @@ from unittest import mock, skip, skipIf
 
 import pytz
 
-import django.__main__
 from django.apps.registry import Apps
 from django.test import SimpleTestCase
 from django.test.utils import extend_sys_path
@@ -24,6 +23,11 @@ from django.utils import autoreload
 from django.utils.autoreload import WatchmanUnavailable
 
 from .utils import on_macos_with_hfs
+
+
+def patch_main_spec(parent):
+    spec = types.SimpleNamespace(parent=parent) if parent is not None else None
+    return mock.patch.object(sys.modules['__main__'], '__spec__', spec, create=True)
 
 
 class TestIterModulesAndFiles(SimpleTestCase):
@@ -157,13 +161,36 @@ class TestIterModulesAndFiles(SimpleTestCase):
 
 
 class TestChildArguments(SimpleTestCase):
-    @mock.patch('sys.argv', [django.__main__.__file__, 'runserver'])
+    @mock.patch('sys.argv', ['django/__main__.py', 'runserver'])
     @mock.patch('sys.warnoptions', [])
     def test_run_as_module(self):
-        self.assertEqual(
-            autoreload.get_child_arguments(),
-            [sys.executable, '-m', 'django', 'runserver']
-        )
+        with patch_main_spec('django'):
+            self.assertEqual(
+                autoreload.get_child_arguments(),
+                [sys.executable, '-m', 'django', 'runserver']
+            )
+
+    @mock.patch('sys.argv', ['otherpkg/__main__.py', 'serve'])
+    @mock.patch('sys.warnoptions', [])
+    def test_run_as_other_module(self):
+        with patch_main_spec('otherpkg'):
+            self.assertEqual(
+                autoreload.get_child_arguments(),
+                [sys.executable, '-m', 'otherpkg', 'serve']
+            )
+
+    @mock.patch('sys.warnoptions', [])
+    def test_spec_parent_empty_falls_back_to_script(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = Path(tmpdir) / '__main__.py'
+            script_path.touch()
+            argv = [str(script_path), 'runserver']
+            with mock.patch('sys.argv', argv):
+                with patch_main_spec(''):
+                    self.assertEqual(
+                        autoreload.get_child_arguments(),
+                        [sys.executable, *argv]
+                    )
 
     @mock.patch('sys.argv', [__file__, 'runserver'])
     @mock.patch('sys.warnoptions', ['error'])
@@ -175,32 +202,35 @@ class TestChildArguments(SimpleTestCase):
 
     @mock.patch('sys.warnoptions', [])
     def test_exe_fallback(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            exe_path = Path(tmpdir) / 'django-admin.exe'
-            exe_path.touch()
-            with mock.patch('sys.argv', [str(exe_path.with_suffix('')), 'runserver']):
-                self.assertEqual(
-                    autoreload.get_child_arguments(),
-                    [str(exe_path), 'runserver']
-                )
+        with patch_main_spec(None):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                exe_path = Path(tmpdir) / 'django-admin.exe'
+                exe_path.touch()
+                with mock.patch('sys.argv', [str(exe_path.with_suffix('')), 'runserver']):
+                    self.assertEqual(
+                        autoreload.get_child_arguments(),
+                        [str(exe_path), 'runserver']
+                    )
 
     @mock.patch('sys.warnoptions', [])
     def test_entrypoint_fallback(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            script_path = Path(tmpdir) / 'django-admin-script.py'
-            script_path.touch()
-            with mock.patch('sys.argv', [str(script_path.with_name('django-admin')), 'runserver']):
-                self.assertEqual(
-                    autoreload.get_child_arguments(),
-                    [sys.executable, str(script_path), 'runserver']
-                )
+        with patch_main_spec(None):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                script_path = Path(tmpdir) / 'django-admin-script.py'
+                script_path.touch()
+                with mock.patch('sys.argv', [str(script_path.with_name('django-admin')), 'runserver']):
+                    self.assertEqual(
+                        autoreload.get_child_arguments(),
+                        [sys.executable, str(script_path), 'runserver']
+                    )
 
     @mock.patch('sys.argv', ['does-not-exist', 'runserver'])
     @mock.patch('sys.warnoptions', [])
     def test_raises_runtimeerror(self):
-        msg = 'Script does-not-exist does not exist.'
-        with self.assertRaisesMessage(RuntimeError, msg):
-            autoreload.get_child_arguments()
+        with patch_main_spec(None):
+            msg = 'Script does-not-exist does not exist.'
+            with self.assertRaisesMessage(RuntimeError, msg):
+                autoreload.get_child_arguments()
 
 
 class TestUtilities(SimpleTestCase):
@@ -446,7 +476,7 @@ class RestartWithReloaderTests(SimpleTestCase):
         main = '/usr/lib/pythonX.Y/site-packages/django/__main__.py'
         argv = [main, 'runserver']
         mock_call = self.patch_autoreload(argv)
-        with mock.patch('django.__main__.__file__', main):
+        with patch_main_spec('django'):
             autoreload.restart_with_reloader()
             self.assertEqual(mock_call.call_count, 1)
             self.assertEqual(mock_call.call_args[0][0], [self.executable, '-Wall', '-m', 'django'] + argv[1:])


### PR DESCRIPTION
## Summary
- use `__main__.__spec__.parent` to detect `python -m <pkg>` invocations in `get_child_arguments()`
- fall back to argv/script handling when the parent is empty so directory and zip imports behave like before
- extend autoreload tests to cover non-Django packages and ensure Windows fallbacks bypass the spec path

## Observed Failure
Running the updated tests against the previous implementation raised runtime errors when `sys.argv[0]` pointed at non-existent module wrappers:

```
Testing against Django installed in '/workspace/django/django'
System check identified no issues (0 silenced).
..........E......................EE........................ssssssssssssssssssss
======================================================================
ERROR: test_python_m_django (utils_tests.test_autoreload.RestartWithReloaderTests.test_python_m_django)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/utils_tests/test_autoreload.py", line 480, in test_python_m_django
    autoreload.restart_with_reloader()
  File "/workspace/django/django/utils/autoreload.py", line 256, in restart_with_reloader
    args = get_child_arguments()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/utils/autoreload.py", line 243, in get_child_arguments
    raise RuntimeError('Script %s does not exist.' % py_script)
RuntimeError: Script /usr/lib/pythonX.Y/site-packages/django/__main__.py does not exist.

======================================================================
ERROR: test_run_as_module (utils_tests.test_autoreload.TestChildArguments.test_run_as_module)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.11/unittest/mock.py", line 1378, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/utils_tests/test_autoreload.py", line 169, in test_run_as_module
    autoreload.get_child_arguments(),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/utils/autoreload.py", line 243, in get_child_arguments
    raise RuntimeError('Script %s does not exist.' % py_script)
RuntimeError: Script django/__main__.py does not exist.

======================================================================
ERROR: test_run_as_other_module (utils_tests.test_autoreload.TestChildArguments.test_run_as_other_module)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.11/unittest/mock.py", line 1378, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/utils_tests/test_autoreload.py", line 178, in test_run_as_other_module
    autoreload.get_child_arguments(),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/utils/autoreload.py", line 243, in get_child_arguments
    raise RuntimeError('Script %s does not exist.' % py_script)
RuntimeError: Script otherpkg/__main__.py does not exist.
```

Refs #283.

## Reproduction
- Python 3.11.14 (deadsnakes) on Ubuntu 24.04 container
- Within `tests/`: `PYTHONPATH=/workspace/django ./runtests.py utils_tests.test_autoreload --parallel=1`

## Rationale
Relying on `__main__.__spec__.parent` matches how Python identifies the package for `python -m <pkg>` regardless of framework. When the parent is empty (e.g. running from a directory or zip), we fall back to the legacy script-based path so existing behaviours and Windows entry point detection continue to work.

## Testing
- `PYTHONPATH=/workspace/django ./runtests.py utils_tests.test_autoreload --parallel=1`
- `flake8 django/utils/autoreload.py tests/utils_tests/test_autoreload.py`