### PR TITLE
Assert set type for ProjectState.real_apps; remove conversion

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -90,9 +90,11 @@ class ProjectState:
 
     def __init__(self, models=None, real_apps=None):
         self.models = models or {}
-        # Apps to include from main registry, usually unmigrated ones
-        if real_apps:
-            self.real_apps = real_apps if isinstance(real_apps, set) else set(real_apps)
+        # Apps to include from main registry, usually unmigrated ones.
+        # Assume callers pass a set (per PR #14760) and assert type when provided.
+        if real_apps is not None:
+            assert isinstance(real_apps, set), "ProjectState.real_apps must be a set"
+            self.real_apps = real_apps
         else:
             self.real_apps = set()
         self.is_delayed = False


### PR DESCRIPTION
Change summary
- Assert that real_apps is a set when provided to ProjectState.__init__ and remove conversion of non-set iterables.

Files
- django/db/migrations/state.py — ProjectState.__init__.

Rationale
- Internal callers (loader/executor/graph) pass sets. Align with PR #14760 intent to standardize callers; enforce invariant in core.

Details
- If real_apps is not None: assert isinstance(real_apps, set); assign directly.
- Else: real_apps = set().

Risks
- External callers passing list/tuple will now raise AssertionError; adjust external code accordingly.

Verification
- Grep for ProjectState(real_apps=...) shows only set types in this branch.
- Recommended test modules: tests/migrations/*, tests/auth_tests/test_management.py, tests/postgres_tests/test_operations.py.