### PR TITLE
fix: preserve mixed-case FK deconstruct (swev-id: django__django-13112)

### DIFF
--- a/django/db/models/fields/related.py
+++ b/django/db/models/fields/related.py
@@ -582,7 +582,11 @@ class ForeignObject(RelatedField):
         if self.remote_field.parent_link:
             kwargs['parent_link'] = self.remote_field.parent_link
         if isinstance(self.remote_field.model, str):
-            kwargs['to'] = self.remote_field.model.lower()
+            if '.' in self.remote_field.model:
+                app_label, model_name = self.remote_field.model.rsplit('.', 1)
+                kwargs['to'] = f"{app_label}.{model_name.lower()}"
+            else:
+                kwargs['to'] = self.remote_field.model.lower()
         else:
             kwargs['to'] = self.remote_field.model._meta.label_lower
         # If swappable is True, then see if we're actually pointing to the target

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -791,6 +791,19 @@ class WriterTests(SimpleTestCase):
         string = MigrationWriter.serialize(models.CharField(default=DeconstructibleInstances))[0]
         self.assertEqual(string, "models.CharField(default=migrations.test_writer.DeconstructibleInstances)")
 
+    def test_foreign_key_deconstruct_preserves_app_label_case(self):
+        field = models.ForeignKey('MixedCaseApp.ModelName', models.CASCADE)
+        _, _, _, kwargs = field.deconstruct()
+        self.assertEqual(kwargs['to'], 'MixedCaseApp.modelname')
+
+        class Target(models.Model):
+            class Meta:
+                app_label = 'MixedCaseApp'
+
+        class_field = models.ForeignKey(Target, models.CASCADE)
+        _, _, _, kwargs = class_field.deconstruct()
+        self.assertEqual(kwargs['to'], Target._meta.label_lower)
+
     def test_register_serializer(self):
         class ComplexSerializer(BaseSerializer):
             def serialize(self):


### PR DESCRIPTION
## Summary
- update `ForeignObject.deconstruct()` to preserve mixed-case app labels when serializing string model references
- keep existing behavior for undotted strings and class references to maintain compatibility
- closes #342

## Reproduction
1. Create a new Django project using this checkout (`pip install -e /workspace/django`).
2. Add an app named `DJ_RegLogin` with `AppConfig.name = 'DJ_RegLogin'` and register it in `INSTALLED_APPS`.
3. Define models:
   ```python
   class Category(models.Model):
       name = models.CharField(max_length=255)

   class Content(models.Model):
       category = models.ForeignKey('DJ_RegLogin.Category', on_delete=models.CASCADE)
   ```
4. Run `python manage.py makemigrations`.

### Observed failure (before fix)
```
$(cat /workspace/makemigrations_failure.log)
```

### Fixed behavior
- After this change, `makemigrations` succeeds and serializes the foreign key target as `DJ_RegLogin.category`.

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py migrations --parallel=1
- flake8 django/db/models/fields/related.py
- python manage.py makemigrations (temporary DJ_RegLogin project)