### PR TITLE
swev-id: django__django-15731 fix manager wraps signature

### DIFF
--- a/django/db/models/manager.py
+++ b/django/db/models/manager.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+from functools import wraps
 from importlib import import_module
 
 from django.db import router
@@ -81,11 +82,9 @@ class BaseManager:
     @classmethod
     def _get_queryset_methods(cls, queryset_class):
         def create_method(name, method):
+            @wraps(method)
             def manager_method(self, *args, **kwargs):
                 return getattr(self.get_queryset(), name)(*args, **kwargs)
-
-            manager_method.__name__ = method.__name__
-            manager_method.__doc__ = method.__doc__
             return manager_method
 
         new_methods = {}

--- a/tests/basic/test_manager_signatures.py
+++ b/tests/basic/test_manager_signatures.py
@@ -1,0 +1,30 @@
+import inspect
+
+from django.db import models
+from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
+
+
+@isolate_apps("basic")
+class ManagerSignatureTests(SimpleTestCase):
+    def test_bulk_create_signature_matches_queryset(self):
+        class BulkCreateModel(models.Model):
+            name = models.CharField(max_length=50)
+
+        manager_signature = inspect.signature(BulkCreateModel.objects.bulk_create)
+        queryset_signature = inspect.signature(
+            BulkCreateModel.objects.get_queryset().bulk_create
+        )
+        self.assertEqual(manager_signature, queryset_signature)
+
+    def test_update_or_create_signature_matches_queryset(self):
+        class UpdateOrCreateModel(models.Model):
+            name = models.CharField(max_length=50)
+
+        manager_signature = inspect.signature(
+            UpdateOrCreateModel.objects.update_or_create
+        )
+        queryset_signature = inspect.signature(
+            UpdateOrCreateModel.objects.get_queryset().update_or_create
+        )
+        self.assertEqual(manager_signature, queryset_signature)


### PR DESCRIPTION
## Summary
- decorate manager queryset proxies with functools.wraps
- add signature regression tests for bulk_create and update_or_create

Fixes #347

## Testing
- PYTHONPATH=/workspace/django .venv/bin/python tests/runtests.py basic.test_manager_signatures --parallel=1
- .venv/bin/flake8 django/db/models/manager.py tests/basic/test_manager_signatures.py