### PR TITLE
fix: adjust W042 for inherited PKs (swev-id: django__django-13925)

### DIFF
--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1297,8 +1297,13 @@ class Model(metaclass=ModelBase):
 
     @classmethod
     def _check_default_pk(cls):
+        pk = cls._meta.pk
+        remote = getattr(pk, "remote_field", None)
+        is_parent_link = bool(getattr(remote, "parent_link", False))
+
         if (
-            cls._meta.pk.auto_created and
+            pk.auto_created and
+            not is_parent_link and
             not settings.is_overridden('DEFAULT_AUTO_FIELD') and
             not cls._meta.app_config._is_default_auto_field_overridden
         ):

--- a/tests/check_framework/test_model_checks.py
+++ b/tests/check_framework/test_model_checks.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest import mock
 
 from django.core import checks
@@ -415,3 +416,83 @@ class ModelDefaultAutoFieldTests(SimpleTestCase):
                 app_label = 'check_framework.apps.CheckPKConfig'
 
         self.assertEqual(checks.run_checks(app_configs=apps.get_app_configs()), [])
+
+
+@mock.patch('django.conf.UserSettingsHolder.is_overridden', mocked_is_overridden)
+@override_settings(DEFAULT_AUTO_FIELD='django.db.models.AutoField')
+@isolate_apps('check_framework.apps.CheckDefaultPKConfig', attr_name='apps')
+@override_system_checks([checks.model_checks.check_all_models])
+class ModelDefaultAutoFieldInheritanceTests(SimpleTestCase):
+    def test_child_inherits_explicit_big_auto_field(self):
+        class Parent(models.Model):
+            id = models.BigAutoField(primary_key=True)
+
+        class Child(Parent):
+            pass
+
+        self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [])
+
+    def test_child_inherits_explicit_uuid_field(self):
+        class Parent(models.Model):
+            id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+        class Child(Parent):
+            pass
+
+        self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [])
+
+    def test_parent_warning_child_skipped(self):
+        class Parent(models.Model):
+            pass
+
+        class Child(Parent):
+            pass
+
+        self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [
+            Warning(
+                "Auto-created primary key used when not defining a primary "
+                "key type, by default 'django.db.models.AutoField'.",
+                hint=(
+                    "Configure the DEFAULT_AUTO_FIELD setting or the "
+                    "CheckDefaultPKConfig.default_auto_field attribute to "
+                    "point to a subclass of AutoField, e.g. "
+                    "'django.db.models.BigAutoField'."
+                ),
+                obj=Parent,
+                id='models.W042',
+            ),
+        ])
+
+    @override_settings(DEFAULT_AUTO_FIELD='django.db.models.BigAutoField')
+    def test_override_default_auto_field(self):
+        class Parent(models.Model):
+            pass
+
+        class Child(Parent):
+            pass
+
+        self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [])
+
+    def test_multilevel_inheritance_with_explicit_pk(self):
+        class GrandParent(models.Model):
+            id = models.BigAutoField(primary_key=True)
+
+        class Parent(GrandParent):
+            pass
+
+        class Child(Parent):
+            pass
+
+        self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [])
+
+    def test_abstract_base_with_explicit_pk(self):
+        class AbstractBase(models.Model):
+            id = models.BigAutoField(primary_key=True)
+
+            class Meta:
+                abstract = True
+
+        class Concrete(AbstractBase):
+            pass
+
+        self.assertEqual(checks.run_checks(app_configs=self.apps.get_app_configs()), [])


### PR DESCRIPTION
## Summary
- skip models.W042 for MTI children whose primary key is the auto-created parent link
- add regression coverage for explicit PK inheritance, default overrides, multi-level MTI, and abstract base scenarios

## Reproduction
1. Ensure DEFAULT_AUTO_FIELD keeps its default value.
2. Define models:
   ```python
   from django.db import models

   class Parent(models.Model):
       id = models.BigAutoField(primary_key=True)

   class Child(Parent):
       pass
   ```
3. Run `python manage.py check`.

Observed incorrect output:

```
System check identified some issues:

WARNINGS:

<app>.Child: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field property to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

## DEFAULT_AUTO_FIELD and inheritance
- Without overriding DEFAULT_AUTO_FIELD, only parents that rely on the implicit "id" still raise W042; MTI descendants inheriting explicit PKs stay quiet.
- Global or app-level DEFAULT_AUTO_FIELD overrides continue to suppress W042 for both parent and child models.

## Testing
- PYTHONPATH=/workspace/django python tests/runtests.py check_framework.test_model_checks --parallel=1
- flake8 django/db/models/base.py tests/check_framework/test_model_checks.py

Fixes #291