### PR TITLE
swev-id: django__django-14053: HashedFilesMixin.post_process yields each original file once; suppress intermediate yields

### DIFF
--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -267,10 +267,9 @@ class HashedFilesMixin:
             unresolved_paths = next_unresolved_paths
         else:
             if unresolved_paths:
-                unresolved_list = ', '.join(sorted(unresolved_paths))
-                yield 'All', None, RuntimeError(
-                    'Max post-process passes exceeded for: %s' % unresolved_list
-                )
+                error = RuntimeError('Max post-process passes exceeded.')
+                error.unresolved_paths = tuple(sorted(unresolved_paths))
+                yield 'All', None, error
 
         self.hashed_files.update(hashed_files)
 

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -214,39 +214,69 @@ class HashedFilesMixin:
         If either of these are performed on a file, then that file is considered
         post-processed.
         """
-        # don't even dare to process the files if we're in dry run mode
         if dry_run:
             return
 
-        # where to store the new paths
         hashed_files = {}
-
-        # build a list of adjustable files
         adjustable_paths = [
             path for path in paths
             if matches_patterns(path, self._patterns)
         ]
-        # Do a single pass first. Post-process all files once, then repeat for
-        # adjustable files.
-        for name, hashed_name, processed, _ in self._post_process(paths, adjustable_paths, hashed_files):
-            yield name, hashed_name, processed
+        adjustable_path_set = set(adjustable_paths)
+        processed_adjustable_paths = {}
+        unresolved_paths = set()
+        reported_errors = set()
 
-        paths = {path: paths[path] for path in adjustable_paths}
+        for name, hashed_name, processed, substitutions in self._post_process(paths, adjustable_paths, hashed_files):
+            if isinstance(processed, Exception):
+                if name not in reported_errors:
+                    yield name, hashed_name, processed
+                    reported_errors.add(name)
+                continue
 
-        for i in range(self.max_post_process_passes):
-            substitutions = False
-            for name, hashed_name, processed, subst in self._post_process(paths, adjustable_paths, hashed_files):
+            if name in adjustable_path_set:
+                processed_adjustable_paths[name] = (name, hashed_name, processed)
+                if substitutions:
+                    unresolved_paths.add(name)
+            else:
                 yield name, hashed_name, processed
-                substitutions = substitutions or subst
 
-            if not substitutions:
+        adjustable_only_paths = {path: paths[path] for path in adjustable_paths}
+
+        for _ in range(self.max_post_process_passes):
+            if not unresolved_paths:
                 break
 
-        if substitutions:
-            yield 'All', None, RuntimeError('Max post-process passes exceeded.')
+            next_unresolved_paths = set()
+            post_process_results = self._post_process(
+                adjustable_only_paths,
+                adjustable_paths,
+                hashed_files,
+            )
+            for name, hashed_name, processed, substitutions in post_process_results:
+                if isinstance(processed, Exception):
+                    if name not in reported_errors:
+                        yield name, hashed_name, processed
+                        reported_errors.add(name)
+                    continue
 
-        # Store the processed paths
+                processed_adjustable_paths[name] = (name, hashed_name, processed)
+                if substitutions:
+                    next_unresolved_paths.add(name)
+
+            unresolved_paths = next_unresolved_paths
+        else:
+            if unresolved_paths:
+                unresolved_list = ', '.join(sorted(unresolved_paths))
+                yield 'All', None, RuntimeError(
+                    'Max post-process passes exceeded for: %s' % unresolved_list
+                )
+
         self.hashed_files.update(hashed_files)
+
+        for name in adjustable_paths:
+            if name in processed_adjustable_paths:
+                yield processed_adjustable_paths[name]
 
     def _post_process(self, paths, adjustable_paths, hashed_files):
         # Sort the files by directory level

--- a/tests/staticfiles_tests/storage.py
+++ b/tests/staticfiles_tests/storage.py
@@ -93,3 +93,22 @@ class ExtraPatternsStorage(ManifestStaticFilesStorage):
 class NoneHashStorage(ManifestStaticFilesStorage):
     def file_hash(self, name, content=None):
         return None
+
+
+class TrackingPostProcessStorage(ManifestStaticFilesStorage):
+    """Storage that records post_process calls and rejects duplicates."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._latest_post_process_names = []
+
+    def post_process(self, paths, dry_run=False, **options):
+        seen = set()
+        self._latest_post_process_names = []
+        for name, hashed_name, processed in super().post_process(paths, dry_run=dry_run, **options):
+            if name != 'All':
+                if name in seen:
+                    raise RuntimeError("Duplicate post_process invocation for '%s'" % name)
+                seen.add(name)
+            self._latest_post_process_names.append(name)
+            yield name, hashed_name, processed

--- a/tests/staticfiles_tests/test_storage.py
+++ b/tests/staticfiles_tests/test_storage.py
@@ -3,8 +3,10 @@ import shutil
 import sys
 import tempfile
 import unittest
+from collections import Counter
 from io import StringIO
 from pathlib import Path
+from types import MethodType
 from unittest import mock
 
 from django.conf import settings
@@ -12,6 +14,7 @@ from django.contrib.staticfiles import finders, storage
 from django.contrib.staticfiles.management.commands.collectstatic import (
     Command as CollectstaticCommand,
 )
+from django.contrib.staticfiles.utils import matches_patterns
 from django.core.management import call_command
 from django.test import override_settings
 
@@ -42,6 +45,45 @@ class TestHashedFiles:
         the end of each test.
         """
         pass
+
+    def _collectstatic_options(self, **overrides):
+        options = {
+            'interactive': False,
+            'verbosity': 0,
+            'link': False,
+            'clear': False,
+            'dry_run': False,
+            'post_process': True,
+            'use_default_ignore_patterns': True,
+            'ignore_patterns': ['*.ignoreme'],
+        }
+        options.update(overrides)
+        return options
+
+    def _collectstatic_stats(self, **overrides):
+        collectstatic_cmd = CollectstaticCommand()
+        collectstatic_cmd.set_options(**self._collectstatic_options(**overrides))
+        return collectstatic_cmd.collect()
+
+    def _collectstatic_with_capture(self, **overrides):
+        collectstatic_cmd = CollectstaticCommand()
+        collectstatic_cmd.set_options(**self._collectstatic_options(**overrides))
+        storage_obj = collectstatic_cmd.storage
+        captured = []
+        original_post_process = storage_obj.post_process
+
+        def capturing_post_process(self_storage, *args, **kwargs):
+            for result in original_post_process(*args, **kwargs):
+                captured.append(result)
+                yield result
+
+        storage_obj.post_process = MethodType(capturing_post_process, storage_obj)
+        try:
+            stats = collectstatic_cmd.collect()
+        finally:
+            storage_obj.post_process = original_post_process
+
+        return stats, captured, storage_obj
 
     def test_template_tag_return(self):
         self.assertStaticRaises(ValueError, "does/not/exist.png", "/static/does/not/exist.png")
@@ -203,6 +245,71 @@ class TestHashedFiles:
         self.assertIn(os.path.join('cached', 'css', 'window.css'), stats['post_processed'])
         self.assertIn(os.path.join('cached', 'css', 'img', 'window.png'), stats['unmodified'])
         self.assertIn(os.path.join('test', 'nonascii.css'), stats['post_processed'])
+        self.assertPostCondition()
+
+    def test_collectstatic_post_process_no_duplicates(self):
+        stats = self._collectstatic_stats()
+        self.assertTrue(stats['post_processed'])
+        counts = Counter(stats['post_processed'])
+        duplicates = [name for name, count in counts.items() if count > 1]
+        self.assertEqual(duplicates, [])
+        self.assertPostCondition()
+
+    def test_adjustable_files_yielded_once_with_final_name(self):
+        stats, captured, storage_obj = self._collectstatic_with_capture()
+        self.assertTrue(stats['post_processed'])
+        adjustable_results = [
+            result for result in captured
+            if matches_patterns(result[0], storage_obj._patterns)
+        ]
+        self.assertTrue(adjustable_results)
+        counts = Counter(name for name, _, _ in adjustable_results)
+        self.assertEqual(len(adjustable_results), len(counts))
+        for name, hashed_name, _ in adjustable_results:
+            clean_name = storage_obj.clean_name(name)
+            self.assertIn(clean_name, storage_obj.hashed_files)
+            self.assertEqual(storage_obj.hashed_files[clean_name], hashed_name)
+        self.assertPostCondition()
+
+    def test_post_process_counts_reflect_unique_files(self):
+        stats, captured, _ = self._collectstatic_with_capture()
+        unique_processed_names = {
+            name for name, _, processed in captured
+            if name != 'All' and processed
+        }
+        self.assertEqual(len(stats['post_processed']), len(unique_processed_names))
+        self.assertPostCondition()
+
+    def test_nested_references_resolved_without_duplicates(self):
+        _, captured, storage_obj = self._collectstatic_with_capture()
+        nested_files = {
+            os.path.join('cached', 'styles.css'),
+            os.path.join('cached', 'relative.css'),
+            os.path.join('cached', 'css', 'window.css'),
+        }
+        counts = Counter(name for name, _, _ in captured if name in nested_files)
+        for name in nested_files:
+            self.assertEqual(counts[name], 1)
+
+        hashed_relative = self.hashed_file_path(os.path.join('cached', 'relative.css'))
+        with storage_obj.open(hashed_relative) as relfile:
+            content = relfile.read()
+            self.assertIn(b'../cached/styles.5e0040571e1a.css', content)
+            self.assertIn(b'url("img/relative.acae32e4532b.png")', content)
+
+        hashed_window = self.hashed_file_path(os.path.join('cached', 'css', 'window.css'))
+        with storage_obj.open(hashed_window) as relfile:
+            content = relfile.read()
+            self.assertIn(b'url("img/window.acae32e4532b.png")', content)
+        self.assertPostCondition()
+
+    def test_non_adjustable_assets_unchanged_and_counted_once(self):
+        stats, captured, _ = self._collectstatic_with_capture()
+        image_name = os.path.join('cached', 'css', 'img', 'window.png')
+        occurrences = [entry for entry in captured if entry[0] == image_name]
+        self.assertEqual(len(occurrences), 1)
+        self.assertFalse(occurrences[0][2])
+        self.assertEqual(stats['unmodified'].count(image_name), 1)
         self.assertPostCondition()
 
     def test_css_import_case_insensitive(self):
@@ -385,6 +492,20 @@ class TestCollectionManifestStorage(TestHashedFiles, CollectionTestCase):
             ]),
             2,
         )
+
+
+@override_settings(STATICFILES_STORAGE='staticfiles_tests.storage.TrackingPostProcessStorage')
+class TestTrackingPostProcessStorage(CollectionTestCase):
+
+    def test_downstream_hooks_receive_no_duplicates(self):
+        self.run_collectstatic(verbosity=0)
+        seen = getattr(storage.staticfiles_storage, '_latest_post_process_names', [])
+        self.assertTrue(seen)
+        duplicates = [
+            name for name, count in Counter(name for name in seen if name != 'All').items()
+            if count > 1
+        ]
+        self.assertEqual(duplicates, [])
 
 
 @override_settings(STATICFILES_STORAGE='staticfiles_tests.storage.NoneHashStorage')


### PR DESCRIPTION
### Summary
- Refactor `HashedFilesMixin.post_process` to aggregate adjustable files and emit each original path once with its final hashed name.
- Track unresolved adjustable paths across passes, aggregate failures when the max limit is exceeded, and suppress intermediate yields.
- Add regression tests covering unique collectstatic counts, downstream hook instrumentation, nested CSS references, and non-adjustable assets.

### Reproduction
```python
from django.contrib.staticfiles.management.commands.collectstatic import Command
cmd = Command()
cmd.set_options(interactive=False, verbosity=0, link=False, clear=False, dry_run=False, post_process=True,
                use_default_ignore_patterns=True, ignore_patterns=['*.ignoreme'])
stats = cmd.collect()
from collections import Counter
print([k for k, v in Counter(stats['post_processed']).items() if v > 1])
```
Produces duplicate entries for adjustable files such as `cached/css/window.css`, `cached/relative.css`, and `cached/styles.css` prior to this fix.

### Observed failure
- Inflated `collectstatic` `post_processed` counts and duplicate downstream work.
- Intermediate hashed filenames surfaced while nested references were resolving.

### Stack trace (representative)
- Raise when the same original file is observed twice while consuming `post_process`.
- Traceback shows frames in `django/contrib/staticfiles/management/commands/collectstatic.py` and `django/contrib/staticfiles/storage.py` across passes.

### Related tickets
- Resolves #303 and aligns this branch with upstream Django behaviour from ticket 14053.

### Tests
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py staticfiles_tests --settings=tests.test_sqlite`
- `flake8 django/contrib/staticfiles/storage.py tests/staticfiles_tests/test_storage.py tests/staticfiles_tests/storage.py`