### PR TITLE
fix(forms): align ModelChoiceField invalid_choice message (swev-id: django__django-13933)

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1188,8 +1188,8 @@ class ModelChoiceField(ChoiceField):
     # This class is a subclass of ChoiceField for purity, but it doesn't
     # actually use any of ChoiceField's implementation.
     default_error_messages = {
-        'invalid_choice': _('Select a valid choice. That choice is not one of'
-                            ' the available choices.'),
+        'invalid_choice': _('Select a valid choice. %(value)s is not one of the'
+                            ' available choices.'),
     }
     iterator = ModelChoiceIterator
 
@@ -1284,7 +1284,11 @@ class ModelChoiceField(ChoiceField):
                 value = getattr(value, key)
             value = self.queryset.get(**{key: value})
         except (ValueError, TypeError, self.queryset.model.DoesNotExist):
-            raise ValidationError(self.error_messages['invalid_choice'], code='invalid_choice')
+            raise ValidationError(
+                self.error_messages['invalid_choice'],
+                code='invalid_choice',
+                params={'value': value},
+            )
         return value
 
     def validate(self, value):

--- a/tests/admin_widgets/tests.py
+++ b/tests/admin_widgets/tests.py
@@ -20,6 +20,7 @@ from django.db.models import (
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import translation
+from django.utils.html import escape
 
 from .models import (
     Advisor, Album, Band, Bee, Car, Company, Event, Honeycomb, Individual,
@@ -243,7 +244,10 @@ class AdminForeignKeyRawIdWidget(TestDataMixin, TestCase):
         # Try posting with a nonexistent pk in a raw id field: this
         # should result in an error message, not a server exception.
         response = self.client.post(reverse('admin:admin_widgets_event_add'), post_data)
-        self.assertContains(response, 'Select a valid choice. That choice is not one of the available choices.')
+        self.assertContains(
+            response,
+            f'Select a valid choice. {escape(str(pk))} is not one of the available choices.',
+        )
 
     def test_invalid_target_id(self):
 
@@ -251,7 +255,11 @@ class AdminForeignKeyRawIdWidget(TestDataMixin, TestCase):
             # This should result in an error message, not a server exception.
             response = self.client.post(reverse('admin:admin_widgets_event_add'), {"main_band": test_str})
 
-            self.assertContains(response, 'Select a valid choice. That choice is not one of the available choices.')
+            self.assertContains(
+                response,
+                f'Select a valid choice. {escape(str(test_str))} '
+                'is not one of the available choices.',
+            )
 
     def test_url_params_from_lookup_dict_any_iterable(self):
         lookup1 = widgets.url_params_from_lookup_dict({'color__in': ('red', 'blue')})

--- a/tests/forms_tests/field_tests/test_modelchoicefield.py
+++ b/tests/forms_tests/field_tests/test_modelchoicefield.py
@@ -1,0 +1,52 @@
+from django.core.exceptions import ValidationError
+from django.forms import ChoiceField, ModelChoiceField, ModelMultipleChoiceField
+from django.test import TestCase
+
+from ..models import ChoiceModel
+
+
+class ModelChoiceFieldTests(TestCase):
+
+    def test_modelchoicefield_invalid_choice_includes_value_in_message_and_params(self):
+        ChoiceModel.objects.create(pk=1, name='alpha')
+        field = ModelChoiceField(queryset=ChoiceModel.objects.all())
+        invalid_value = '2'
+
+        with self.assertRaises(ValidationError) as cm:
+            field.clean(invalid_value)
+
+        self.assertEqual(
+            cm.exception.messages,
+            ['Select a valid choice. 2 is not one of the available choices.'],
+        )
+        self.assertEqual(cm.exception.error_list[0].code, 'invalid_choice')
+        self.assertEqual(cm.exception.error_list[0].params['value'], invalid_value)
+
+    def test_parity_with_choicefield_invalid_choice_message(self):
+        ChoiceModel.objects.create(pk=1, name='alpha')
+        choice_field = ChoiceField(choices=[('1', 'alpha')])
+        model_field = ModelChoiceField(queryset=ChoiceModel.objects.all())
+        invalid_value = '2'
+
+        with self.assertRaises(ValidationError) as model_exc:
+            model_field.clean(invalid_value)
+
+        with self.assertRaises(ValidationError) as choice_exc:
+            choice_field.clean(invalid_value)
+
+        self.assertEqual(model_exc.exception.messages, choice_exc.exception.messages)
+
+    def test_modelmultiplechoicefield_invalid_choice_still_includes_value(self):
+        ChoiceModel.objects.create(pk=1, name='alpha')
+        field = ModelMultipleChoiceField(queryset=ChoiceModel.objects.all())
+        invalid_value = '2'
+
+        with self.assertRaises(ValidationError) as cm:
+            field.clean([invalid_value])
+
+        self.assertEqual(
+            cm.exception.messages,
+            ['Select a valid choice. 2 is not one of the available choices.'],
+        )
+        self.assertEqual(cm.exception.error_list[0].code, 'invalid_choice')
+        self.assertEqual(cm.exception.error_list[0].params['value'], invalid_value)

--- a/tests/model_forms/test_modelchoicefield.py
+++ b/tests/model_forms/test_modelchoicefield.py
@@ -51,7 +51,7 @@ class ModelChoiceFieldTests(TestCase):
         # instantiated. This proves clean() checks the database during clean()
         # rather than caching it at instantiation time.
         Category.objects.get(url='4th').delete()
-        msg = "['Select a valid choice. That choice is not one of the available choices.']"
+        msg = f"['Select a valid choice. {c4.id} is not one of the available choices.']"
         with self.assertRaisesMessage(ValidationError, msg):
             f.clean(c4.id)
 
@@ -59,9 +59,10 @@ class ModelChoiceFieldTests(TestCase):
         f = forms.ModelChoiceField(Category.objects.all())
         self.assertEqual(f.clean(self.c1), self.c1)
         # An instance of incorrect model.
-        msg = "['Select a valid choice. That choice is not one of the available choices.']"
+        book = Book.objects.create()
+        msg = f"['Select a valid choice. {book} is not one of the available choices.']"
         with self.assertRaisesMessage(ValidationError, msg):
-            f.clean(Book.objects.create())
+            f.clean(book)
 
     def test_clean_to_field_name(self):
         f = forms.ModelChoiceField(Category.objects.all(), to_field_name='slug')
@@ -212,11 +213,12 @@ class ModelChoiceFieldTests(TestCase):
                 model = Book
                 fields = ['author']
 
-        book = Book.objects.create(author=Writer.objects.create(name='Test writer'))
+        writer = Writer.objects.create(name='Test writer')
+        book = Book.objects.create(author=writer)
         form = ModelChoiceForm({}, instance=book)
         self.assertEqual(
             form.errors['author'],
-            ['Select a valid choice. That choice is not one of the available choices.']
+            [f'Select a valid choice. {writer.pk} is not one of the available choices.']
         )
 
     def test_disabled_modelchoicefield_has_changed(self):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1675,7 +1675,7 @@ class ModelFormBasicTests(TestCase):
         self.assertIs(form.is_valid(), False)
         self.assertEqual(
             form.errors,
-            {'writer': ['Select a valid choice. That choice is not one of the available choices.']},
+            {'writer': [f'Select a valid choice. {w.pk} is not one of the available choices.']},
         )
 
     def test_validate_foreign_key_to_model_with_overridden_manager(self):

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -1748,7 +1748,7 @@ class ModelFormsetTest(TestCase):
         formset = AuthorFormSet(data)
         self.assertEqual(
             formset.errors,
-            [{'id': ['Select a valid choice. That choice is not one of the available choices.']}],
+            [{'id': ['Select a valid choice. abc is not one of the available choices.']}],
         )
 
     def test_validation_with_nonexistent_id(self):
@@ -1763,7 +1763,7 @@ class ModelFormsetTest(TestCase):
         formset = AuthorFormSet(data)
         self.assertEqual(
             formset.errors,
-            [{'id': ['Select a valid choice. That choice is not one of the available choices.']}],
+            [{'id': ['Select a valid choice. 12345 is not one of the available choices.']}],
         )
 
     def test_initial_form_count_empty_data(self):


### PR DESCRIPTION
## Summary
- include the invalid value in `ModelChoiceField`'s default `invalid_choice` message
- pass the offending value through `to_python()` when raising `ValidationError`
- add regression tests covering ModelChoiceField, ChoiceField parity, and the existing ModelMultipleChoiceField behavior

## Reproduction Steps
1. Check out `django__django-13933`.
2. Add the new tests from this change.
3. Run:
   ```bash
   python tests/runtests.py forms_tests.field_tests.test_modelchoicefield --parallel=1
   ```

### Observed failure (issue excerpt)
```
FAIL: test_modelchoicefield_invalid_choice_includes_value_in_message_and_params
Traceback (most recent call last):
  File "/workspace/django/django/forms/models.py", line 1285, in to_python
    value = self.queryset.get(**{key: value})
  File "/workspace/django/django/db/models/query.py", line 435, in get
    raise self.model.DoesNotExist(
forms_tests.models.ChoiceModel.DoesNotExist: ChoiceModel matching query does not exist.

During handling of the above exception, another exception occurred:

django.core.exceptions.ValidationError: ['Select a valid choice. That choice is not one of the available choices.']

During handling of the above exception, another exception occurred:

AssertionError: "'Select a valid choice. 4 is not one of the available choices.'" not found in "['Select a valid choice. That choice is not one of the available choices.']"
```

### Observed failure (local, before fix)
```
FAIL: test_modelchoicefield_invalid_choice_includes_value_in_message_and_params (forms_tests.field_tests.test_modelchoicefield.ModelChoiceFieldTests)
AssertionError: Lists differ: ['Select a valid choice. That choice is not one of the available choices.'] != ['Select a valid choice. 2 is not one of the available choices.']

FAIL: test_parity_with_choicefield_invalid_choice_message (forms_tests.field_tests.test_modelchoicefield.ModelChoiceFieldTests)
AssertionError: Lists differ: ['Select a valid choice. That choice is not one of the available choices.'] != ['Select a valid choice. 2 is not one of the available choices.']
```

## Parity Notes
- The default message now matches `ChoiceField` word-for-word.
- `ModelMultipleChoiceField` already includes the value and continues to behave correctly (verified by the regression test).

## Testing
- `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py forms_tests.field_tests.test_modelchoicefield --parallel=1`
- `flake8 django/forms/models.py tests/forms_tests/field_tests/test_modelchoicefield.py`

Fixes https://github.com/agyn-sandbox/django/issues/292