### PR TITLE
fix: ensure iso_year lookups use extraction (swev-id: django__django-14170)

### DIFF
--- a/django/db/models/functions/datetime.py
+++ b/django/db/models/functions/datetime.py
@@ -6,6 +6,7 @@ from django.db.models.fields import (
     DateField, DateTimeField, DurationField, Field, IntegerField, TimeField,
 )
 from django.db.models.lookups import (
+    Exact, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual,
     Transform, YearExact, YearGt, YearGte, YearLt, YearLte,
 )
 from django.utils import timezone
@@ -164,11 +165,11 @@ ExtractYear.register_lookup(YearGte)
 ExtractYear.register_lookup(YearLt)
 ExtractYear.register_lookup(YearLte)
 
-ExtractIsoYear.register_lookup(YearExact)
-ExtractIsoYear.register_lookup(YearGt)
-ExtractIsoYear.register_lookup(YearGte)
-ExtractIsoYear.register_lookup(YearLt)
-ExtractIsoYear.register_lookup(YearLte)
+ExtractIsoYear.register_lookup(Exact)
+ExtractIsoYear.register_lookup(GreaterThan)
+ExtractIsoYear.register_lookup(GreaterThanOrEqual)
+ExtractIsoYear.register_lookup(LessThan)
+ExtractIsoYear.register_lookup(LessThanOrEqual)
 
 
 class Now(Func):

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -90,6 +90,26 @@ class DateFunctionTests(TestCase):
             duration=(end_datetime - start_datetime) if start_datetime and end_datetime else None,
         )
 
+    def assertIsoYearQueryUsesExtraction(self, query):
+        sql = str(query).lower()
+        self.assertIn('extract', sql)
+        self.assertNotIn(' between ', sql)
+        return sql
+
+    def create_iso_year_samples(self):
+        datetimes = [
+            datetime(2014, 12, 28, 12, 0),
+            datetime(2014, 12, 29, 12, 0),
+            datetime(2015, 12, 31, 12, 0),
+            datetime(2016, 1, 1, 12, 0),
+            datetime(2016, 1, 4, 12, 0),
+            datetime(2016, 12, 31, 12, 0),
+            datetime(2017, 1, 1, 12, 0),
+        ]
+        for value in datetimes:
+            self.create_model(value, value + timedelta(hours=1))
+        return datetimes
+
     def test_extract_year_exact_lookup(self):
         """
         Extract year uses a BETWEEN filter to compare the year to allow indexes
@@ -103,7 +123,7 @@ class DateFunctionTests(TestCase):
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
-        for lookup in ('year', 'iso_year'):
+        for lookup in ('year',):
             with self.subTest(lookup):
                 qs = DTModel.objects.filter(**{'start_datetime__%s__exact' % lookup: 2015})
                 self.assertEqual(qs.count(), 1)
@@ -140,7 +160,7 @@ class DateFunctionTests(TestCase):
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
-        for lookup in ('year', 'iso_year'):
+        for lookup in ('year',):
             with self.subTest(lookup):
                 qs = DTModel.objects.filter(**{'start_datetime__%s__gt' % lookup: 2015})
                 self.assertEqual(qs.count(), 1)
@@ -163,7 +183,7 @@ class DateFunctionTests(TestCase):
         self.create_model(start_datetime, end_datetime)
         self.create_model(end_datetime, start_datetime)
 
-        for lookup in ('year', 'iso_year'):
+        for lookup in ('year',):
             with self.subTest(lookup):
                 qs = DTModel.objects.filter(**{'start_datetime__%s__lt' % lookup: 2016})
                 self.assertEqual(qs.count(), 1)
@@ -370,6 +390,62 @@ class DateFunctionTests(TestCase):
             (week_1_day_2014_2015, 2015),
             (week_53_day_2015, 2015),
         ], lambda m: (m.start_datetime, m.extracted))
+
+    def test_extract_iso_year_lookup_uses_extraction(self):
+        datetimes = self.create_iso_year_samples()
+        target_iso_year = 2015
+        expected = [value for value in datetimes if value.isocalendar().year == target_iso_year]
+        qs = DTModel.objects.filter(start_datetime__iso_year=target_iso_year).order_by('start_datetime')
+        self.assertIsoYearQueryUsesExtraction(qs.query)
+        self.assertQuerysetEqual(qs, expected, lambda m: m.start_datetime)
+
+        qs = DTModel.objects.annotate(
+            iso_year=ExtractIsoYear('start_datetime'),
+        ).filter(iso_year=target_iso_year).order_by('start_datetime')
+        self.assertIsoYearQueryUsesExtraction(qs.query)
+        self.assertQuerysetEqual(qs, expected, lambda m: m.start_datetime)
+
+    def test_extract_iso_year_inequality_lookups_use_extraction(self):
+        datetimes = self.create_iso_year_samples()
+
+        def get_iso_year(value):
+            return value.isocalendar().year
+
+        cases = (
+            ('gt', 2015, [value for value in datetimes if get_iso_year(value) > 2015]),
+            ('gte', 2015, [value for value in datetimes if get_iso_year(value) >= 2015]),
+            ('lt', 2015, [value for value in datetimes if get_iso_year(value) < 2015]),
+            ('lte', 2015, [value for value in datetimes if get_iso_year(value) <= 2015]),
+        )
+        for lookup, comparison_value, expected in cases:
+            with self.subTest(lookup):
+                filter_kwargs = {'start_datetime__iso_year__%s' % lookup: comparison_value}
+                qs = DTModel.objects.filter(**filter_kwargs).order_by('start_datetime')
+                self.assertIsoYearQueryUsesExtraction(qs.query)
+                self.assertQuerysetEqual(qs, expected, lambda m: m.start_datetime)
+
+    def test_extract_iso_year_differs_from_calendar_year(self):
+        datetimes = self.create_iso_year_samples()
+        target_year = 2015
+        iso_expected = sorted(
+            [value for value in datetimes if value.isocalendar().year == target_year]
+        )
+        calendar_expected = sorted(
+            [value for value in datetimes if value.year == target_year]
+        )
+
+        iso_qs = DTModel.objects.filter(start_datetime__iso_year=target_year).order_by('start_datetime')
+        calendar_qs = DTModel.objects.filter(start_datetime__year=target_year).order_by('start_datetime')
+
+        self.assertIsoYearQueryUsesExtraction(iso_qs.query)
+        iso_start_times = list(iso_qs.values_list('start_datetime', flat=True))
+        calendar_start_times = list(calendar_qs.values_list('start_datetime', flat=True))
+        self.assertEqual(iso_start_times, iso_expected)
+        self.assertEqual(calendar_start_times, calendar_expected)
+        self.assertNotEqual(iso_start_times, calendar_start_times)
+
+        calendar_sql = str(calendar_qs.query).lower()
+        self.assertIn(' between ', calendar_sql)
 
     def test_extract_month_func(self):
         start_datetime = datetime(2015, 6, 15, 14, 30, 50, 321)

--- a/tests/db_functions/datetime/test_extract_trunc.py
+++ b/tests/db_functions/datetime/test_extract_trunc.py
@@ -92,8 +92,27 @@ class DateFunctionTests(TestCase):
 
     def assertIsoYearQueryUsesExtraction(self, query):
         sql = str(query).lower()
-        self.assertIn('extract', sql)
         self.assertNotIn(' between ', sql)
+
+        def collect_lookups(node, collected):
+            for child in getattr(node, 'children', []):
+                if hasattr(child, 'children'):
+                    collect_lookups(child, collected)
+                else:
+                    collected.append(child)
+
+        lookups = []
+        collect_lookups(query.where, lookups)
+        iso_year_lookups = [
+            lookup for lookup in lookups
+            if getattr(getattr(lookup, 'lhs', None), 'lookup_name', None) == 'iso_year'
+        ]
+        self.assertTrue(
+            iso_year_lookups,
+            'Expected iso_year lookups to be present in query where clause.',
+        )
+        for lookup in iso_year_lookups:
+            self.assertIsInstance(lookup.lhs, ExtractIsoYear)
         return sql
 
     def create_iso_year_samples(self):


### PR DESCRIPTION
## Summary
- register standard comparison lookups on `ExtractIsoYear` so ISO-year filters always expand to extraction expressions instead of BETWEEN
- keep calendar year lookups untouched and extend regression coverage for ISO-year equality and inequality cases
- add tests comparing ISO week years to calendar years around boundary dates to prevent regressions

## Testing
- source .venv/bin/activate && PYTHONPATH=/workspace/django python tests/runtests.py db_functions.datetime.test_extract_trunc.DateFunctionTests --parallel=1
- source .venv/bin/activate && flake8 django/db/models/functions/datetime.py tests/db_functions/datetime/test_extract_trunc.py

## Reproduction
1. git checkout django__django-14170
2. source .venv/bin/activate && PYTHONPATH=/workspace/django python tests/runtests.py db_functions.datetime.test_extract_trunc.DateFunctionTests --parallel=1
3. Failure in `test_extract_iso_year_lookup_uses_extraction`:
   ```
   AssertionError: 'extract' not found in 'select "db_functions_dtmodel"."id", "db_functions_dtmodel"."name", ... where "db_functions_dtmodel"."start_datetime" between 2015-01-01 00:00:00 and 2015-12-31 23:59:59.999999 order by "db_functions_dtmodel"."start_datetime" asc'
   ```
4. Instrumented `django.db.models.lookups.YearLookup.as_sql()` to print the call stack:
   ```
   File ".../django/db/models/sql/query.py", line 277, in sql_with_params
       return self.get_compiler(DEFAULT_DB_ALIAS).as_sql()
   File ".../django/db/models/sql/compiler.py", line 523, in as_sql
       where, w_params = self.compile(self.where) if self.where is not None else ("", [])
   File ".../django/db/models/sql/compiler.py", line 440, in compile
       sql, params = node.as_sql(self, self.connection)
   File ".../django/db/models/sql/where.py", line 81, in as_sql
       sql, params = compiler.compile(child)
   File ".../django/db/models/sql/compiler.py", line 440, in compile
       sql, params = node.as_sql(self, self.connection)
   File "<instrumented YearLookup.as_sql>", line 19, in traced_as_sql
   ```
   SQL emitted before the fix:
   ```
   SELECT "db_functions_dtmodel"."id", "db_functions_dtmodel"."name", "db_functions_dtmodel"."start_datetime", ...
   FROM "db_functions_dtmodel"
   WHERE "db_functions_dtmodel"."start_datetime" BETWEEN 2015-01-01 00:00:00 AND 2015-12-31 23:59:59.999999
   ```
5. After applying this patch the suite passes and the generated SQL contains the ISO extraction with no BETWEEN.

Resolves #309.