### PR TITLE
fix: preserve PostgreSQL runshell env (swev-id: django__django-14315)

### DIFF
--- a/django/db/backends/base/client.py
+++ b/django/db/backends/base/client.py
@@ -20,7 +20,12 @@ class BaseDatabaseClient:
         )
 
     def runshell(self, parameters):
-        args, env = self.settings_to_cmd_args_env(self.connection.settings_dict, parameters)
-        if env:
-            env = {**os.environ, **env}
+        args, env_overrides = self.settings_to_cmd_args_env(
+            self.connection.settings_dict,
+            parameters,
+        )
+        if env_overrides:
+            env = {**os.environ, **env_overrides}
+        else:
+            env = None
         subprocess.run(args, env=env, check=True)

--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -51,7 +51,7 @@ class DatabaseClient(BaseDatabaseClient):
             env['PGSSLKEY'] = str(sslkey)
         if passfile:
             env['PGPASSFILE'] = str(passfile)
-        return args, env
+        return args, env or None
 
     def runshell(self, parameters):
         sigint_handler = signal.getsignal(signal.SIGINT)

--- a/tests/dbshell/test_postgresql.py
+++ b/tests/dbshell/test_postgresql.py
@@ -39,7 +39,7 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
                 'PORT': '444',
             }), (
                 ['psql', '-U', 'someuser', '-h', 'somehost', '-p', '444', 'dbname'],
-                {},
+                None,
             )
         )
 
@@ -134,8 +134,42 @@ class PostgreSqlDbshellCommandTestCase(SimpleTestCase):
     def test_parameters(self):
         self.assertEqual(
             self.settings_to_cmd_args_env({'NAME': 'dbname'}, ['--help']),
-            (['psql', 'dbname', '--help'], {}),
+            (['psql', 'dbname', '--help'], None),
         )
+
+    def test_runshell_inherits_environment_without_overrides(self):
+        settings = {'NAME': 'dbname'}
+        _, env = self.settings_to_cmd_args_env(settings, [])
+        self.assertIsNone(env)
+        self.assertNotEqual(env, {})
+        fake_connection = type('Conn', (), {'settings_dict': settings})()
+        with mock.patch('subprocess.run') as mocked_run:
+            DatabaseClient(fake_connection).runshell([])
+        mocked_run.assert_called_once()
+        _, kwargs = mocked_run.call_args
+        self.assertIn('env', kwargs)
+        self.assertIsNone(kwargs['env'])
+
+    def test_runshell_merges_environment_overrides(self):
+        """Regression: env={} dropped PATH and raised FileNotFoundError('psql')."""
+        settings = {'NAME': 'dbname', 'PASSWORD': 'override'}
+        _, env = self.settings_to_cmd_args_env(settings, [])
+        self.assertEqual(env, {'PGPASSWORD': 'override'})
+        self.assertNotEqual(env, {})
+        fake_connection = type('Conn', (), {'settings_dict': settings})()
+        with mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=False):
+            expected_path = os.environ['PATH']
+            with mock.patch('subprocess.run') as mocked_run:
+                DatabaseClient(fake_connection).runshell([])
+            mocked_run.assert_called_once()
+            _, kwargs = mocked_run.call_args
+            merged_env = kwargs['env']
+            # agyn-sandbox/django#321 - env={} dropped PATH and caused FileNotFoundError.
+            self.assertIsNotNone(merged_env)
+            self.assertNotEqual(merged_env, {})
+            self.assertEqual(merged_env['PGPASSWORD'], 'override')
+            self.assertIn('PATH', merged_env)
+            self.assertEqual(merged_env['PATH'], expected_path)
 
     @skipUnless(connection.vendor == 'postgresql', 'Requires a PostgreSQL connection')
     def test_sigint_handler(self):


### PR DESCRIPTION
## Summary
- normalize `BaseDatabaseClient.runshell()` to inherit the current process env unless explicit overrides are provided
- return `None` from the PostgreSQL client when there are no overrides so `PATH` and other defaults are preserved
- add regression tests covering env inheritance, override merging, and the previous env={} failure

## Reproduction Steps
1. Configure a PostgreSQL database with `PASSWORD` set and rely on the process `PATH` to find `psql`.
2. Invoke `connection.client.runshell([])` or `python manage.py dbshell`.
3. Observe the subprocess invocation.

## Observed Behavior
- `settings_to_cmd_args_env()` returned an empty dict, so `BaseDatabaseClient.runshell()` forwarded `env={}` to `subprocess.run()`.
- Passing an empty env stripped `PATH`, leading to a `FileNotFoundError` for `psql`.

```
FileNotFoundError: [Errno 2] No such file or directory: 'psql'
  File ".../subprocess.py", line 1963, in _execute_child
  File ".../django/db/backends/base/client.py", line 24, in runshell
    subprocess.run(args, env=env, check=True)
```

## Fix
- Treat `None` and empty dicts identically in `runshell`, inheriting `os.environ` unless explicit overrides exist.
- Limit the PostgreSQL client env dict to only the provided overrides so the environment is either `None` or a merge of overrides with the parent environment.
- Added regression coverage ensuring env inheritance, override merging, and preventing `{}` from reaching `subprocess.run()`.

## Upstream Reference
- https://github.com/django/django/commit/bbe6fbb8768e8fb1aecb96d51c049d7ceaf802d3

## Issue
- https://github.com/agyn-sandbox/django/issues/321

## Testing
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py dbshell.test_postgresql --parallel=1
- PYTHONPATH=$PWD .venv/bin/flake8 django/db/backends/base/client.py django/db/backends/postgresql/client.py tests/dbshell/test_postgresql.py