### PR TITLE
swev-id: django__django-14855 — Fix readonly FK admin link for namespaced AdminSite

### DIFF
--- a/django/contrib/admin/helpers.py
+++ b/django/contrib/admin/helpers.py
@@ -209,7 +209,11 @@ class AdminReadonlyField:
             remote_field.model._meta.model_name,
         )
         try:
-            url = reverse(url_name, args=[quote(remote_obj.pk)])
+            url = reverse(
+                url_name,
+                args=[quote(remote_obj.pk)],
+                current_app=self.model_admin.admin_site.name,
+            )
             return format_html('<a href="{}">{}</a>', url, remote_obj)
         except NoReverseMatch:
             return str(remote_obj)

--- a/tests/admin_views/tests.py
+++ b/tests/admin_views/tests.py
@@ -44,7 +44,7 @@ from django.utils.html import escape
 from django.utils.http import urlencode
 
 from . import customadmin
-from .admin import CityAdmin, site, site2
+from .admin import CityAdmin, LanguageAdmin, ReadOnlyRelatedFieldAdmin, site, site2
 from .models import (
     Actor, AdminOrderedAdminMethod, AdminOrderedCallable, AdminOrderedField,
     AdminOrderedModelMethod, Album, Answer, Answer2, Article, BarAccount, Book,
@@ -5130,6 +5130,65 @@ class ReadonlyTest(AdminFieldExtractionMixin, TestCase):
             html=True,
         )
         # Related ForeignKey object not registered in admin.
+        self.assertContains(response, '<div class="readonly">Chapter 1</div>', html=True)
+
+    def test_readonly_foreignkey_links_namespaced_admin(self):
+        """Readonly ForeignKey links use the current AdminSite namespace."""
+
+        def register_temp(admin_site, model, admin_class):
+            if model in admin_site._registry:
+                original_admin = admin_site._registry[model].__class__
+                admin_site.unregister(model)
+                self.addCleanup(admin_site.register, model, original_admin)
+            admin_site.register(model, admin_class)
+            self.addCleanup(admin_site.unregister, model)
+
+        register_temp(site2, ReadOnlyRelatedField, ReadOnlyRelatedFieldAdmin)
+        register_temp(site2, Language, LanguageAdmin)
+
+        chapter = Chapter.objects.create(
+            title='Chapter 1',
+            content='content',
+            book=Book.objects.create(name='Book 1'),
+        )
+        language = Language.objects.create(iso='_40', name='Test')
+        obj = ReadOnlyRelatedField.objects.create(
+            chapter=chapter,
+            language=language,
+            user=self.superuser,
+        )
+        change_url = reverse(
+            'admin:admin_views_readonlyrelatedfield_change',
+            args=(obj.pk,),
+            current_app=site2.name,
+        )
+        response = self.client.get(change_url)
+
+        user_url = reverse(
+            'admin:auth_user_change',
+            args=(self.superuser.pk,),
+            current_app=site2.name,
+        )
+        self.assertContains(
+            response,
+            '<div class="readonly"><a href="%s">super</a></div>' % user_url,
+            html=True,
+        )
+
+        language_url = reverse(
+            'admin:admin_views_language_change',
+            args=(quote(language.pk),),
+            current_app=site2.name,
+        )
+        self.assertContains(
+            response,
+            '<div class="readonly"><a href="%s">%s</a></div>' % (language_url, language.pk),
+            html=True,
+        )
+
+        default_user_url = reverse('admin:auth_user_change', args=(self.superuser.pk,))
+        self.assertNotContains(response, f'href="{default_user_url}"')
+
         self.assertContains(response, '<div class="readonly">Chapter 1</div>', html=True)
 
     def test_readonly_manytomany_backwards_ref(self):


### PR DESCRIPTION
Summary
- Add a regression test ensuring readonly ForeignKey links honor the active AdminSite namespace and continue quoting string primary keys.
- Pass the current AdminSite namespace to reverse() so readonly ForeignKey links render under custom admin namespaces.

Issue
- https://github.com/agyn-sandbox/django/issues/331

Reproduction Steps
1. Register `ReadOnlyRelatedField` (and the `Language` string-PK model) on `namespaced_admin`.
2. Open the change form for `ReadOnlyRelatedField` via `/test_admin/admin5/`.
3. Inspect the readonly `user` and `language` fields.
4. Compare the rendered hrefs with the active admin namespace.

Observed Failure (before fix)
- PYTHONPATH=/workspace/django/tests:/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python -m tests.runtests admin_views --parallel=1 -v 2 -k namespaced_admin
```
FAIL: test_readonly_foreignkey_links_namespaced_admin (admin_views.tests.ReadonlyTest.test_readonly_foreignkey_links_namespaced_admin)
Readonly ForeignKey links use the current AdminSite namespace.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/admin_views/tests.py", line 5172, in test_readonly_foreignkey_links_namespaced_admin
    self.assertContains(
  File "/workspace/django/django/test/testcases.py", line 465, in assertContains
    self.assertTrue(real_count != 0, msg_prefix + "Couldn't find %s in response" % text_repr)
AssertionError: False is not true : Couldn't find '<div class="readonly"><a href="/test_admin/admin5/auth/user/1/change/">super</a></div>' in response
```

Fix
- Call reverse() with current_app=self.model_admin.admin_site.name inside ReadOnlyField.get_admin_url.
- Regression test asserts the user link is namespaced, string PK quoting remains intact, and the unregistered chapter relation stays plain text.

Tests
- PYTHONPATH=/workspace/django/tests:/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python -m tests.runtests admin_views --parallel=1 -v 2 -k namespaced_admin
- source /workspace/django/.venv/bin/activate && flake8 django/contrib/admin/helpers.py tests/admin_views/tests.py

Notes
- Python 3.11.14 virtualenv with nix-provided toolchain (gcc, libmemcached, zlib.dev).