### PR TITLE
fix: swev-id: django__django-14792 handle Etc/GMT offsets

### DIFF
--- a/django/db/backends/mysql/operations.py
+++ b/django/db/backends/mysql/operations.py
@@ -76,10 +76,35 @@ class DatabaseOperations(BaseDatabaseOperations):
             return "DATE(%s)" % (field_name)
 
     def _prepare_tzname_delta(self, tzname):
-        if '+' in tzname:
-            return tzname[tzname.find('+'):]
-        elif '-' in tzname:
-            return tzname[tzname.find('-'):]
+        def is_numeric(body):
+            if not body or body.count(':') > 1:
+                return False
+            return body.replace(':', '').isdigit()
+
+        def format_offset(sign, body):
+            if ':' in body:
+                hours_part, minutes_part = body.split(':', 1)
+            elif len(body) <= 2:
+                hours_part, minutes_part = body, '0'
+            else:
+                hours_part, minutes_part = body[:-2], body[-2:]
+            hours = int(hours_part) if hours_part else 0
+            minutes = int(minutes_part) if minutes_part else 0
+            return f"{sign}{hours:02d}:{minutes:02d}"
+
+        if tzname.startswith('Etc/GMT') and len(tzname) > 7:
+            offset = tzname[7:]
+            sign = offset[0]
+            body = offset[1:]
+            if sign in '+-' and is_numeric(body):
+                translated_sign = '-' if sign == '+' else '+'
+                return format_offset(translated_sign, body)
+            return tzname
+
+        if tzname and tzname[0] in '+-':
+            body = tzname[1:]
+            if is_numeric(body):
+                return format_offset(tzname[0], body)
         return tzname
 
     def _convert_field_to_tz(self, field_name, tzname):

--- a/django/db/backends/postgresql/operations.py
+++ b/django/db/backends/postgresql/operations.py
@@ -44,11 +44,19 @@ class DatabaseOperations(BaseDatabaseOperations):
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
     def _prepare_tzname_delta(self, tzname):
-        if '+' in tzname:
-            return tzname.replace('+', '-')
-        elif '-' in tzname:
-            return tzname.replace('-', '+')
-        return tzname
+        if not tzname or tzname[0] not in '+-':
+            return tzname
+
+        remainder = tzname[1:]
+        if not remainder or remainder.count(':') > 1:
+            return tzname
+
+        numeric_part = remainder.replace(':', '')
+        if not numeric_part.isdigit():
+            return tzname
+
+        flipped_sign = '+' if tzname[0] == '-' else '-'
+        return flipped_sign + remainder
 
     def _convert_field_to_tz(self, field_name, tzname):
         if tzname and settings.USE_TZ:

--- a/tests/backends/test_timezone_operations.py
+++ b/tests/backends/test_timezone_operations.py
@@ -1,0 +1,127 @@
+from zoneinfo import ZoneInfo
+
+import pytz
+
+from django.db.backends.mysql.operations import (
+    DatabaseOperations as MySQLDatabaseOperations,
+)
+from django.db.backends.postgresql.operations import (
+    DatabaseOperations as PostgresDatabaseOperations,
+)
+from django.db.models import DateTimeField
+from django.db.models.expressions import RawSQL
+from django.db.models.functions import ExtractHour, TruncDay
+from django.test import SimpleTestCase, override_settings
+
+
+class _BaseFakeConnection:
+    timezone_name = 'UTC'
+
+    def __init__(self):
+        self.ops = None
+
+
+class _FakePostgresConnection(_BaseFakeConnection):
+    vendor = 'postgresql'
+
+    def __init__(self):
+        super().__init__()
+        self.ops = PostgresDatabaseOperations(self)
+
+
+class _FakeMySQLConnection(_BaseFakeConnection):
+    vendor = 'mysql'
+
+    def __init__(self):
+        super().__init__()
+        self.ops = MySQLDatabaseOperations(self)
+
+
+class _FakeCompiler:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def compile(self, node):
+        return node.as_sql(self, self.connection)
+
+    def quote_name_unless_alias(self, value):
+        return value
+
+
+def _datetime_column_expression():
+    field = DateTimeField()
+    field.set_attributes_from_name('last_updated')
+    return RawSQL('"backends_schoolclass"."last_updated"', [], output_field=field)
+
+
+class PostgreSQLPrepareTznameDeltaTests(SimpleTestCase):
+    def setUp(self):
+        self.ops = _FakePostgresConnection().ops
+
+    def test_preserves_etc_gmt_zone(self):
+        self.assertEqual(self.ops._prepare_tzname_delta('Etc/GMT-10'), 'Etc/GMT-10')
+
+    def test_flip_numeric_offsets(self):
+        self.assertEqual(self.ops._prepare_tzname_delta('+10'), '-10')
+        self.assertEqual(self.ops._prepare_tzname_delta('-05:30'), '+05:30')
+        self.assertEqual(self.ops._prepare_tzname_delta('+1000'), '-1000')
+
+    def test_preserves_named_zone(self):
+        self.assertEqual(self.ops._prepare_tzname_delta('Europe/London'), 'Europe/London')
+
+
+class MySQLPrepareTznameDeltaTests(SimpleTestCase):
+    def setUp(self):
+        self.ops = _FakeMySQLConnection().ops
+
+    def test_translates_etc_gmt_zone(self):
+        self.assertEqual(self.ops._prepare_tzname_delta('Etc/GMT-10'), '+10:00')
+
+    def test_normalizes_numeric_offsets(self):
+        self.assertEqual(self.ops._prepare_tzname_delta('+10'), '+10:00')
+        self.assertEqual(self.ops._prepare_tzname_delta('-05:30'), '-05:30')
+        self.assertEqual(self.ops._prepare_tzname_delta('+1000'), '+10:00')
+
+    def test_preserves_named_zone(self):
+        self.assertEqual(self.ops._prepare_tzname_delta('America/New_York'), 'America/New_York')
+
+
+@override_settings(USE_TZ=True)
+class BackendTimezoneSQLCompilationTests(SimpleTestCase):
+    def setUp(self):
+        self.postgres_connection = _FakePostgresConnection()
+        self.mysql_connection = _FakeMySQLConnection()
+
+    def _compile(self, connection, expression):
+        compiler = _FakeCompiler(connection)
+        sql, params = expression.as_sql(compiler, connection)
+        return sql, params
+
+    def _assert_params_empty(self, params):
+        self.assertEqual(params, [])
+
+    def test_postgres_truncday_with_pytz_timezone(self):
+        expression = TruncDay(_datetime_column_expression(), tzinfo=pytz.timezone('Etc/GMT-10'))
+        sql, params = self._compile(self.postgres_connection, expression)
+        self._assert_params_empty(params)
+        self.assertIn("AT TIME ZONE 'Etc/GMT-10'", sql)
+
+    def test_postgres_truncday_with_zoneinfo_timezone(self):
+        expression = TruncDay(_datetime_column_expression(), tzinfo=ZoneInfo('Etc/GMT-10'))
+        sql, params = self._compile(self.postgres_connection, expression)
+        self._assert_params_empty(params)
+        self.assertIn("AT TIME ZONE 'Etc/GMT-10'", sql)
+
+    def test_mysql_extracthour_with_pytz_timezone(self):
+        expression = ExtractHour(_datetime_column_expression(), tzinfo=pytz.timezone('Etc/GMT-10'))
+        sql, params = self._compile(self.mysql_connection, expression)
+        self._assert_params_empty(params)
+        self.assertIn('CONVERT_TZ', sql)
+        self.assertIn("'+10:00'", sql)
+
+    def test_mysql_extracthour_with_zoneinfo_timezone(self):
+        expression = ExtractHour(_datetime_column_expression(), tzinfo=ZoneInfo('Etc/GMT-10'))
+        sql, params = self._compile(self.mysql_connection, expression)
+        self._assert_params_empty(params)
+        self.assertIn('CONVERT_TZ', sql)
+        self.assertIn("'+10:00'", sql)


### PR DESCRIPTION
Fixes #333.

## Summary
- flip only numeric timezone offsets for PostgreSQL so named zones remain unchanged
- normalize numeric offsets and translate Etc/GMT semantics for MySQL conversions
- add regression tests covering operations and SQL compilation for pytz and ZoneInfo timezones

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py backends.test_timezone_operations --parallel=1
