### PR TITLE
feat: unwrap ResolverMatch partial repr (swev-id: django__django-14155)

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -59,8 +59,57 @@ class ResolverMatch:
         return (self.func, self.args, self.kwargs)[index]
 
     def __repr__(self):
+        func_repr = self._func_path
+        func = self.func
+        partial_chain = []
+
+        while isinstance(func, functools.partial):
+            partial_chain.append(func)
+            func = func.func
+
+        if partial_chain:
+
+            def describe_callable(callable_obj):
+                if inspect.ismethod(callable_obj):
+                    return f"{callable_obj.__module__}.{callable_obj.__qualname__}"
+                if inspect.isfunction(callable_obj):
+                    return f"{callable_obj.__module__}.{callable_obj.__qualname__}"
+                if hasattr(callable_obj, '__call__'):
+                    cls = callable_obj.__class__
+                    return f"{cls.__module__}.{cls.__qualname__}.__call__"
+                module = getattr(callable_obj, '__module__', None)
+                qualname = getattr(callable_obj, '__qualname__', None)
+                name = getattr(callable_obj, '__name__', None)
+                if module and qualname:
+                    return f"{module}.{qualname}"
+                if module and name:
+                    return f"{module}.{name}"
+                return repr(callable_obj)
+
+            combined_args = []
+            combined_kwargs = {}
+            for partial_obj in reversed(partial_chain):
+                if partial_obj.args:
+                    combined_args.extend(partial_obj.args)
+                if partial_obj.keywords:
+                    combined_kwargs.update(partial_obj.keywords)
+
+            combined_args_tuple = tuple(combined_args)
+            sorted_kwargs = (
+                {key: combined_kwargs[key] for key in sorted(combined_kwargs)}
+                if combined_kwargs
+                else {}
+            )
+
+            func_repr = describe_callable(func)
+            if combined_args_tuple or sorted_kwargs:
+                func_repr = (
+                    f"{func_repr} [partial args={repr(combined_args_tuple)}, "
+                    f"kwargs={repr(sorted_kwargs)}]"
+                )
+
         return "ResolverMatch(func=%s, args=%s, kwargs=%s, url_name=%s, app_names=%s, namespaces=%s, route=%s)" % (
-            self._func_path, self.args, self.kwargs, self.url_name,
+            func_repr, self.args, self.kwargs, self.url_name,
             self.app_names, self.namespaces, self.route,
         )
 

--- a/tests/urlpatterns_reverse/tests.py
+++ b/tests/urlpatterns_reverse/tests.py
@@ -1146,6 +1146,46 @@ class ResolverMatchTests(SimpleTestCase):
         )
 
 
+@override_settings(ROOT_URLCONF='urlpatterns_reverse.urls')
+class ResolverMatchPartialTests(SimpleTestCase):
+
+    def test_repr_partial(self):
+        self.assertEqual(
+            repr(resolve('/partial/')),
+            "ResolverMatch(func=urlpatterns_reverse.views.empty_view "
+            "[partial args=(), kwargs={'template_name': 'template.html'}], "
+            "args=(), kwargs={}, url_name=partial, app_names=[], namespaces=[], "
+            "route=partial/)",
+        )
+
+    def test_repr_partial_nested(self):
+        self.assertEqual(
+            repr(resolve('/partial_nested/')),
+            "ResolverMatch(func=urlpatterns_reverse.views.empty_view "
+            "[partial args=(), kwargs={'template_name': 'nested_partial.html'}], "
+            "args=(), kwargs={}, url_name=partial_nested, app_names=[], "
+            "namespaces=[], route=partial_nested/)",
+        )
+
+    def test_repr_partial_wrapped(self):
+        self.assertEqual(
+            repr(resolve('/partial_wrapped/')),
+            "ResolverMatch(func=urlpatterns_reverse.views.empty_view "
+            "[partial args=(), kwargs={'template_name': 'template.html'}], "
+            "args=(), kwargs={}, url_name=partial_wrapped, app_names=[], "
+            "namespaces=[], route=partial_wrapped/)",
+        )
+
+    def test_repr_partial_callable_instance(self):
+        self.assertEqual(
+            repr(resolve('/partial_callable/')),
+            "ResolverMatch(func=urlpatterns_reverse.views.ViewClass.__call__ "
+            "[partial args=(), kwargs={'status': 204}], args=(), kwargs={}, "
+            "url_name=partial_callable, app_names=[], namespaces=[], "
+            "route=partial_callable/)",
+        )
+
+
 @override_settings(ROOT_URLCONF='urlpatterns_reverse.erroneous_urls')
 class ErroneousViewTests(SimpleTestCase):
 

--- a/tests/urlpatterns_reverse/urls.py
+++ b/tests/urlpatterns_reverse/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path, re_path
 from .views import (
     absolute_kwargs_view, defaults_view, empty_view, empty_view_nested_partial,
     empty_view_partial, empty_view_wrapped, nested_view,
+    view_class_instance_partial,
 )
 
 other_patterns = [
@@ -62,6 +63,7 @@ urlpatterns = [
     path('partial/', empty_view_partial, name='partial'),
     path('partial_nested/', empty_view_nested_partial, name='partial_nested'),
     path('partial_wrapped/', empty_view_wrapped, name='partial_wrapped'),
+    path('partial_callable/', view_class_instance_partial, name='partial_callable'),
 
     # This is non-reversible, but we shouldn't blow up when parsing it.
     re_path(r'^(?:foo|bar)(\w+)/$', empty_view, name='disjunction'),

--- a/tests/urlpatterns_reverse/views.py
+++ b/tests/urlpatterns_reverse/views.py
@@ -41,6 +41,7 @@ class ViewClass:
 
 
 view_class_instance = ViewClass()
+view_class_instance_partial = partial(view_class_instance, status=204)
 
 
 class LazyRedirectView(RedirectView):


### PR DESCRIPTION
## Summary
- unwrap nested functools.partial instances in `ResolverMatch.__repr__`
- surface the underlying callable path and bound args/kwargs with deterministic formatting
- add regression coverage for partial views, nested partials, wrapped partials, and callable-instance partials

## Reproduction
1. From branch `django__django-14155`, run `python - <<'PY'`
   ```python
   from django.urls import resolve
   print(repr(resolve('/partial/')))
   ```
   PY
2. Observed prior to this fix:
   ```
   ResolverMatch(func=functools.partial, args=(), kwargs={}, url_name=partial, app_names=[], namespaces=[], route=partial/)
   ```

## Failing test traceback
```
py3 run-test: commands[0] | /workspace/django/.tox/py3/bin/python runtests.py tests.urlpatterns_reverse.tests.ResolverMatchPartialTests
Testing against Django installed in '/workspace/django/django' with up to 16 processes
System check identified no issues (0 silenced).
FFFF
======================================================================
FAIL: test_repr_partial (tests.urlpatterns_reverse.tests.ResolverMatchPartialTests.test_repr_partial)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/urlpatterns_reverse/tests.py", line 1153, in test_repr_partial
    self.assertEqual(
AssertionError: 'ResolverMatch(func=functools.partial, args=(), kwargs={}, url_name=partial, app_names=[], namespaces=[], route=partial/)' != "ResolverMatch(func=urlpatterns_reverse.views.empty_view [partial args=(), kwargs={'template_name': 'template.html'}], args=(), kwargs={}, url_name=partial, app_names=[], namespaces=[], route=partial/)"

======================================================================
FAIL: test_repr_partial_callable_instance (tests.urlpatterns_reverse.tests.ResolverMatchPartialTests.test_repr_partial_callable_instance)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/urlpatterns_reverse/tests.py", line 1180, in test_repr_partial_callable_instance
    self.assertEqual(
AssertionError: 'ResolverMatch(func=functools.partial, args=(), kwargs={}, url_name=partial_callable, app_names=[], namespaces=[], route=partial_callable/)' != "ResolverMatch(func=urlpatterns_reverse.views.ViewClass.__call__ [partial args=(), kwargs={'status': 204}], args=(), kwargs={}, url_name=partial_callable, app_names=[], namespaces=[], route=partial_callable/)"

======================================================================
FAIL: test_repr_partial_nested (tests.urlpatterns_reverse.tests.ResolverMatchPartialTests.test_repr_partial_nested)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/urlpatterns_reverse/tests.py", line 1162, in test_repr_partial_nested
    self.assertEqual(
AssertionError: 'ResolverMatch(func=functools.partial, args=(), kwargs={}, url_name=partial_nested, app_names=[], namespaces=[], route=partial_nested/)' != "ResolverMatch(func=urlpatterns_reverse.views.empty_view [partial args=(), kwargs={'template_name': 'nested_partial.html'}], args=(), kwargs={}, url_name=partial_nested, app_names=[], namespaces=[], route=partial_nested/)"

======================================================================
FAIL: test_repr_partial_wrapped (tests.urlpatterns_reverse.tests.ResolverMatchPartialTests.test_repr_partial_wrapped)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/urlpatterns_reverse/tests.py", line 1171, in test_repr_partial_wrapped
    self.assertEqual(
AssertionError: 'ResolverMatch(func=urlpatterns_reverse.views.empty_view, args=(), kwargs={}, url_name=partial_wrapped, app_names=[], namespaces=[], route=partial_wrapped/)' != "ResolverMatch(func=urlpatterns_reverse.views.empty_view [partial args=(), kwargs={'template_name': 'template.html'}], args=(), kwargs={}, url_name=partial_wrapped, app_names=[], namespaces=[], route=partial_wrapped/)"
```

## Testing
- `PYTHONPATH=/workspace/django .venv/bin/tox -e py3 -- tests.urlpatterns_reverse.tests.ResolverMatchTests.test_repr tests.urlpatterns_reverse.tests.ResolverMatchPartialTests`
