### PR TITLE
Set disabled=True on ReadOnlyPasswordHashField; remove redundant clean_password; update docs and tests (swev-id: django__django-13741)

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -55,7 +55,9 @@ class ReadOnlyPasswordHashField(forms.Field):
     widget = ReadOnlyPasswordHashWidget
 
     def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", ReadOnlyPasswordHashWidget)
         kwargs.setdefault("required", False)
+        kwargs.setdefault("disabled", True)
         super().__init__(*args, **kwargs)
 
     def bound_data(self, data, initial):
@@ -162,12 +164,6 @@ class UserChangeForm(forms.ModelForm):
         user_permissions = self.fields.get('user_permissions')
         if user_permissions:
             user_permissions.queryset = user_permissions.queryset.select_related('content_type')
-
-    def clean_password(self):
-        # Regardless of what the user provides, return the initial value.
-        # This is done here, rather than on the field, because the
-        # field does not have access to the initial value
-        return self.initial.get('password')
 
 
 class AuthenticationForm(forms.Form):

--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -55,7 +55,6 @@ class ReadOnlyPasswordHashField(forms.Field):
     widget = ReadOnlyPasswordHashWidget
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("widget", ReadOnlyPasswordHashWidget)
         kwargs.setdefault("required", False)
         kwargs.setdefault("disabled", True)
         super().__init__(*args, **kwargs)

--- a/docs/ref/contrib/admin/index.txt
+++ b/docs/ref/contrib/admin/index.txt
@@ -469,6 +469,13 @@ subclass::
         ``fields = []`` in the ``Meta`` class to satisfy the validation on the
         ``ModelForm``.
 
+    The built-in :class:`~django.contrib.auth.admin.UserAdmin` uses
+    :class:`~django.contrib.auth.forms.UserChangeForm`, where the ``password``
+    field is a disabled
+    :class:`~django.contrib.auth.forms.ReadOnlyPasswordHashField`. Any value
+    submitted for that field is ignored in favor of the stored hash; use the
+    "change password" workflow to update user credentials.
+
     .. admonition:: Note
 
         If your ``ModelForm`` and ``ModelAdmin`` both define an ``exclude``

--- a/docs/ref/contrib/auth.txt
+++ b/docs/ref/contrib/auth.txt
@@ -700,3 +700,21 @@ Utility functions
     :setting:`AUTHENTICATION_BACKENDS`, if a user isn't returned by the
     backend's ``get_user()`` method, or if the session auth hash doesn't
     validate.
+
+Forms
+=====
+
+.. currentmodule:: django.contrib.auth.forms
+
+.. class:: ReadOnlyPasswordHashField
+
+    Displays the stored password hash using
+    :class:`~django.contrib.auth.forms.ReadOnlyPasswordHashWidget`. The field
+    is disabled by default so the rendered widget includes the ``disabled``
+    attribute, and any submitted value is ignored during cleaning in favor of
+    the initial hashed password. When working with
+    :class:`~django.contrib.auth.forms.UserChangeForm` or similar forms, you no
+    longer need to override :meth:`~django.forms.Form.clean` or define a
+    custom ``clean_password()`` method to preserve the original value.
+
+.. currentmodule:: django.contrib.auth

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -16,6 +16,7 @@ from django.contrib.admin.tests import AdminSeleniumTestCase
 from django.contrib.admin.utils import quote
 from django.contrib.admin.views.main import IS_POPUP_VAR
 from django.contrib.auth import REDIRECT_FIELD_NAME, get_permission_codename
+from django.contrib.auth.forms import UserChangeForm
 from django.contrib.auth.models import Group, Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
@@ -5407,6 +5408,23 @@ class UserAdminTest(TestCase):
         self.assertRedirects(response, reverse('admin:auth_user_add'))
         self.assertEqual(User.objects.count(), user_count + 1)
         self.assertTrue(new_user.has_usable_password())
+
+    def test_userchangeform_password_not_editable_and_validations_unchanged(self):
+        user = User.objects.create_user(
+            username='readonly-password-user',
+            email='readonly@example.com',
+            password='secret',
+            is_staff=True,
+        )
+        form_for_data = UserChangeForm(instance=user)
+        post_data = form_for_data.initial
+        post_data['email'] = 'updated@example.com'
+        post_data['password'] = 'tampered'
+        form = UserChangeForm(data=post_data, instance=user)
+        self.assertTrue(form.fields['password'].disabled)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['password'], user.password)
+        self.assertEqual(form.cleaned_data['email'], 'updated@example.com')
 
     def test_user_permission_performance(self):
         u = User.objects.all()[0]

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -2,11 +2,13 @@ import datetime
 import re
 from unittest import mock
 
+from django import forms
 from django.contrib.auth.forms import (
     AdminPasswordChangeForm, AuthenticationForm, PasswordChangeForm,
     PasswordResetForm, ReadOnlyPasswordHashField, ReadOnlyPasswordHashWidget,
     SetPasswordForm, UserChangeForm, UserCreationForm,
 )
+from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.models import User
 from django.contrib.auth.signals import user_login_failed
 from django.contrib.sites.models import Site
@@ -25,6 +27,29 @@ from .models.custom_user import (
 from .models.with_custom_email_field import CustomEmailField
 from .models.with_integer_username import IntegerUsernameUser
 from .settings import AUTH_TEMPLATES
+
+
+class DummyReadOnlyPasswordForm(forms.Form):
+    password = ReadOnlyPasswordHashField()
+
+
+class ReadOnlyPasswordHashFieldTests(SimpleTestCase):
+
+    def test_readonly_password_hash_field_renders_disabled_attribute(self):
+        form = DummyReadOnlyPasswordForm(
+            initial={"password": f"{UNUSABLE_PASSWORD_PREFIX}hash"}
+        )
+        self.assertTrue(form.fields["password"].disabled)
+        self.assertIn("disabled", str(form["password"]))
+
+    def test_readonly_password_hash_field_clean_uses_initial_when_disabled(self):
+        initial_value = f"{UNUSABLE_PASSWORD_PREFIX}hash"
+        form = DummyReadOnlyPasswordForm(
+            data={"password": "tampered"},
+            initial={"password": initial_value},
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["password"], initial_value)
 
 
 class TestDataMixin:


### PR DESCRIPTION
### Summary
- Default disabled=True on ReadOnlyPasswordHashField to prevent editing and ignore tampered values.
- Remove redundant UserChangeForm.clean_password.
- Add tests covering disabled rendering, initial-preserving cleaning, and unchanged admin/UserChangeForm behavior.
- Update docs (auth forms, admin) to reflect disabled default and ignored submissions.

### Reproduction (pre-change failures)
- Rendering
```python
class DummyForm(forms.Form):
    password = ReadOnlyPasswordHashField()
form = DummyForm(initial={"password": "hash"})
html = str(form["password"])
assert "disabled" in html
# AssertionError: 'disabled' not found in rendered HTML
```

- Cleaning
```python
class DummyForm(forms.Form):
    password = ReadOnlyPasswordHashField()
form = DummyForm(data={"password": "tampered"}, initial={"password": "stored-hash"})
form.is_valid()
assert form.cleaned_data["password"] == "stored-hash"
# AssertionError: 'tampered' != 'stored-hash'
```

### Notes
- Base: django__django-13741
- CI: do not run; PR is unmerged by request.
- Issue: #285