### PR TITLE
swev-id: django__django-14404 — Admin catch_all_view respects FORCE_SCRIPT_NAME

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -420,14 +420,15 @@ class AdminSite:
     def catch_all_view(self, request, url):
         if settings.APPEND_SLASH and not url.endswith('/'):
             urlconf = getattr(request, 'urlconf', None)
-            path = '%s/' % request.path_info
+            path_info_with_slash = f"{request.path_info}/"
+            redirect_path = f"{request.path}/"
             try:
-                match = resolve(path, urlconf)
+                match = resolve(path_info_with_slash, urlconf)
             except Resolver404:
                 pass
             else:
                 if getattr(match.func, 'should_append_slash', True):
-                    return HttpResponsePermanentRedirect(path)
+                    return HttpResponsePermanentRedirect(redirect_path)
         raise Http404
 
     def _build_app_dict(self, request, label=None):

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -6602,6 +6602,36 @@ class AdminSiteFinalCatchAllPatternTests(TestCase):
         response = self.client.get(known_url[:-1])
         self.assertRedirects(response, known_url, status_code=301, target_status_code=403)
 
+    @override_settings(APPEND_SLASH=True, FORCE_SCRIPT_NAME='/script-root')
+    def test_missing_slash_append_slash_true_preserves_force_script_name(self):
+        superuser = User.objects.create_user(
+            username='staff',
+            password='secret',
+            email='staff@example.com',
+            is_staff=True,
+        )
+        self.client.force_login(superuser)
+        changelist_url = reverse('admin:admin_views_article_changelist')
+        request_path = changelist_url[:-1]
+        response = self.client.get(request_path)
+        self.assertEqual(response.status_code, 301)
+        location = response['Location']
+        expected_location = f"/script-root{changelist_url}"
+        self.assertEqual(location, expected_location)
+        self.assertTrue(location.startswith('/script-root'))
+
+    @override_settings(APPEND_SLASH=True, FORCE_SCRIPT_NAME='/script-root')
+    def test_missing_slash_append_slash_true_unknown_url_does_not_redirect(self):
+        superuser = User.objects.create_user(
+            username='staff',
+            password='secret',
+            email='staff@example.com',
+            is_staff=True,
+        )
+        self.client.force_login(superuser)
+        response = self.client.get('/test_admin/admin/unknown')
+        self.assertEqual(response.status_code, 404)
+
     @override_settings(APPEND_SLASH=True)
     def test_missing_slash_append_slash_true_non_staff_user(self):
         user = User.objects.create_user(
@@ -6614,6 +6644,21 @@ class AdminSiteFinalCatchAllPatternTests(TestCase):
         known_url = reverse('admin:admin_views_article_changelist')
         response = self.client.get(known_url[:-1])
         self.assertRedirects(response, '/test_admin/admin/login/?next=/test_admin/admin/admin_views/article')
+
+    @override_settings(APPEND_SLASH=True, FORCE_SCRIPT_NAME='/script-root')
+    def test_missing_slash_append_slash_true_non_staff_preserves_force_script_name(self):
+        user = User.objects.create_user(
+            username='user',
+            password='secret',
+            email='user@example.com',
+            is_staff=False,
+        )
+        self.client.force_login(user)
+        changelist_url = reverse('admin:admin_views_article_changelist')
+        request_path = changelist_url[:-1]
+        response = self.client.get(request_path)
+        expected_login_url = f"{reverse('admin:login')}?next=/script-root{request_path}"
+        self.assertRedirects(response, expected_login_url)
 
     @override_settings(APPEND_SLASH=False)
     def test_missing_slash_append_slash_false(self):


### PR DESCRIPTION
## Summary
- ensure the admin catch-all redirect uses `request.path` so script prefixes are preserved
- extend admin catch-all coverage for FORCE_SCRIPT_NAME scenarios (staff, unknown URL, non-staff)

## Reproduction steps
1. Override settings with `ROOT_URLCONF='admin_views.urls'`, `APPEND_SLASH=True`, and `FORCE_SCRIPT_NAME='/script-root'`.
2. Authenticate a staff user.
3. GET `reverse('admin:admin_views_article_changelist')[:-1]`.

**Observed**: the 301 redirect Location is `/test_admin/admin/admin_views/article/`, missing the `/script-root` prefix even though FORCE_SCRIPT_NAME is set.

## Failing test before the fix
```
AssertionError: '/test_admin/admin/admin_views/article/' != '/script-root/test_admin/admin/admin_views/article/'
- /test_admin/admin/admin_views/article/
+ /script-root/test_admin/admin/admin_views/article/
? ++++++++++++
```

## Upstream reference
https://github.com/django/django/pull/14404