### PR TITLE
Fix Q combinable behavior with conditional expressions (swev-id: django__django-14017)

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -41,7 +41,9 @@ class Q(tree.Node):
 
     def _combine(self, other, conn):
         if not isinstance(other, Q):
-            raise TypeError(other)
+            if not hasattr(other, 'resolve_expression') or not getattr(other, 'conditional', False):
+                raise TypeError(other)
+            other = Q(other)
 
         # If the other Q() is empty, ignore it and just use `self`.
         if not other:

--- a/tests/expressions/test_q_combinable.py
+++ b/tests/expressions/test_q_combinable.py
@@ -1,0 +1,81 @@
+from unittest import SkipTest
+
+from django.apps import apps
+from django.db.models import BooleanField, Exists, OuterRef, Q, Value
+from django.test import TestCase
+
+
+class QCombinableTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        try:
+            Number = apps.get_model('queries', 'Number')
+            ReservedName = apps.get_model('queries', 'ReservedName')
+        except LookupError as exc:
+            raise SkipTest("'queries' app is not installed") from exc
+        cls.Number = Number
+        cls.ReservedName = ReservedName
+        Number.objects.bulk_create([
+            Number(num=1),
+            Number(num=2),
+            Number(num=3),
+            Number(num=4),
+        ])
+        ReservedName.objects.bulk_create([
+            ReservedName(name="first", order=1),
+            ReservedName(name="third", order=3),
+        ])
+
+    def assertNums(self, queryset, expected):
+        self.assertEqual(
+            list(queryset.order_by("num").values_list("num", flat=True)),
+            expected,
+        )
+
+    def test_q_and_exists(self):
+        rn_exists = Exists(
+            self.ReservedName.objects.filter(order=OuterRef("num"))
+        )
+        queryset = self.Number.objects.filter(Q(num__lt=3) & rn_exists)
+        self.assertNums(queryset, [1])
+
+    def test_exists_and_q(self):
+        rn_exists = Exists(
+            self.ReservedName.objects.filter(order=OuterRef("num"))
+        )
+        queryset = self.Number.objects.filter(rn_exists & Q(num__lt=3))
+        self.assertNums(queryset, [1])
+
+    def test_q_or_exists(self):
+        rn_exists = Exists(
+            self.ReservedName.objects.filter(order=OuterRef("num"))
+        )
+        queryset = self.Number.objects.filter(Q(num__lt=3) | rn_exists)
+        self.assertNums(queryset, [1, 2, 3])
+
+    def test_exists_or_q(self):
+        rn_exists = Exists(
+            self.ReservedName.objects.filter(order=OuterRef("num"))
+        )
+        queryset = self.Number.objects.filter(rn_exists | Q(num__lt=3))
+        self.assertNums(queryset, [1, 2, 3])
+
+    def test_q_and_boolean_expression(self):
+        bool_expr = Value(True, output_field=BooleanField())
+        queryset = self.Number.objects.filter(Q(num__lt=3) & bool_expr)
+        self.assertNums(queryset, [1, 2])
+
+    def test_boolean_expression_and_q(self):
+        bool_expr = Value(True, output_field=BooleanField())
+        queryset = self.Number.objects.filter(bool_expr & Q(num__lt=3))
+        self.assertNums(queryset, [1, 2])
+
+    def test_q_or_boolean_expression(self):
+        bool_expr = Value(True, output_field=BooleanField())
+        queryset = self.Number.objects.filter(Q(num__lt=3) | bool_expr)
+        self.assertNums(queryset, [1, 2, 3, 4])
+
+    def test_boolean_expression_or_q(self):
+        bool_expr = Value(True, output_field=BooleanField())
+        queryset = self.Number.objects.filter(bool_expr | Q(num__lt=3))
+        self.assertNums(queryset, [1, 2, 3, 4])


### PR DESCRIPTION
## Summary
- Allow `Q._combine()` to accept resolvable boolean expressions (e.g., `Exists`, `Value(True)`) and combine safely.
- Add regression coverage for combining `Q` with `Exists` and other conditional expressions, ensuring commutativity for `&` and `|`.

Resolves #302.

## Reproduction Steps (pre-fix)
```python
from django.db.models.query_utils import Q
from django.db.models.expressions import Value
from django.db.models import BooleanField

q = Q(name='x')
expr = Value(True, output_field=BooleanField())
q & expr  # raises TypeError
```

## Observed Failure (pre-fix stack trace)
```
Traceback (most recent call last):
  File "<stdin>", line 6, in <module>
  File "django/db/models/query_utils.py", line 65, in __and__
    return self._combine(other, self.AND)
  File "django/db/models/query_utils.py", line 44, in _combine
    raise TypeError(other)
TypeError: Value(True)
```

## Fix
In `django/db/models/query_utils.py`, `Q._combine` now permits non-`Q` operands that:
- implement `resolve_expression`, and
- have `conditional=True` (Boolean output field).

Non-expressions and non-boolean expressions continue to raise `TypeError`.

## Tests
New file: `tests/expressions/test_q_combinable.py`
- `Q & Exists` (Q LHS) and `Exists & Q` return the same rows.
- `Q | Exists` and `Exists | Q` return the same rows.
- Additional symmetry checks with `Value(True)` boolean expressions.

Local run:
- `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv/bin/python tests/runtests.py queries expressions.test_q_combinable --parallel=1`
- `/workspace/.venv/bin/flake8 django/db/models/query_utils.py tests/expressions/test_q_combinable.py`