### PR TITLE
swev-id: django__django-14238 | Fix DEFAULT_AUTO_FIELD subclass recognition

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -2524,7 +2524,7 @@ class AutoFieldMeta(type):
         return isinstance(instance, self._subclasses) or super().__instancecheck__(instance)
 
     def __subclasscheck__(self, subclass):
-        return subclass in self._subclasses or super().__subclasscheck__(subclass)
+        return issubclass(subclass, self._subclasses) or super().__subclasscheck__(subclass)
 
 
 class AutoField(AutoFieldMixin, IntegerField, metaclass=AutoFieldMeta):

--- a/tests/model_options/apps.py
+++ b/tests/model_options/apps.py
@@ -10,6 +10,16 @@ class ModelPKConfig(AppConfig):
     default_auto_field = 'django.db.models.SmallAutoField'
 
 
+class ModelPKCustomBigConfig(AppConfig):
+    name = 'model_options'
+    default_auto_field = 'model_options.fields.MyBigAutoField'
+
+
+class ModelPKCustomSmallConfig(AppConfig):
+    name = 'model_options'
+    default_auto_field = 'model_options.fields.MySmallAutoField'
+
+
 class ModelPKNonAutoConfig(AppConfig):
     name = 'model_options'
     default_auto_field = 'django.db.models.TextField'

--- a/tests/model_options/fields.py
+++ b/tests/model_options/fields.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class MyBigAutoField(models.BigAutoField):
+    pass
+
+
+class MySmallAutoField(models.SmallAutoField):
+    pass

--- a/tests/model_options/test_default_pk.py
+++ b/tests/model_options/test_default_pk.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import isolate_apps
+from model_options.fields import MyBigAutoField, MySmallAutoField
 
 
 @isolate_apps('model_options')
@@ -74,6 +75,26 @@ class TestDefaultPK(SimpleTestCase):
 
         self.assertIsInstance(Model._meta.pk, models.SmallAutoField)
 
+    @isolate_apps('model_options.apps.ModelDefaultPKConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='model_options.fields.MyBigAutoField')
+    def test_default_auto_field_setting_custom_big_subclass(self):
+        class Model(models.Model):
+            pass
+
+        pk = Model._meta.pk
+        self.assertIsInstance(pk, MyBigAutoField)
+        self.assertIsInstance(pk, models.BigAutoField)
+
+    @isolate_apps('model_options.apps.ModelDefaultPKConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='model_options.fields.MySmallAutoField')
+    def test_default_auto_field_setting_custom_small_subclass(self):
+        class Model(models.Model):
+            pass
+
+        pk = Model._meta.pk
+        self.assertIsInstance(pk, MySmallAutoField)
+        self.assertIsInstance(pk, models.SmallAutoField)
+
     @isolate_apps('model_options.apps.ModelPKConfig')
     @override_settings(DEFAULT_AUTO_FIELD='django.db.models.AutoField')
     def test_app_default_auto_field(self):
@@ -81,6 +102,26 @@ class TestDefaultPK(SimpleTestCase):
             pass
 
         self.assertIsInstance(Model._meta.pk, models.SmallAutoField)
+
+    @isolate_apps('model_options.apps.ModelPKCustomBigConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='django.db.models.AutoField')
+    def test_app_default_auto_field_custom_big_subclass(self):
+        class Model(models.Model):
+            pass
+
+        pk = Model._meta.pk
+        self.assertIsInstance(pk, MyBigAutoField)
+        self.assertIsInstance(pk, models.BigAutoField)
+
+    @isolate_apps('model_options.apps.ModelPKCustomSmallConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='django.db.models.AutoField')
+    def test_app_default_auto_field_custom_small_subclass(self):
+        class Model(models.Model):
+            pass
+
+        pk = Model._meta.pk
+        self.assertIsInstance(pk, MySmallAutoField)
+        self.assertIsInstance(pk, models.SmallAutoField)
 
     @isolate_apps('model_options.apps.ModelDefaultPKConfig')
     @override_settings(DEFAULT_AUTO_FIELD='django.db.models.SmallAutoField')
@@ -98,4 +139,44 @@ class TestDefaultPK(SimpleTestCase):
             m2m = models.ManyToManyField('self')
 
         m2m_pk = M2MModel._meta.get_field('m2m').remote_field.through._meta.pk
+        self.assertIsInstance(m2m_pk, models.SmallAutoField)
+
+    @isolate_apps('model_options.apps.ModelDefaultPKConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='model_options.fields.MyBigAutoField')
+    def test_m2m_default_auto_field_setting_custom_big_subclass(self):
+        class M2MModel(models.Model):
+            m2m = models.ManyToManyField('self')
+
+        m2m_pk = M2MModel._meta.get_field('m2m').remote_field.through._meta.pk
+        self.assertIsInstance(m2m_pk, MyBigAutoField)
+        self.assertIsInstance(m2m_pk, models.BigAutoField)
+
+    @isolate_apps('model_options.apps.ModelDefaultPKConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='model_options.fields.MySmallAutoField')
+    def test_m2m_default_auto_field_setting_custom_small_subclass(self):
+        class M2MModel(models.Model):
+            m2m = models.ManyToManyField('self')
+
+        m2m_pk = M2MModel._meta.get_field('m2m').remote_field.through._meta.pk
+        self.assertIsInstance(m2m_pk, MySmallAutoField)
+        self.assertIsInstance(m2m_pk, models.SmallAutoField)
+
+    @isolate_apps('model_options.apps.ModelPKCustomBigConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='django.db.models.AutoField')
+    def test_m2m_app_default_auto_field_custom_big_subclass(self):
+        class M2MModel(models.Model):
+            m2m = models.ManyToManyField('self')
+
+        m2m_pk = M2MModel._meta.get_field('m2m').remote_field.through._meta.pk
+        self.assertIsInstance(m2m_pk, MyBigAutoField)
+        self.assertIsInstance(m2m_pk, models.BigAutoField)
+
+    @isolate_apps('model_options.apps.ModelPKCustomSmallConfig')
+    @override_settings(DEFAULT_AUTO_FIELD='django.db.models.AutoField')
+    def test_m2m_app_default_auto_field_custom_small_subclass(self):
+        class M2MModel(models.Model):
+            m2m = models.ManyToManyField('self')
+
+        m2m_pk = M2MModel._meta.get_field('m2m').remote_field.through._meta.pk
+        self.assertIsInstance(m2m_pk, MySmallAutoField)
         self.assertIsInstance(m2m_pk, models.SmallAutoField)


### PR DESCRIPTION
**Issue**: https://github.com/agyn-sandbox/django/issues/310

**Summary**
DEFAULT_AUTO_FIELD subclass check fails for subclasses of BigAutoField and SmallAutoField.
- Problem: Setting DEFAULT_AUTO_FIELD to a subclass (e.g., MyBigAutoField) raises ValueError: must subclass AutoField.
- Goal: Update AutoFieldMeta.__subclasscheck__ (and related checks) to recognize subclasses of BigAutoField/SmallAutoField, not only direct subclasses.

**Fix**
- In AutoFieldMeta.__subclasscheck__, use issubclass(subclass, self._subclasses) instead of direct membership so custom subclasses are recognized.
- Add regression tests covering DEFAULT_AUTO_FIELD/AppConfig paths, including ManyToMany through models, for custom BigAutoField/SmallAutoField subclasses.

**Reproduction steps**
1) Define custom subclasses:

   class MyBigAutoField(models.BigAutoField): pass
   class MySmallAutoField(models.SmallAutoField): pass

2) Set DEFAULT_AUTO_FIELD to one of these and import a model with no explicit PK.

**Observed failures and stack traces**
MyBigAutoField:

Traceback (most recent call last):
  File "/workspace/django/repro.py", line 17, in run
    django.setup()
  File "/workspace/django/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/workspace/django/django/apps/registry.py", line 114, in populate
    app_config.import_models()
  File "/workspace/django/django/apps/config.py", line 300, in import_models
    self.models_module = import_module(models_module_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/kbyysxq0ry8vqbpkdwld118fi92wvqsf-python3-3.11.14/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/workspace/django/repro_app/models.py", line 3, in <module>
    class ReproModel(models.Model):
  File "/workspace/django/django/db/models/base.py", line 320, in __new__
    new_class._prepare()
  File "/workspace/django/django/db/models/base.py", line 333, in _prepare
    opts._prepare(cls)
  File "/workspace/django/django/db/models/options.py", line 285, in _prepare
    pk_class = self._get_default_pk_class()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/models/options.py", line 246, in _get_default_pk_class
    raise ValueError(
ValueError: Primary key 'repro_field.MyBigAutoField' referred by DEFAULT_AUTO_FIELD must subclass AutoField.

MySmallAutoField:

Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "/workspace/django/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/workspace/django/django/apps/registry.py", line 114, in populate
    app_config.import_models()
  File "/workspace/django/django/apps/config.py", line 300, in import_models
    self.models_module = import_module(models_module_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/kbyysxq0ry8vqbpkdwld118fi92wvqsf-python3-3.11.14/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/workspace/django/repro_app/models.py", line 3, in <module>
    class ReproModel(models.Model):
  File "/workspace/django/django/db/models/base.py", line 320, in __new__
    new_class._prepare()
  File "/workspace/django/django/db/models/base.py", line 333, in _prepare
    opts._prepare(cls)
  File "/workspace/django/django/db/models/options.py", line 285, in _prepare
    pk_class = self._get_default_pk_class()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/models/options.py", line 246, in _get_default_pk_class
    raise ValueError(
ValueError: Primary key 'repro_field.MySmallAutoField' referred by DEFAULT_AUTO_FIELD must subclass AutoField.

**Tests**
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py model_options.test_default_pk --parallel=1
- .venv/bin/flake8 django/db/models/fields/__init__.py tests/model_options/apps.py tests/model_options/test_default_pk.py tests/model_options/fields.py

**Notes**
- Base branch: django__django-14238
- Please do not manually trigger CI; ensure local tests pass.