### PR TITLE
swev-id: django__django-14311 Fix autoreloader module detection

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -237,7 +237,7 @@ def get_child_arguments():
             args += ['-m', module_name]
             args += sys.argv[1:]
             return args
-    elif not py_script.exists():
+    if not py_script.exists():
         # sys.argv[0] may not exist for several reasons on Windows.
         # It may exist with a .exe extension or have a -script.py suffix.
         exe_entrypoint = py_script.with_suffix('.exe')

--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -223,9 +223,20 @@ def get_child_arguments():
     # __spec__ is set when the server was started with the `-m` option,
     # see https://docs.python.org/3/reference/import.html#main-spec
     # __spec__ may not exist, e.g. when running in a Conda env.
-    if getattr(__main__, '__spec__', None) is not None and __main__.__spec__.parent:
-        args += ['-m', __main__.__spec__.parent]
-        args += sys.argv[1:]
+    spec = getattr(__main__, '__spec__', None)
+    module_name = None
+    if spec is not None:
+        if spec.name == '__main__':
+            module_name = spec.parent
+        elif spec.name.endswith('.__main__') and spec.parent:
+            module_name = spec.parent
+        else:
+            module_name = spec.name
+
+        if module_name:
+            args += ['-m', module_name]
+            args += sys.argv[1:]
+            return args
     elif not py_script.exists():
         # sys.argv[0] may not exist for several reasons on Windows.
         # It may exist with a .exe extension or have a -script.py suffix.
@@ -238,8 +249,7 @@ def get_child_arguments():
             # Should be executed as usual.
             return [*args, script_entrypoint, *sys.argv[1:]]
         raise RuntimeError('Script %s does not exist.' % py_script)
-    else:
-        args += sys.argv
+    args += sys.argv
     return args
 
 

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -1,4 +1,5 @@
 import contextlib
+import importlib.machinery
 import os
 import py_compile
 import shutil
@@ -181,6 +182,54 @@ class TestChildArguments(SimpleTestCase):
             autoreload.get_child_arguments(),
             [sys.executable, '-m', 'utils_tests.test_module', 'runserver'],
         )
+
+    @mock.patch('sys.warnoptions', [])
+    def test_preserves_non_package_spec_name(self):
+        module = types.ModuleType('__main__')
+        module.__file__ = 'manage.py'
+        module.__spec__ = importlib.machinery.ModuleSpec('app.module', loader=None)
+        with mock.patch.dict(sys.modules, {'__main__': module}):
+            with mock.patch('sys.argv', ['manage.py', 'runserver']):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [sys.executable, '-m', 'app.module', 'runserver'],
+                )
+
+    @mock.patch('sys.warnoptions', [])
+    def test_package_main_uses_parent(self):
+        module = types.ModuleType('__main__')
+        module.__file__ = 'manage.py'
+        module.__spec__ = importlib.machinery.ModuleSpec('pkg.sub.__main__', loader=None)
+        with mock.patch.dict(sys.modules, {'__main__': module}):
+            with mock.patch('sys.argv', ['manage.py', 'runserver']):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [sys.executable, '-m', 'pkg.sub', 'runserver'],
+                )
+
+    @mock.patch('sys.warnoptions', [])
+    def test_nested_dotted_module_preserved(self):
+        module = types.ModuleType('__main__')
+        module.__file__ = 'manage.py'
+        module.__spec__ = importlib.machinery.ModuleSpec('a.b.c.d', loader=None)
+        with mock.patch.dict(sys.modules, {'__main__': module}):
+            with mock.patch('sys.argv', ['manage.py', 'runserver']):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [sys.executable, '-m', 'a.b.c.d', 'runserver'],
+                )
+
+    @mock.patch('sys.warnoptions', [])
+    def test_bare_main_falls_back_to_script(self):
+        module = types.ModuleType('__main__')
+        module.__file__ = 'manage.py'
+        module.__spec__ = importlib.machinery.ModuleSpec('__main__', loader=None)
+        with mock.patch.dict(sys.modules, {'__main__': module}):
+            with mock.patch('sys.argv', ['manage.py', 'runserver']):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [sys.executable, 'manage.py', 'runserver'],
+                )
 
     @mock.patch('sys.argv', [__file__, 'runserver'])
     @mock.patch('sys.warnoptions', ['error'])

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -222,14 +222,17 @@ class TestChildArguments(SimpleTestCase):
     @mock.patch('sys.warnoptions', [])
     def test_bare_main_falls_back_to_script(self):
         module = types.ModuleType('__main__')
-        module.__file__ = 'manage.py'
-        module.__spec__ = importlib.machinery.ModuleSpec('__main__', loader=None)
-        with mock.patch.dict(sys.modules, {'__main__': module}):
-            with mock.patch('sys.argv', ['manage.py', 'runserver']):
-                self.assertEqual(
-                    autoreload.get_child_arguments(),
-                    [sys.executable, 'manage.py', 'runserver'],
-                )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = Path(tmpdir) / 'manage.py'
+            script_path.touch()
+            module.__file__ = str(script_path)
+            module.__spec__ = importlib.machinery.ModuleSpec('__main__', loader=None)
+            with mock.patch.dict(sys.modules, {'__main__': module}):
+                with mock.patch('sys.argv', [module.__file__, 'runserver']):
+                    self.assertEqual(
+                        autoreload.get_child_arguments(),
+                        [sys.executable, module.__file__, 'runserver'],
+                    )
 
     @mock.patch('sys.argv', [__file__, 'runserver'])
     @mock.patch('sys.warnoptions', ['error'])
@@ -260,6 +263,21 @@ class TestChildArguments(SimpleTestCase):
                     autoreload.get_child_arguments(),
                     [sys.executable, script_path, 'runserver']
                 )
+
+    @mock.patch('sys.warnoptions', [])
+    def test_spec_without_module_uses_windows_fallback(self):
+        module = types.ModuleType('__main__')
+        module.__file__ = 'manage.py'
+        module.__spec__ = importlib.machinery.ModuleSpec('__main__', loader=None)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exe_path = Path(tmpdir) / 'django-admin.exe'
+            exe_path.touch()
+            with mock.patch.dict(sys.modules, {'__main__': module}):
+                with mock.patch('sys.argv', [exe_path.with_suffix(''), 'runserver']):
+                    self.assertEqual(
+                        autoreload.get_child_arguments(),
+                        [exe_path, 'runserver']
+                    )
 
     @mock.patch('sys.argv', ['does-not-exist', 'runserver'])
     @mock.patch('sys.warnoptions', [])


### PR DESCRIPTION
## Summary
- preserve the full module spec when the autoreloader restarts a process launched with `python -m module.path`
- only collapse to the parent package for `__main__.py` loaders so package execution keeps working
- add regression coverage for dotted specs, nested packages, and the bare `__main__` fallback

## Reproduction
1. Create a minimal package:
   ```
   mypkg/
     __init__.py
     start.py  # calls execute_from_command_line(sys.argv)
   ```
2. Start the server: `python -m mypkg.start runserver`
3. Modify a watched file to trigger reload.
4. Before this fix the autoreloader restarted with `python -m mypkg runserver` and crashed:
   ```
   Traceback (most recent call last):
     File ".../runpy.py", line NNN, in _run_module_as_main
       mod_name, mod_spec, code = _get_module_details(mod_name)
     File ".../runpy.py", line NNN, in _get_module_details
       raise ImportError(f"No module named {pkg}.__main__; '{pkg}' is a package and cannot be directly executed")
   ImportError: No module named mypkg.__main__; 'mypkg' is a package and cannot be directly executed
   ```
5. After this change Django restarts with `python -m mypkg.start runserver` so the autoreloader works for dotted module paths again.

## Upstream References
- Mirrors django/django@ec6d2531c59466924b645f314ac33f54470d7ac3 follow-up logic
- Aligns with django/django#13837

## Corner Cases Covered
- dotted but non-package modules keep their full spec name
- package `__main__.py` continues to restart via the package name
- nested module names and bare `__main__` fall back to the script path

## Testing
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py utils_tests.test_autoreload --parallel=1`
- `flake8 django/utils/autoreload.py tests/utils_tests/test_autoreload.py`