### PR TITLE
Use \A/\Z anchors in username validators to disallow trailing newlines (swev-id: django__django-11099)

### DIFF
--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 @deconstructible
 class ASCIIUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r"\A[\w.@+-]+\Z"
     message = _(
         'Enter a valid username. This value may contain only English letters, '
         'numbers, and @/./+/-/_ characters.'
@@ -17,7 +17,7 @@ class ASCIIUsernameValidator(validators.RegexValidator):
 
 @deconstructible
 class UnicodeUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r"\A[\w.@+-]+\Z"
     message = _(
         'Enter a valid username. This value may contain only letters, '
         'numbers, and @/./+/-/_ characters.'

--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -259,3 +259,17 @@ class UsernameValidatorsTests(SimpleTestCase):
             with self.subTest(invalid=invalid):
                 with self.assertRaises(ValidationError):
                     v(invalid)
+
+    def test_unicode_validator_rejects_newlines(self):
+        v = validators.UnicodeUsernameValidator()
+        for candidate in ['user\n', 'line\nbreak']:
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(ValidationError):
+                    v(candidate)
+
+    def test_ascii_validator_rejects_newlines(self):
+        v = validators.ASCIIUsernameValidator()
+        for candidate in ['user\n', 'line\nbreak']:
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(ValidationError):
+                    v(candidate)


### PR DESCRIPTION
## Problem Summary
- Username validators anchored on ^/$ accept trailing newline characters, allowing unexpected values like `user` followed by a newline to pass validation.
- New regression tests demonstrate both ASCII and Unicode validators silently allow embedded/newline-terminated usernames.

## Changes
- Anchor `ASCIIUsernameValidator` and `UnicodeUsernameValidator` patterns with `\A`/`\Z` to enforce full-string matches.
- Extend `UsernameValidatorsTests` with assertions that trailing and embedded newlines raise `ValidationError` for both validators.

## Reproduction
1. Checkout `django__django-11099`.
2. Run `PYTHONPATH=$PWD ./tests/runtests.py auth_tests --verbosity=2` before this patch.

### Observed Failure (pre-fix)
```
FAIL: test_ascii_validator_rejects_newlines (auth_tests.test_validators.UsernameValidatorsTests.test_ascii_validator_rejects_newlines) [<object object at 0xffffb287f700>] (candidate='user\n')
AssertionError: ValidationError not raised

FAIL: test_unicode_validator_rejects_newlines (auth_tests.test_validators.UsernameValidatorsTests.test_unicode_validator_rejects_newlines) [<object object at 0xffffb287f700>] (candidate='user\n')
AssertionError: ValidationError not raised
```

## Testing
- `PYTHONPATH=$PWD ./tests/runtests.py auth_tests --verbosity=2`

Fixes #340

Task reference: Ensure validators reject usernames containing newlines.