### PR TITLE
Allow reversed() on OrderedSet (swev-id: django__django-14089)

### DIFF
--- a/django/utils/datastructures.py
+++ b/django/utils/datastructures.py
@@ -1,4 +1,5 @@
 import copy
+from collections import OrderedDict
 from collections.abc import Mapping
 
 
@@ -8,7 +9,7 @@ class OrderedSet:
     """
 
     def __init__(self, iterable=None):
-        self.dict = dict.fromkeys(iterable or ())
+        self.dict = OrderedDict.fromkeys(iterable or ())
 
     def add(self, item):
         self.dict[item] = None
@@ -24,6 +25,9 @@ class OrderedSet:
 
     def __iter__(self):
         return iter(self.dict)
+
+    def __reversed__(self):
+        return reversed(self.dict)
 
     def __contains__(self, item):
         return item in self.dict

--- a/tests/utils_tests/test_datastructures.py
+++ b/tests/utils_tests/test_datastructures.py
@@ -55,6 +55,34 @@ class OrderedSetTests(SimpleTestCase):
         s.add(2)
         self.assertEqual(len(s), 2)
 
+    def test_reversed_basic(self):
+        s = OrderedSet(['a', 'b', 'c'])
+        self.assertEqual(list(reversed(s)), ['c', 'b', 'a'])
+
+    def test_reversed_empty(self):
+        self.assertEqual(list(reversed(OrderedSet())), [])
+
+    def test_reversed_after_mutations(self):
+        s = OrderedSet(['a', 'b'])
+        s.add('c')
+        s.add('b')
+        s.remove('a')
+        s.add('d')
+        s.discard('x')
+        self.assertEqual(list(s), ['b', 'c', 'd'])
+        self.assertEqual(list(reversed(s)), ['d', 'c', 'b'])
+
+    def test_reversed_parity_with_sequences(self):
+        s = OrderedSet([1, 2, 3, 4])
+        forward = list(s)
+        self.assertEqual(list(reversed(s)), list(reversed(forward)))
+        self.assertEqual(list(reversed(s)), list(reversed(tuple(s))))
+
+    def test_reversed_matches_forward_iteration_order(self):
+        s = OrderedSet([10, 20, 30])
+        forward = list(iter(s))
+        self.assertEqual(list(reversed(s)), list(reversed(forward)))
+
 
 class MultiValueDictTests(SimpleTestCase):
 


### PR DESCRIPTION
## Reproduction Steps
```python
from django.utils.datastructures import OrderedSet
s = OrderedSet([1, 2, 3])
list(reversed(s))
```

## Observed Failure
```
Traceback (most recent call last):
  File "repro.py", line 3, in <module>
    list(reversed(OrderedSet([1, 2, 3])))
TypeError: 'OrderedSet' object is not reversible
```

## Summary
- back OrderedSet with collections.OrderedDict to enable reverse iteration
- add __reversed__ that delegates to the underlying mapping
- extend OrderedSet tests to cover reversed iteration semantics and mutations

## Testing
- .venv/bin/flake8 django/utils/datastructures.py tests/utils_tests/test_datastructures.py
- PYTHONPATH=/workspace/django ../.venv/bin/python tests/runtests.py utils_tests.test_datastructures --parallel=1

Fixes #307