### PR TITLE
fix: restore RenameIndex idempotency (swev-id: django__django-15695)

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -953,9 +953,12 @@ class RenameIndex(IndexOperation):
                         ", ".join(columns),
                     )
                 )
+            current_index_name = matching_index_name[0]
+            if current_index_name.lower() == self.new_name_lower:
+                return
             old_index = models.Index(
                 fields=self.old_fields,
-                name=matching_index_name[0],
+                name=current_index_name,
             )
         else:
             from_model_state = from_state.models[app_label, self.model_name_lower]
@@ -967,7 +970,60 @@ class RenameIndex(IndexOperation):
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         if self.old_fields:
-            # Backward operation with unnamed index is a no-op.
+            model = to_state.apps.get_model(app_label, self.model_name)
+            if not self.allow_migrate_model(
+                schema_editor.connection.alias, model
+            ):
+                return
+            columns = [
+                model._meta.get_field(field).column for field in self.old_fields
+            ]
+            fields_tuple = tuple(self.old_fields)
+            opts = model._meta
+            if fields_tuple in [tuple(fields) for fields in opts.index_together]:
+                suffix = "_idx"
+            elif fields_tuple in [tuple(fields) for fields in opts.unique_together]:
+                suffix = "_uniq"
+            else:
+                suffix = "_idx"
+
+            old_auto_name = schema_editor._create_index_name(
+                opts.db_table,
+                columns,
+                suffix=suffix,
+            )
+            matching_index_name = schema_editor._constraint_names(
+                model,
+                column_names=columns,
+                index=True,
+            )
+            if len(matching_index_name) != 1:
+                raise ValueError(
+                    "Found wrong number (%s) of indexes for %s(%s)."
+                    % (
+                        len(matching_index_name),
+                        opts.db_table,
+                        ", ".join(columns),
+                    )
+                )
+            current_index_name = matching_index_name[0]
+            if current_index_name.lower() == old_auto_name.lower():
+                return
+            existing_index_names = schema_editor._constraint_names(model, index=True)
+            if any(
+                name.lower() == old_auto_name.lower()
+                for name in existing_index_names
+            ):
+                return
+            old_index = models.Index(
+                fields=self.old_fields,
+                name=current_index_name,
+            )
+            new_index = models.Index(
+                fields=self.old_fields,
+                name=old_auto_name,
+            )
+            schema_editor.rename_index(model, old_index, new_index)
             return
 
         self.new_name_lower, self.old_name_lower = (

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -2978,16 +2978,35 @@ class OperationTests(OperationTestBase):
             "rename_pony_weight_pink_new_pony_test_idx",
         )
 
+        with connection.schema_editor() as editor:
+            auto_name = editor._create_index_name(
+                table_name,
+                ["weight", "pink"],
+                suffix="_idx",
+            )
+
         new_state = project_state.clone()
         operation.state_forwards(app_label, new_state)
         # Rename index.
         with connection.schema_editor() as editor:
             operation.database_forwards(app_label, editor, project_state, new_state)
         self.assertIndexNameExists(table_name, "new_pony_test_idx")
-        # Reverse is a no-op.
-        with connection.schema_editor() as editor, self.assertNumQueries(0):
-            operation.database_backwards(app_label, editor, new_state, project_state)
+        self.assertIndexNameNotExists(table_name, auto_name)
+        # Idempotent re-apply while already renamed.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
         self.assertIndexNameExists(table_name, "new_pony_test_idx")
+        self.assertIndexNameNotExists(table_name, auto_name)
+        # Reverse restores the auto-generated name.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, project_state)
+        self.assertIndexNameExists(table_name, auto_name)
+        self.assertIndexNameNotExists(table_name, "new_pony_test_idx")
+        # Re-apply renaming succeeds after restoration.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertIndexNameExists(table_name, "new_pony_test_idx")
+        self.assertIndexNameNotExists(table_name, auto_name)
         # Deconstruction.
         definition = operation.deconstruct()
         self.assertEqual(definition[0], "RenameIndex")
@@ -2998,6 +3017,57 @@ class OperationTests(OperationTestBase):
                 "model_name": "Pony",
                 "new_name": "new_pony_test_idx",
                 "old_fields": ("weight", "pink"),
+            },
+        )
+
+    def test_rename_index_unnamed_unique_index(self):
+        app_label = "test_rniuui"
+        project_state = self.set_up_test_model(app_label, unique_together=True)
+        table_name = app_label + "_pony"
+        self.assertIndexNameNotExists(table_name, "new_pony_test_idx")
+        operation = migrations.RenameIndex(
+            "Pony", new_name="new_pony_test_idx", old_fields=("pink", "weight")
+        )
+
+        with connection.schema_editor() as editor:
+            auto_name = editor._create_index_name(
+                table_name,
+                ["pink", "weight"],
+                suffix="_uniq",
+            )
+
+        new_state = project_state.clone()
+        operation.state_forwards(app_label, new_state)
+        # Rename unique constraint index.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertIndexNameExists(table_name, "new_pony_test_idx")
+        self.assertIndexNameNotExists(table_name, auto_name)
+        # Idempotent re-apply while already renamed.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertIndexNameExists(table_name, "new_pony_test_idx")
+        self.assertIndexNameNotExists(table_name, auto_name)
+        # Reverse restores the auto-generated unique index name.
+        with connection.schema_editor() as editor:
+            operation.database_backwards(app_label, editor, new_state, project_state)
+        self.assertIndexNameExists(table_name, auto_name)
+        self.assertIndexNameNotExists(table_name, "new_pony_test_idx")
+        # Re-apply renaming succeeds after restoration.
+        with connection.schema_editor() as editor:
+            operation.database_forwards(app_label, editor, project_state, new_state)
+        self.assertIndexNameExists(table_name, "new_pony_test_idx")
+        self.assertIndexNameNotExists(table_name, auto_name)
+        # Deconstruction.
+        definition = operation.deconstruct()
+        self.assertEqual(definition[0], "RenameIndex")
+        self.assertEqual(definition[1], [])
+        self.assertEqual(
+            definition[2],
+            {
+                "model_name": "Pony",
+                "new_name": "new_pony_test_idx",
+                "old_fields": ("pink", "weight"),
             },
         )
 


### PR DESCRIPTION
## Summary
- rebuild `RenameIndex` backwards handling for unnamed indexes so reverse migrations restore the original auto-generated name
- short-circuit forwards renames when the unnamed index is already using the requested name to keep operations idempotent
- extend migration operation regression coverage for both `index_together` and `unique_together` derived indexes

Resolves #345.

## Testing
- `PYTHONPATH=/workspace/django /workspace/.venv/bin/python tests/runtests.py migrations.test_operations.OperationTests.test_rename_index_unnamed_index migrations.test_operations.OperationTests.test_rename_index_unnamed_unique_index --parallel=1`
- `PYTHONPATH=/workspace/django /workspace/.venv/bin/flake8 django/db/migrations/operations/models.py tests/migrations/test_operations.py`

## Reproduction
1. Check out `django__django-15695` without this patch.
2. Run `PYTHONPATH=/workspace/django /workspace/.venv/bin/python tests/runtests.py migrations.test_operations.OperationTests.test_rename_index_unnamed_index --parallel=1`

Observed failure on SQLite before the fix:
```
Traceback (most recent call last):
  File "/workspace/django/tests/migrations/test_operations.py", line 3003, in test_rename_index_unnamed_index
    self.assertIndexNameExists(table_name, auto_name)
  File "/workspace/django/tests/migrations/test_base.py", line 102, in assertIndexNameExists
    self.assertIn(
AssertionError: 'test_rninui_pony_weight_pink_80f4307b_idx' not found in {'new_pony_test_idx': {'columns': ['weight', 'pink'], 'primary_key': False, 'unique': False, 'foreign_key': None, 'check': False, 'index': True, 'type': 'idx', 'orders': ['ASC', 'ASC']}, '__primary__': {'columns': ['id'], 'primary_key': True, 'unique': False, 'foreign_key': None, 'check': False, 'index': False}}
```

Backend: SQLite (default test database).
