### PR TITLE
Respect model overrides of get_FIELD_display for choices (swev-id: django__django-11999)

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -762,8 +762,9 @@ class Field(RegisterLookupMixin):
             # such fields can't be deferred (we don't have a check for this).
             if not getattr(cls, self.attname, None):
                 setattr(cls, self.attname, self.descriptor_class(self))
-        if self.choices is not None:
-            setattr(cls, 'get_%s_display' % self.name,
+        display_method_name = 'get_%s_display' % self.name
+        if self.choices is not None and not hasattr(cls, display_method_name):
+            setattr(cls, display_method_name,
                     partialmethod(cls._get_FIELD_display, field=self))
 
     def get_filter_kwargs_for_object(self, obj):

--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -763,9 +763,18 @@ class Field(RegisterLookupMixin):
             if not getattr(cls, self.attname, None):
                 setattr(cls, self.attname, self.descriptor_class(self))
         display_method_name = 'get_%s_display' % self.name
-        if self.choices is not None and not hasattr(cls, display_method_name):
-            setattr(cls, display_method_name,
-                    partialmethod(cls._get_FIELD_display, field=self))
+        if self.choices is not None:
+            existing_display = None
+            for base in cls.__mro__:
+                if display_method_name in base.__dict__:
+                    existing_display = base.__dict__[display_method_name]
+                    break
+            if existing_display is None or isinstance(existing_display, partialmethod):
+                setattr(
+                    cls,
+                    display_method_name,
+                    partialmethod(cls._get_FIELD_display, field=self),
+                )
 
     def get_filter_kwargs_for_object(self, obj):
         """

--- a/tests/model_fields/test_display_overrides.py
+++ b/tests/model_fields/test_display_overrides.py
@@ -1,0 +1,60 @@
+from django.db import models
+from django.test import SimpleTestCase
+
+
+class GetFieldDisplayOverrideTests(SimpleTestCase):
+
+    def test_override_get_field_display_before_field(self):
+        class HatBefore(models.Model):
+            class Meta:
+                app_label = "tests"
+
+            def get_style_display(self):
+                return f"before:{self.style}"
+
+            STYLE_CHOICES = [("B", "Bowler"), ("F", "Fedora")]
+            style = models.CharField(max_length=1, choices=STYLE_CHOICES)
+
+        self.assertEqual(HatBefore(style="B").get_style_display(), "before:B")
+
+    def test_override_get_field_display_after_field(self):
+        class HatAfter(models.Model):
+            STYLE_CHOICES = [("B", "Bowler"), ("F", "Fedora")]
+            style = models.CharField(max_length=1, choices=STYLE_CHOICES)
+
+            def get_style_display(self):
+                return f"after:{self.style}"
+
+            class Meta:
+                app_label = "tests"
+
+        self.assertEqual(HatAfter(style="F").get_style_display(), "after:F")
+
+    def test_override__get_FIELD_display_for_specific_field(self):
+        class Jacket(models.Model):
+            STYLE_CHOICES = [("T", "Trench"), ("P", "Peacoat")]
+            style = models.CharField(max_length=1, choices=STYLE_CHOICES)
+
+            class Meta:
+                app_label = "tests"
+
+            def _get_FIELD_display(self, field):
+                value = super()._get_FIELD_display(field)
+                return f"custom:{value}"
+
+        self.assertEqual(Jacket(style="T").get_style_display(), "custom:Trench")
+
+    def test_get_field_display_default_choices_label(self):
+        class Scarf(models.Model):
+            MATERIAL_CHOICES = [("C", "Cotton")]
+            material = models.CharField(max_length=1, choices=MATERIAL_CHOICES, null=True)
+
+            class Meta:
+                app_label = "tests"
+
+        scarf = Scarf(material="C")
+        self.assertEqual(scarf.get_material_display(), "Cotton")
+        scarf.material = "W"
+        self.assertEqual(scarf.get_material_display(), "W")
+        scarf.material = None
+        self.assertIsNone(scarf.get_material_display())

--- a/tests/model_fields/test_display_overrides.py
+++ b/tests/model_fields/test_display_overrides.py
@@ -13,14 +13,20 @@ class GetFieldDisplayOverrideTests(SimpleTestCase):
                 return f"before:{self.style}"
 
             STYLE_CHOICES = [("B", "Bowler"), ("F", "Fedora")]
-            style = models.CharField(max_length=1, choices=STYLE_CHOICES)
+            style = models.CharField(
+                max_length=1,
+                choices=STYLE_CHOICES,
+            )
 
         self.assertEqual(HatBefore(style="B").get_style_display(), "before:B")
 
     def test_override_get_field_display_after_field(self):
         class HatAfter(models.Model):
             STYLE_CHOICES = [("B", "Bowler"), ("F", "Fedora")]
-            style = models.CharField(max_length=1, choices=STYLE_CHOICES)
+            style = models.CharField(
+                max_length=1,
+                choices=STYLE_CHOICES,
+            )
 
             def get_style_display(self):
                 return f"after:{self.style}"
@@ -33,7 +39,10 @@ class GetFieldDisplayOverrideTests(SimpleTestCase):
     def test_override__get_FIELD_display_for_specific_field(self):
         class Jacket(models.Model):
             STYLE_CHOICES = [("T", "Trench"), ("P", "Peacoat")]
-            style = models.CharField(max_length=1, choices=STYLE_CHOICES)
+            style = models.CharField(
+                max_length=1,
+                choices=STYLE_CHOICES,
+            )
 
             class Meta:
                 app_label = "tests"
@@ -47,7 +56,11 @@ class GetFieldDisplayOverrideTests(SimpleTestCase):
     def test_get_field_display_default_choices_label(self):
         class Scarf(models.Model):
             MATERIAL_CHOICES = [("C", "Cotton")]
-            material = models.CharField(max_length=1, choices=MATERIAL_CHOICES, null=True)
+            material = models.CharField(
+                max_length=1,
+                choices=MATERIAL_CHOICES,
+                null=True,
+            )
 
             class Meta:
                 app_label = "tests"
@@ -58,3 +71,29 @@ class GetFieldDisplayOverrideTests(SimpleTestCase):
         self.assertEqual(scarf.get_material_display(), "W")
         scarf.material = None
         self.assertIsNone(scarf.get_material_display())
+
+    def test_partialmethod_rebind_on_subclass_override(self):
+        class BaseDisplay(models.Model):
+            BASE_KIND_CHOICES = [("A", "Alpha")]
+            kind = models.CharField(
+                max_length=1,
+                choices=BASE_KIND_CHOICES,
+            )
+
+            class Meta:
+                abstract = True
+
+        class ChildDisplay(BaseDisplay):
+            CHILD_KIND_CHOICES = [("B", "Beta")]
+            kind = models.CharField(
+                max_length=1,
+                choices=CHILD_KIND_CHOICES,
+            )
+
+            class Meta:
+                app_label = "tests"
+
+        self.assertEqual(
+            ChildDisplay(kind="B").get_kind_display(),
+            "Beta",
+        )


### PR DESCRIPTION
## Summary
- guard `Field.contribute_to_class()` so existing `get_<field>_display()` overrides survive choice injection
- add regression tests covering overrides declared before/after the field, custom `_get_FIELD_display()`, and default display fallbacks

## Reproduction
1. Add `tests/model_fields/test_display_overrides_tmp.py` with:
   ```python
   from django.db import models
   from django.test import SimpleTestCase


   class DisplayOverrideFailureTests(SimpleTestCase):
       def test_override_after_field_fails_currently(self):
           class Hat(models.Model):
               STYLE_CHOICES = [("B", "Bowler"), ("F", "Fedora")]
               style = models.CharField(max_length=1, choices=STYLE_CHOICES)

               def get_style_display(self):
                   return f"custom:{self.style}"

               class Meta:
                   app_label = "tests"

           self.assertEqual(Hat(style="B").get_style_display(), "custom:B")
   ```
2. Run `/workspace/.venv/bin/python tests/runtests.py model_fields.test_display_overrides_tmp --parallel=1`

```
F
======================================================================
FAIL: test_override_after_field_fails_currently (model_fields.test_display_overrides_tmp.DisplayOverrideFailureTests.test_override_after_field_fails_currently)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_fields/test_display_overrides_tmp.py", line 17, in test_override_after_field_fails_currently
    self.assertEqual(Hat(style="B").get_style_display(), "custom:B")
AssertionError: 'Bowler' != 'custom:B'
- Bowler
+ custom:B
```

## Testing
- `/workspace/.venv/bin/python tests/runtests.py model_fields.test_display_overrides --parallel=1`
- `/workspace/.venv/bin/python tests/runtests.py model_fields --parallel=1`

Fixes #338
