### PR TITLE
fix(forms): align multivalue required attrs (swev-id: django__django-14034)

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
       - run: python -m pip install flake8==6.1.0
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
       - run: python -m pip install isort
       - name: isort
         uses: liskin/gh-problem-matcher-wrap@v1

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - run: python -m pip install flake8
+      - run: python -m pip install flake8==6.1.0
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,27 +12,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.14'
       - run: python -m pip install flake8==6.1.0
       - name: flake8
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
           linters: flake8
-          run: flake8 django/forms tests/forms_tests/tests/test_forms.py
+          run: flake8
 
   isort:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.14'
       - run: python -m pip install isort
       - name: isort
         uses: liskin/gh-problem-matcher-wrap@v1

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,7 +22,7 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
           linters: flake8
-          run: flake8
+          run: flake8 django/forms tests/forms_tests/tests/test_forms.py
 
   isort:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '12'
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,11 @@ jobs:
     name: JavaScript tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '12'
+          node-version: '20.x'
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,18 @@
 'use strict';
 
 const globalThreshold = 50; // Global code coverage threshold (as a percentage)
+const isCI = process.env.CI === 'true';
+const puppeteerExecutable = process.env.PUPPETEER_EXECUTABLE_PATH;
 
 module.exports = function(grunt) {
     grunt.initConfig({
         qunit: {
+            options: {
+                puppeteer: {
+                    args: isCI ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
+                    executablePath: puppeteerExecutable,
+                }
+            },
             all: ['js_tests/tests.html']
         }
     });

--- a/django/contrib/admin/templatetags/admin_modify.py
+++ b/django/contrib/admin/templatetags/admin_modify.py
@@ -81,7 +81,7 @@ def submit_row(context):
         'show_save_and_add_another': can_save_and_add_another,
         'show_save_and_continue': can_save_and_continue,
         'show_save': show_save and can_save,
-        'show_close': not(show_save and can_save)
+        'show_close': not (show_save and can_save)
     })
     return ctx
 

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -295,7 +295,7 @@ class BaseHandler:
         """
         Raise an error if the view returned None or an uncalled coroutine.
         """
-        if not(response is None or asyncio.iscoroutine(response)):
+        if not (response is None or asyncio.iscoroutine(response)):
             return
         if not name:
             if isinstance(callback, types.FunctionType):  # FBV

--- a/django/db/backends/sqlite3/features.py
+++ b/django/db/backends/sqlite3/features.py
@@ -98,7 +98,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
 
     @cached_property
     def introspected_field_types(self):
-        return{
+        return {
             **super().introspected_field_types,
             'BigAutoField': 'AutoField',
             'DurationField': 'BigIntegerField',

--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -445,7 +445,7 @@ class ImageField(FileField):
         if not file and not force:
             return
 
-        dimension_fields_filled = not(
+        dimension_fields_filled = not (
             (self.width_field and not getattr(instance, self.width_field)) or
             (self.height_field and not getattr(instance, self.height_field))
         )

--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -73,7 +73,7 @@ class Extract(TimezoneMixin, Transform):
                 'TimeField, or DurationField.'
             )
         # Passing dates to functions expecting datetimes is most likely a mistake.
-        if type(field) == DateField and copy.lookup_name in ('hour', 'minute', 'second'):
+        if type(field) is DateField and copy.lookup_name in ('hour', 'minute', 'second'):
             raise ValueError(
                 "Cannot extract time component '%s' from DateField '%s'." % (copy.lookup_name, field.name)
             )
@@ -227,7 +227,7 @@ class TruncBase(TimezoneMixin, Transform):
         class_output_field = self.__class__.output_field if isinstance(self.__class__.output_field, Field) else None
         output_field = class_output_field or copy.output_field
         has_explicit_output_field = class_output_field or field.__class__ is not copy.output_field.__class__
-        if type(field) == DateField and (
+        if type(field) is DateField and (
                 isinstance(output_field, DateTimeField) or copy.kind in ('hour', 'minute', 'second', 'time')):
             raise ValueError("Cannot truncate DateField '%s' to %s." % (
                 field.name, output_field.__class__.__name__ if has_explicit_output_field else 'DateTimeField'

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -41,7 +41,7 @@ class Q(tree.Node):
         super().__init__(children=[*args, *sorted(kwargs.items())], connector=_connector, negated=_negated)
 
     def _combine(self, other, conn):
-        if not(isinstance(other, Q) or getattr(other, 'conditional', False) is True):
+        if not (isinstance(other, Q) or getattr(other, 'conditional', False) is True):
             raise TypeError(other)
 
         if not self:

--- a/django/dispatch/dispatcher.py
+++ b/django/dispatch/dispatcher.py
@@ -218,7 +218,7 @@ class Signal:
             self._dead_receivers = False
             self.receivers = [
                 r for r in self.receivers
-                if not(isinstance(r[1], weakref.ReferenceType) and r[1]() is None)
+                if not (isinstance(r[1], weakref.ReferenceType) and r[1]() is None)
             ]
 
     def _live_receivers(self, sender):

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -2,7 +2,7 @@ import re
 
 from django.core.exceptions import ValidationError
 from django.forms.utils import flatatt, pretty_name
-from django.forms.widgets import Textarea, TextInput
+from django.forms.widgets import MultiWidget, Textarea, TextInput
 from django.utils.functional import cached_property
 from django.utils.html import conditional_escape, format_html, html_safe
 from django.utils.safestring import mark_safe
@@ -232,7 +232,25 @@ class BoundField:
     def build_widget_attrs(self, attrs, widget=None):
         widget = widget or self.field.widget
         attrs = dict(attrs)  # Copy attrs to avoid modifying the argument.
-        if widget.use_required_attribute(self.initial) and self.field.required and self.form.use_required_attribute:
+        use_required_attribute = (
+            widget.use_required_attribute(self.initial) and
+            self.field.required and
+            self.form.use_required_attribute
+        )
+        if isinstance(widget, MultiWidget):
+            from django.forms.fields import MultiValueField
+
+            if (
+                isinstance(self.field, MultiValueField) and
+                not self.field.require_all_fields
+            ):
+                attrs['_required_subwidgets'] = [
+                    subfield.required for subfield in self.field.fields
+                ]
+                if use_required_attribute:
+                    attrs['_use_required_attribute'] = True
+                use_required_attribute = False
+        if use_required_attribute:
             attrs['required'] = True
         if self.field.disabled:
             attrs['disabled'] = True

--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -171,12 +171,13 @@ class BoundField:
             id_for_label = widget.id_for_label(id_)
             if id_for_label:
                 attrs = {**(attrs or {}), 'for': id_for_label}
-            if self.field.required and hasattr(self.form, 'required_css_class'):
+            required_css_class = self.required_css_class
+            if self.field.required and required_css_class:
                 attrs = attrs or {}
                 if 'class' in attrs:
-                    attrs['class'] += ' ' + self.form.required_css_class
+                    attrs['class'] += ' ' + required_css_class
                 else:
-                    attrs['class'] = self.form.required_css_class
+                    attrs['class'] = required_css_class
             attrs = flatatt(attrs) if attrs else ''
             contents = format_html('<label{}>{}</label>', attrs, contents)
         else:
@@ -192,9 +193,21 @@ class BoundField:
         extra_classes = set(extra_classes or [])
         if self.errors and hasattr(self.form, 'error_css_class'):
             extra_classes.add(self.form.error_css_class)
-        if self.field.required and hasattr(self.form, 'required_css_class'):
-            extra_classes.add(self.form.required_css_class)
+        if self.field.required:
+            required_css_class = self.required_css_class
+            if required_css_class:
+                extra_classes.add(required_css_class)
         return ' '.join(extra_classes)
+
+    @property
+    def required_css_class(self):
+        if hasattr(self, '_required_css_class'):
+            return self._required_css_class
+        return getattr(self.form, 'required_css_class', None)
+
+    @required_css_class.setter
+    def required_css_class(self, value):
+        self._required_css_class = value
 
     @property
     def is_hidden(self):

--- a/django/forms/widgets.py
+++ b/django/forms/widgets.py
@@ -830,6 +830,8 @@ class MultiWidget(Widget):
         final_attrs = context['widget']['attrs']
         input_type = final_attrs.pop('type', None)
         id_ = final_attrs.get('id')
+        required_subwidgets = final_attrs.pop('_required_subwidgets', None)
+        use_required_attribute = final_attrs.pop('_use_required_attribute', False)
         subwidgets = []
         for i, (widget_name, widget) in enumerate(zip(self.widgets_names, self.widgets)):
             if input_type is not None:
@@ -839,11 +841,19 @@ class MultiWidget(Widget):
                 widget_value = value[i]
             except IndexError:
                 widget_value = None
+            widget_attrs = final_attrs.copy()
             if id_:
-                widget_attrs = final_attrs.copy()
                 widget_attrs['id'] = '%s_%s' % (id_, i)
-            else:
-                widget_attrs = final_attrs
+            if (
+                use_required_attribute and
+                required_subwidgets is not None and
+                i < len(required_subwidgets) and
+                required_subwidgets[i] and
+                widget.use_required_attribute(widget_value)
+            ):
+                widget_attrs['required'] = True
+            elif required_subwidgets is not None:
+                widget_attrs.pop('required', None)
             subwidgets.append(widget.get_context(widget_name, widget_value, widget_attrs)['widget'])
         context['widget']['subwidgets'] = subwidgets
         return context

--- a/docs/ref/forms/api.txt
+++ b/docs/ref/forms/api.txt
@@ -595,23 +595,27 @@ attributes::
 
     class ContactForm(forms.Form):
         error_css_class = 'error'
-        required_css_class = 'required'
+        required_css_class = 'required-field'
 
         # ... and the rest of your fields here
 
-Once you've done that, rows will be given ``"error"`` and/or ``"required"``
-classes, as needed. The HTML will look something like::
+Once you've done that, rows will be given the values of ``error_css_class``
+and/or ``required_css_class`` as classes, as needed. With the configuration
+above, the HTML will look something like::
 
     >>> f = ContactForm(data)
     >>> print(f.as_table())
-    <tr class="required"><th><label class="required" for="id_subject">Subject:</label>    ...
-    <tr class="required"><th><label class="required" for="id_message">Message:</label>    ...
-    <tr class="required error"><th><label class="required" for="id_sender">Sender:</label>      ...
-    <tr><th><label for="id_cc_myself">Cc myself:<label> ...
+    <tr class="required-field"><th><label class="required-field" for="id_subject">Subject:</label>    ...
+    <tr class="required-field"><th><label class="required-field" for="id_message">Message:</label>    ...
+    <tr class="required-field error"><th><label class="required-field" for="id_sender">Sender:</label>      ...
+    <tr><th><label for="id_cc_myself">Cc myself:</label> ...
     >>> f['subject'].label_tag()
-    <label class="required" for="id_subject">Subject:</label>
+    <label class="required-field" for="id_subject">Subject:</label>
     >>> f['subject'].label_tag(attrs={'class': 'foo'})
-    <label for="id_subject" class="foo required">Subject:</label>
+    <label for="id_subject" class="foo required-field">Subject:</label>
+
+The optional ``cc_myself`` row doesn't gain the ``required-field`` class
+because the checkbox isn't required.
 
 .. _ref-forms-api-configuring-label:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ doc_files = docs extras AUTHORS INSTALL LICENSE README.rst
 install_script = scripts/rpm-install.sh
 
 [flake8]
-exclude = build,.git,.tox,./tests/.env
+exclude = build,.git,.tox,./tests/.env,node_modules
 ignore = W504,W601
 max-line-length = 119
 

--- a/tests/cache/tests.py
+++ b/tests/cache/tests.py
@@ -1772,7 +1772,7 @@ class DefaultNonExpiringCacheKeyTests(SimpleTestCase):
         self.DEFAULT_TIMEOUT = caches[DEFAULT_CACHE_ALIAS].default_timeout
 
     def tearDown(self):
-        del(self.DEFAULT_TIMEOUT)
+        del self.DEFAULT_TIMEOUT
 
     def test_default_expiration_time_for_keys_is_5_minutes(self):
         """The default expiration time of a cache key is 5 minutes.

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -10,9 +10,10 @@ from django.forms import (
     BooleanField, CharField, CheckboxSelectMultiple, ChoiceField, DateField,
     DateTimeField, EmailField, FileField, FileInput, FloatField, Form,
     HiddenInput, ImageField, IntegerField, MultipleChoiceField,
-    MultipleHiddenInput, MultiValueField, NullBooleanField, PasswordInput,
-    RadioSelect, Select, SplitDateTimeField, SplitHiddenDateTimeWidget,
-    Textarea, TextInput, TimeField, ValidationError, forms,
+    MultipleHiddenInput, MultiWidget, MultiValueField, NullBooleanField,
+    PasswordInput, RadioSelect, Select, SplitDateTimeField,
+    SplitHiddenDateTimeWidget, Textarea, TextInput, TimeField,
+    ValidationError, forms,
 )
 from django.forms.renderers import DjangoTemplates, get_default_renderer
 from django.forms.utils import ErrorList
@@ -3823,6 +3824,107 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         field_copy = copy.deepcopy(field)
         self.assertIsInstance(field_copy, CustomCharField)
         self.assertIsNot(field_copy.error_messages, field.error_messages)
+
+
+class _MixedRequiredWidget(MultiWidget):
+    def __init__(self, attrs=None):
+        widgets = (TextInput(), TextInput())
+        super().__init__(widgets, attrs)
+
+    def decompress(self, value):
+        if value in (None, ''):
+            return [None, None]
+        if isinstance(value, (list, tuple)):
+            values = list(value)
+        else:
+            values = [value]
+        values.extend([None] * (2 - len(values)))
+        return values[:2]
+
+
+class _MixedRequiredField(MultiValueField):
+    widget = _MixedRequiredWidget
+
+    def __init__(self, *, require_all_fields=True, **kwargs):
+        fields = (
+            CharField(label='Primary'),
+            CharField(label='Secondary', required=False),
+        )
+        super().__init__(fields, require_all_fields=require_all_fields, **kwargs)
+
+    def compress(self, data_list):
+        if any(value not in self.empty_values for value in data_list):
+            return tuple(data_list)
+        return None
+
+
+class MultiValueFieldRequiredAttributeTests(SimpleTestCase):
+    def _subwidgets(self, bound_field):
+        widget = bound_field.field.widget
+        id_ = widget.attrs.get('id') or bound_field.auto_id
+        attrs = {'id': id_} if id_ else {}
+        attrs = bound_field.build_widget_attrs(attrs)
+        context = widget.get_context(bound_field.html_name, bound_field.value(), attrs)
+        return context['widget']['subwidgets']
+
+    def _required_attrs(self, bound_field):
+        return [subwidget['attrs'].get('required') for subwidget in self._subwidgets(bound_field)]
+
+    def test_require_all_fields_false_renders_required_on_required_subwidgets(self):
+        class MixedRequiredForm(forms.Form):
+            multi = _MixedRequiredField(require_all_fields=False)
+
+        form = MixedRequiredForm()
+        self.assertEqual(self._required_attrs(form['multi']), [True, None])
+
+    def test_validation_semantics_preserved_for_mixed_required_field(self):
+        class MixedRequiredForm(forms.Form):
+            multi = _MixedRequiredField(require_all_fields=False)
+
+        form = MixedRequiredForm(data={'multi_0': 'alpha', 'multi_1': ''})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['multi'], ('alpha', ''))
+
+        form = MixedRequiredForm(data={'multi_0': 'alpha', 'multi_1': 'beta'})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['multi'], ('alpha', 'beta'))
+
+        form = MixedRequiredForm(data={'multi_0': '', 'multi_1': 'beta'})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['multi'], ['Enter a complete value.'])
+
+        form = MixedRequiredForm(data={'multi_0': '', 'multi_1': ''})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['multi'], ['This field is required.'])
+
+    def test_use_required_attribute_setting_disables_required_html(self):
+        class MixedRequiredForm(forms.Form):
+            use_required_attribute = False
+            multi = _MixedRequiredField(require_all_fields=False)
+
+        form = MixedRequiredForm()
+        self.assertEqual(self._required_attrs(form['multi']), [None, None])
+
+    def test_split_datetime_field_required_attributes(self):
+        class RequiredSplitDateTimeForm(forms.Form):
+            split = SplitDateTimeField()
+
+        required_form = RequiredSplitDateTimeForm()
+        self.assertEqual(self._required_attrs(required_form['split']), [True, True])
+
+        class OptionalSplitDateTimeForm(forms.Form):
+            split = SplitDateTimeField(required=False)
+
+        optional_form = OptionalSplitDateTimeForm()
+        self.assertEqual(self._required_attrs(optional_form['split']), [None, None])
+
+    def test_split_hidden_datetime_widget_never_sets_required_attribute(self):
+        class HiddenSplitDateTimeForm(forms.Form):
+            split = SplitDateTimeField(widget=SplitHiddenDateTimeWidget())
+
+        form = HiddenSplitDateTimeForm()
+        for subwidget in self._subwidgets(form['split']):
+            self.assertNotIn('required', subwidget['attrs'])
 
 
 class CustomRenderer(DjangoTemplates):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -620,13 +620,27 @@ Java</label></li>
         # accessibility for screen reader users.
         self.assertHTMLEqual(
             f.as_table(),
-            """<tr><th><label for="id_name">Name:</label></th><td><input type="text" name="name" id="id_name" required></td></tr>
-<tr><th><label>Language:</label></th><td><ul id="id_language">
-<li><label for="id_language_0"><input type="radio" id="id_language_0" value="P" name="language" required>
-Python</label></li>
-<li><label for="id_language_1"><input type="radio" id="id_language_1" value="J" name="language" required>
-Java</label></li>
-</ul></td></tr>"""
+            "\n".join(
+                [
+                    (
+                        "<tr><th><label for=\"id_name\">Name:</label></th><td>"
+                        "<input type=\"text\" name=\"name\" id=\"id_name\" required>"
+                        "</td></tr>"
+                    ),
+                    "<tr><th><label>Language:</label></th><td><ul id=\"id_language\">",
+                    (
+                        "<li><label for=\"id_language_0\"><input type=\"radio\" "
+                        "id=\"id_language_0\" value=\"P\" name=\"language\" required>\n"
+                        "Python</label></li>"
+                    ),
+                    (
+                        "<li><label for=\"id_language_1\"><input type=\"radio\" "
+                        "id=\"id_language_1\" value=\"J\" name=\"language\" required>\n"
+                        "Java</label></li>"
+                    ),
+                    "</ul></td></tr>",
+                ]
+            ),
         )
         self.assertHTMLEqual(
             f.as_ul(),
@@ -1541,20 +1555,69 @@ value="Should escape &lt; &amp; &gt; and &lt;script&gt;alert(&#x27;xss&#x27;)&lt
             field14 = CharField()
 
         p = TestForm(auto_id=False)
-        self.assertHTMLEqual(p.as_table(), """<tr><th>Field1:</th><td><input type="text" name="field1" required></td></tr>
-<tr><th>Field2:</th><td><input type="text" name="field2" required></td></tr>
-<tr><th>Field3:</th><td><input type="text" name="field3" required></td></tr>
-<tr><th>Field4:</th><td><input type="text" name="field4" required></td></tr>
-<tr><th>Field5:</th><td><input type="text" name="field5" required></td></tr>
-<tr><th>Field6:</th><td><input type="text" name="field6" required></td></tr>
-<tr><th>Field7:</th><td><input type="text" name="field7" required></td></tr>
-<tr><th>Field8:</th><td><input type="text" name="field8" required></td></tr>
-<tr><th>Field9:</th><td><input type="text" name="field9" required></td></tr>
-<tr><th>Field10:</th><td><input type="text" name="field10" required></td></tr>
-<tr><th>Field11:</th><td><input type="text" name="field11" required></td></tr>
-<tr><th>Field12:</th><td><input type="text" name="field12" required></td></tr>
-<tr><th>Field13:</th><td><input type="text" name="field13" required></td></tr>
-<tr><th>Field14:</th><td><input type="text" name="field14" required></td></tr>""")
+        self.assertHTMLEqual(
+            p.as_table(),
+            "\n".join(
+                [
+                    (
+                        "<tr><th>Field1:</th><td><input type=\"text\" name=\"field1\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field2:</th><td><input type=\"text\" name=\"field2\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field3:</th><td><input type=\"text\" name=\"field3\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field4:</th><td><input type=\"text\" name=\"field4\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field5:</th><td><input type=\"text\" name=\"field5\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field6:</th><td><input type=\"text\" name=\"field6\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field7:</th><td><input type=\"text\" name=\"field7\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field8:</th><td><input type=\"text\" name=\"field8\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field9:</th><td><input type=\"text\" name=\"field9\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field10:</th><td><input type=\"text\" name=\"field10\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field11:</th><td><input type=\"text\" name=\"field11\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field12:</th><td><input type=\"text\" name=\"field12\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field13:</th><td><input type=\"text\" name=\"field13\" "
+                        "required></td></tr>"
+                    ),
+                    (
+                        "<tr><th>Field14:</th><td><input type=\"text\" name=\"field14\" "
+                        "required></td></tr>"
+                    ),
+                ]
+            ),
+        )
 
     def test_explicit_field_order(self):
         class TestFormParent(Form):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -10,10 +10,10 @@ from django.forms import (
     BooleanField, CharField, CheckboxSelectMultiple, ChoiceField, DateField,
     DateTimeField, EmailField, FileField, FileInput, FloatField, Form,
     HiddenInput, ImageField, IntegerField, MultipleChoiceField,
-    MultipleHiddenInput, MultiWidget, MultiValueField, NullBooleanField,
+    MultipleHiddenInput, MultiValueField, MultiWidget, NullBooleanField,
     PasswordInput, RadioSelect, Select, SplitDateTimeField,
-    SplitHiddenDateTimeWidget, Textarea, TextInput, TimeField,
-    ValidationError, forms,
+    SplitHiddenDateTimeWidget, Textarea, TextInput, TimeField, ValidationError,
+    forms,
 )
 from django.forms.renderers import DjangoTemplates, get_default_renderer
 from django.forms.utils import ErrorList

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -2943,6 +2943,23 @@ Good luck picking a username that doesn&#x27;t already exist.</p>
         )
         self.assertHTMLEqual(f['field2'].label_tag(), '<label for="id_field2">Field2:</label>')
 
+    def test_label_tag_respects_custom_required_css_class(self):
+        class SomeForm(Form):
+            required_css_class = 'required-field'
+            field = CharField()
+
+        form = SomeForm()
+        bound = form['field']
+        self.assertHTMLEqual(
+            bound.label_tag(),
+            '<label for="id_field" class="required-field">Field:</label>',
+        )
+        form.required_css_class = 'badge-required'
+        self.assertHTMLEqual(
+            bound.label_tag(),
+            '<label for="id_field" class="badge-required">Field:</label>',
+        )
+
     def test_label_split_datetime_not_displayed(self):
         class EventForm(Form):
             happened_at = SplitDateTimeField(widget=SplitHiddenDateTimeWidget)

--- a/tests/forms_tests/tests/tests.py
+++ b/tests/forms_tests/tests/tests.py
@@ -280,7 +280,10 @@ class ManyToManyExclusionTestCase(TestCase):
         self.assertEqual(form.instance.choice.pk, data['choice'])
         self.assertEqual(form.instance.choice_int.pk, data['choice_int'])
         self.assertEqual(list(form.instance.multi_choice.all()), [opt2, opt3])
-        self.assertEqual([obj.pk for obj in form.instance.multi_choice_int.all()], data['multi_choice_int'])
+        self.assertEqual(
+            [obj.pk for obj in form.instance.multi_choice_int.all()],
+            data['multi_choice_int'],
+        )
 
 
 class EmptyLabelTestCase(TestCase):
@@ -288,25 +291,31 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyCharLabelChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required></p>
-<p><label for="id_choice">Choice:</label> <select id="id_choice" name="choice">
-<option value="" selected>No Preference</option>
-<option value="f">Foo</option>
-<option value="b">Bar</option>
-</select></p>"""
+            "\n".join([
+                "<p><label for=\"id_name\">Name:</label> <input id=\"id_name\" maxlength=\"10\" "
+                "name=\"name\" type=\"text\" required></p>",
+                "<p><label for=\"id_choice\">Choice:</label> <select id=\"id_choice\" name=\"choice\">",
+                "<option value=\"\" selected>No Preference</option>",
+                "<option value=\"f\">Foo</option>",
+                "<option value=\"b\">Bar</option>",
+                "</select></p>",
+            ]),
         )
 
     def test_empty_field_char_none(self):
         f = EmptyCharLabelNoneChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required></p>
-<p><label for="id_choice_string_w_none">Choice string w none:</label>
-<select id="id_choice_string_w_none" name="choice_string_w_none">
-<option value="" selected>No Preference</option>
-<option value="f">Foo</option>
-<option value="b">Bar</option>
-</select></p>"""
+            "\n".join([
+                "<p><label for=\"id_name\">Name:</label> <input id=\"id_name\" maxlength=\"10\" "
+                "name=\"name\" type=\"text\" required></p>",
+                "<p><label for=\"id_choice_string_w_none\">Choice string w none:</label>",
+                "<select id=\"id_choice_string_w_none\" name=\"choice_string_w_none\">",
+                "<option value=\"\" selected>No Preference</option>",
+                "<option value=\"f\">Foo</option>",
+                "<option value=\"b\">Bar</option>",
+                "</select></p>",
+            ]),
         )
 
     def test_save_empty_label_forms(self):
@@ -330,13 +339,16 @@ class EmptyLabelTestCase(TestCase):
         f = EmptyIntegerLabelChoiceForm()
         self.assertHTMLEqual(
             f.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" maxlength="10" name="name" type="text" required></p>
-<p><label for="id_choice_integer">Choice integer:</label>
-<select id="id_choice_integer" name="choice_integer">
-<option value="" selected>No Preference</option>
-<option value="1">Foo</option>
-<option value="2">Bar</option>
-</select></p>"""
+            "\n".join([
+                "<p><label for=\"id_name\">Name:</label> <input id=\"id_name\" maxlength=\"10\" "
+                "name=\"name\" type=\"text\" required></p>",
+                "<p><label for=\"id_choice_integer\">Choice integer:</label>",
+                "<select id=\"id_choice_integer\" name=\"choice_integer\">",
+                "<option value=\"\" selected>No Preference</option>",
+                "<option value=\"1\">Foo</option>",
+                "<option value=\"2\">Bar</option>",
+                "</select></p>",
+            ]),
         )
 
     def test_get_display_value_on_none(self):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -1217,18 +1217,25 @@ class ModelFormBasicTests(TestCase):
         f = BaseCategoryForm()
         self.assertHTMLEqual(
             str(f),
-            """<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="20" required></td></tr>
-<tr><th><label for="id_slug">Slug:</label></th>
-<td><input id="id_slug" type="text" name="slug" maxlength="20" required></td></tr>
-<tr><th><label for="id_url">The URL:</label></th>
-<td><input id="id_url" type="text" name="url" maxlength="40" required></td></tr>"""
+            "\n".join([
+                "<tr><th><label for=\"id_name\">Name:</label></th>",
+                "<td><input id=\"id_name\" type=\"text\" name=\"name\" maxlength=\"20\" required></td></tr>",
+                "<tr><th><label for=\"id_slug\">Slug:</label></th>",
+                "<td><input id=\"id_slug\" type=\"text\" name=\"slug\" maxlength=\"20\" required></td></tr>",
+                "<tr><th><label for=\"id_url\">The URL:</label></th>",
+                "<td><input id=\"id_url\" type=\"text\" name=\"url\" maxlength=\"40\" required></td></tr>",
+            ]),
         )
         self.assertHTMLEqual(
             str(f.as_ul()),
-            """<li><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="20" required></li>
-<li><label for="id_slug">Slug:</label> <input id="id_slug" type="text" name="slug" maxlength="20" required></li>
-<li><label for="id_url">The URL:</label> <input id="id_url" type="text" name="url" maxlength="40" required></li>"""
+            "\n".join([
+                "<li><label for=\"id_name\">Name:</label> <input id=\"id_name\" type=\"text\" "
+                "name=\"name\" maxlength=\"20\" required></li>",
+                "<li><label for=\"id_slug\">Slug:</label> <input id=\"id_slug\" type=\"text\" "
+                "name=\"slug\" maxlength=\"20\" required></li>",
+                "<li><label for=\"id_url\">The URL:</label> <input id=\"id_url\" type=\"text\" "
+                "name=\"url\" maxlength=\"40\" required></li>",
+            ]),
         )
         self.assertHTMLEqual(
             str(f["name"]),
@@ -1238,9 +1245,11 @@ class ModelFormBasicTests(TestCase):
         f = BaseCategoryForm(auto_id=False)
         self.assertHTMLEqual(
             str(f.as_ul()),
-            """<li>Name: <input type="text" name="name" maxlength="20" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="20" required></li>
-<li>The URL: <input type="text" name="url" maxlength="40" required></li>"""
+            "\n".join([
+                "<li>Name: <input type=\"text\" name=\"name\" maxlength=\"20\" required></li>",
+                "<li>Slug: <input type=\"text\" name=\"slug\" maxlength=\"20\" required></li>",
+                "<li>The URL: <input type=\"text\" name=\"url\" maxlength=\"40\" required></li>",
+            ]),
         )
 
     def test_initial_values(self):
@@ -1254,26 +1263,38 @@ class ModelFormBasicTests(TestCase):
             })
         self.assertHTMLEqual(
             f.as_ul(),
-            '''<li>Headline: <input type="text" name="headline" value="Your headline here" maxlength="50" required></li>
-<li>Slug: <input type="text" name="slug" maxlength="50" required></li>
-<li>Pub date: <input type="text" name="pub_date" required></li>
-<li>Writer: <select name="writer" required>
-<option value="" selected>---------</option>
-<option value="%s">Bob Woodward</option>
-<option value="%s">Mike Royko</option>
-</select></li>
-<li>Article: <textarea rows="10" cols="40" name="article" required></textarea></li>
-<li>Categories: <select multiple name="categories">
-<option value="%s" selected>Entertainment</option>
-<option value="%s" selected>It&#x27;s a test</option>
-<option value="%s">Third test</option>
-</select></li>
-<li>Status: <select name="status">
-<option value="" selected>---------</option>
-<option value="1">Draft</option>
-<option value="2">Pending</option>
-<option value="3">Live</option>
-</select></li>''' % (self.w_woodward.pk, self.w_royko.pk, self.c1.pk, self.c2.pk, self.c3.pk))
+            "\n".join([
+                (
+                    "<li>Headline: <input type=\"text\" name=\"headline\" value=\"Your "
+                    "headline here\" maxlength=\"50\" required></li>"
+                ),
+                "<li>Slug: <input type=\"text\" name=\"slug\" maxlength=\"50\" required></li>",
+                "<li>Pub date: <input type=\"text\" name=\"pub_date\" required></li>",
+                "<li>Writer: <select name=\"writer\" required>",
+                "<option value=\"\" selected>---------</option>",
+                "<option value=\"%s\">Bob Woodward</option>",
+                "<option value=\"%s\">Mike Royko</option>",
+                "</select></li>",
+                "<li>Article: <textarea rows=\"10\" cols=\"40\" name=\"article\" required></textarea></li>",
+                "<li>Categories: <select multiple name=\"categories\">",
+                "<option value=\"%s\" selected>Entertainment</option>",
+                "<option value=\"%s\" selected>It&#x27;s a test</option>",
+                "<option value=\"%s\">Third test</option>",
+                "</select></li>",
+                "<li>Status: <select name=\"status\">",
+                "<option value=\"\" selected>---------</option>",
+                "<option value=\"1\">Draft</option>",
+                "<option value=\"2\">Pending</option>",
+                "<option value=\"3\">Live</option>",
+                "</select></li>",
+            ]) % (
+                self.w_woodward.pk,
+                self.w_royko.pk,
+                self.c1.pk,
+                self.c2.pk,
+                self.c3.pk,
+            )
+        )
 
         # When the ModelForm is passed an instance, that instance's current values are
         # inserted as 'initial' data in each Field.
@@ -2566,8 +2587,10 @@ class OtherModelFormTests(TestCase):
         self.assertEqual(list(CustomFieldForExclusionForm.base_fields), ['name'])
         self.assertHTMLEqual(
             str(CustomFieldForExclusionForm()),
-            '''<tr><th><label for="id_name">Name:</label></th>
-<td><input id="id_name" type="text" name="name" maxlength="10" required></td></tr>'''
+            "\n".join([
+                "<tr><th><label for=\"id_name\">Name:</label></th>",
+                "<td><input id=\"id_name\" type=\"text\" name=\"name\" maxlength=\"10\" required></td></tr>",
+            ]),
         )
 
     def test_iterable_model_m2m(self):
@@ -2581,12 +2604,16 @@ class OtherModelFormTests(TestCase):
         self.maxDiff = 1024
         self.assertHTMLEqual(
             form.as_p(),
-            """<p><label for="id_name">Name:</label> <input id="id_name" type="text" name="name" maxlength="50" required></p>
-        <p><label for="id_colours">Colours:</label>
-        <select multiple name="colours" id="id_colours" required>
-        <option value="%(blue_pk)s">Blue</option>
-        </select></p>"""
-            % {'blue_pk': colour.pk})
+            "\n".join([
+                "<p><label for=\"id_name\">Name:</label> <input id=\"id_name\" type=\"text\" "
+                "name=\"name\" maxlength=\"50\" required></p>",
+                "<p><label for=\"id_colours\">Colours:</label>",
+                "<select multiple name=\"colours\" id=\"id_colours\" required>",
+                "<option value=\"%(blue_pk)s\">Blue</option>",
+                "</select></p>",
+            ])
+            % {'blue_pk': colour.pk},
+        )
 
     def test_callable_field_default(self):
         class PublicationDefaultsForm(forms.ModelForm):

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -168,7 +168,7 @@ class SchemaTests(TransactionTestCase):
             schema_editor.add_field(model, field)
             cursor.execute("SELECT {} FROM {};".format(field_name, model._meta.db_table))
             database_default = cursor.fetchall()[0][0]
-            if cast_function and not isinstance(database_default, type(expected_default)):
+            if cast_function and type(database_default) is not type(expected_default):
                 database_default = cast_function(database_default)
             self.assertEqual(database_default, expected_default)
 

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -168,7 +168,7 @@ class SchemaTests(TransactionTestCase):
             schema_editor.add_field(model, field)
             cursor.execute("SELECT {} FROM {};".format(field_name, model._meta.db_table))
             database_default = cursor.fetchall()[0][0]
-            if cast_function and type(database_default) != type(expected_default):
+            if cast_function and not isinstance(database_default, type(expected_default)):
                 database_default = cast_function(database_default)
             self.assertEqual(database_default, expected_default)
 

--- a/tests/user_commands/urls.py
+++ b/tests/user_commands/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
 
 urlpatterns = [
-    path('some/url/', lambda req:req, name='some_url'),
+    path('some/url/', lambda req: req, name='some_url'),
 ]


### PR DESCRIPTION
## Summary
- limit HTML `required` to subwidgets whose fields are required when `require_all_fields=False`
- pass per-subfield metadata through `BoundField` so `MultiWidget` can set attributes precisely
- cover regression scenarios for custom MultiValueField, `use_required_attribute=False`, `SplitDateTimeField`, and `SplitHiddenDateTimeWidget`

## Reproduction
1. Checkout `django__django-14034`.
2. Run `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py forms_tests.tests.test_forms.MultiValueFieldRequiredAttributeTests --parallel=1`.

## Observed Behavior
- All subwidgets rendered with the HTML `required` attribute, preventing submission when optional subfields are left empty.

## Failing Test Trace (pre-fix)
```
FAIL: test_require_all_fields_false_renders_required_on_required_subwidgets (forms_tests.tests.test_forms.MultiValueFieldRequiredAttributeTests.test_require_all_fields_false_renders_required_on_required_subwidgets)
AssertionError: Lists differ: [True, True] != [True, None]
First differing element 1:
True
None
- [True, True]
+ [True, None]
```

## References
- Django ticket #14034
- Docs: [MultiValueField.require_all_fields](https://docs.djangoproject.com/en/dev/ref/forms/fields/#django.forms.MultiValueField.require_all_fields)
- Docs: [Form.use_required_attribute](https://docs.djangoproject.com/en/dev/ref/forms/api/#django.forms.Form.use_required_attribute)