### PR TITLE
fix(forms): align BoundWidget ids (swev-id: django__django-14534)

### DIFF
--- a/django/forms/boundfield.py
+++ b/django/forms/boundfield.py
@@ -277,6 +277,9 @@ class BoundWidget:
 
     @property
     def id_for_label(self):
+        attrs = self.data.get('attrs')
+        if attrs is not None and 'id' in attrs:
+            return attrs['id']
         return 'id_%s_%s' % (self.data['name'], self.data['index'])
 
     @property

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -714,6 +714,47 @@ Java</label></li>
             'value="paul" id="id_name_1" required> Paul</label>'
         )
 
+    def test_radioselect_custom_auto_id_boundwidget_ids(self):
+        class BeatleForm(Form):
+            name = ChoiceField(
+                choices=[('john', 'John'), ('paul', 'Paul')],
+                widget=RadioSelect,
+            )
+
+        fields = list(BeatleForm(auto_id='prefix_%s')['name'])
+        self.assertEqual(
+            [field.id_for_label for field in fields],
+            ['prefix_name_0', 'prefix_name_1'],
+        )
+        self.assertEqual(
+            [field.data['attrs']['id'] for field in fields],
+            ['prefix_name_0', 'prefix_name_1'],
+        )
+        self.assertHTMLEqual(
+            str(fields[0]),
+            '<label for="prefix_name_0"><input type="radio" name="name" value="john" '
+            'id="prefix_name_0" required> John</label>',
+        )
+        self.assertHTMLEqual(
+            str(fields[1]),
+            '<label for="prefix_name_1"><input type="radio" name="name" value="paul" '
+            'id="prefix_name_1" required> Paul</label>',
+        )
+
+    def test_radioselect_boundwidget_id_without_auto_id(self):
+        class BeatleForm(Form):
+            name = ChoiceField(
+                choices=[('john', 'John'), ('paul', 'Paul')],
+                widget=RadioSelect,
+            )
+
+        fields = list(BeatleForm(auto_id=False)['name'])
+        self.assertEqual(
+            [field.id_for_label for field in fields],
+            ['id_name_0', 'id_name_1'],
+        )
+        self.assertTrue(all('id' not in field.data['attrs'] for field in fields))
+
     def test_iterable_boundfield_select(self):
         class BeatleForm(Form):
             name = ChoiceField(choices=[('john', 'John'), ('paul', 'Paul'), ('george', 'George'), ('ringo', 'Ringo')])
@@ -910,6 +951,35 @@ Java</label></li>
 <li><label for="composers_id_1">
 <input type="checkbox" name="composers" value="P" id="composers_id_1"> Paul McCartney</label></li>
 </ul>"""
+        )
+
+    def test_checkbox_subwidget_custom_id_attrs(self):
+        class SongForm(Form):
+            name = CharField()
+            composers = MultipleChoiceField(
+                choices=[('J', 'John Lennon'), ('P', 'Paul McCartney')],
+                widget=CheckboxSelectMultiple(attrs={'id': 'abc'}),
+            )
+
+        form = SongForm(auto_id=False)
+        subwidgets = list(form['composers'])
+        self.assertEqual(
+            [widget.id_for_label for widget in subwidgets],
+            ['abc_0', 'abc_1'],
+        )
+        self.assertEqual(
+            [widget.data['attrs']['id'] for widget in subwidgets],
+            ['abc_0', 'abc_1'],
+        )
+        self.assertHTMLEqual(
+            str(subwidgets[0]),
+            '<label for="abc_0"><input type="checkbox" name="composers" value="J" id="abc_0"> '
+            'John Lennon</label>',
+        )
+        self.assertHTMLEqual(
+            str(subwidgets[1]),
+            '<label for="abc_1"><input type="checkbox" name="composers" value="P" id="abc_1"> '
+            'Paul McCartney</label>',
         )
 
     def test_multiple_choice_list_data(self):

--- a/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
+++ b/tests/forms_tests/widget_tests/test_checkboxselectmultiple.py
@@ -154,6 +154,23 @@ class CheckboxSelectMultipleTest(WidgetTest):
         """
         self.check_html(widget, 'letters', ['a', 'c'], html=html)
 
+    def test_boundwidget_id_for_label_uses_attrs_id(self):
+        class LettersForm(forms.Form):
+            letters = forms.MultipleChoiceField(
+                choices=[('a', 'A'), ('b', 'B')],
+                widget=CheckboxSelectMultiple(attrs={'id': 'abc'}),
+            )
+
+        subwidgets = list(LettersForm(auto_id=False)['letters'])
+        self.assertEqual(
+            [widget.id_for_label for widget in subwidgets],
+            ['abc_0', 'abc_1'],
+        )
+        self.assertEqual(
+            [widget.data['attrs']['id'] for widget in subwidgets],
+            ['abc_0', 'abc_1'],
+        )
+
     @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
     def test_doesnt_localize_input_value(self):
         choices = [


### PR DESCRIPTION
## Summary
- prefer the subwidget-provided id in `BoundWidget.id_for_label` before falling back to the legacy pattern
- keep the existing fallback path for widgets without explicit ids so templates continue to work with auto-generated identifiers
- add regression coverage for CheckboxSelectMultiple and RadioSelect when custom ids or auto_id strings are supplied

## Testing
- `PYTHONPATH=/workspace/django python tests/runtests.py forms_tests.tests.test_forms --parallel=1`
- `PYTHONPATH=/workspace/django python tests/runtests.py forms_tests.widget_tests.test_checkboxselectmultiple --parallel=1`
- `flake8 django/forms/boundfield.py tests/forms_tests/tests/test_forms.py tests/forms_tests/widget_tests/test_checkboxselectmultiple.py`

## Reproduction
Case A – CheckboxSelectMultiple with explicit id:
```python
from django import forms

class LettersForm(forms.Form):
    letters = forms.MultipleChoiceField(
        choices=[('a', 'A'), ('b', 'B')],
        widget=forms.CheckboxSelectMultiple(attrs={'id': 'abc'}),
    )

fields = list(LettersForm()['letters'])
print(fields[0].data['attrs']['id'])  # 'abc_0'
print(fields[0].id_for_label)         # currently 'id_letters_0'
print(str(fields[0]))
```

Case B – RadioSelect with custom auto_id:
```python
class BeatleForm(forms.Form):
    name = forms.ChoiceField(
        choices=[('john', 'John'), ('paul', 'Paul')],
        widget=forms.RadioSelect,
    )

fields = list(BeatleForm(auto_id='prefix_%s')['name'])
print(fields[0].data['attrs']['id'])  # 'prefix_name_0'
print(fields[0].id_for_label)         # currently 'id_name_0'
print(str(fields[0]))
```

## Observed behavior
- Labels render with the correct per-input ids (`for="abc_0"`, `for="prefix_name_0"`), but `BoundWidget.id_for_label` still returns the fallback values (`id_letters_0`, `id_name_0`).
- This is a semantic mismatch in the generated HTML (no runtime exception), so helpers like `{{ radio.id_for_label }}` disagree with the rendered markup.

Example HTML from Case A:
```html
<label for="abc_0">
  <input id="abc_0" name="letters" type="checkbox" value="a">
  A
</label>
<!-- BoundWidget.id_for_label == "id_letters_0" -->
```

## References
- Fixes #324
- Upstream ticket: https://code.djangoproject.com/ticket/32855
- Upstream PR: https://github.com/django/django/pull/14534