### PR TITLE
swev-id: django__django-15629 - Fix QuerySet.count HAVING handling

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -462,8 +462,10 @@ class Query(BaseExpression):
         # those operations must be done in a subquery so that the query
         # aggregates on the limit and/or distinct results instead of applying
         # the distinct and limit after the aggregation.
+        contains_having = self.where and self.where.contains_aggregate
         if (
-            isinstance(self.group_by, tuple)
+            self.group_by is not None
+            or contains_having
             or self.is_sliced
             or existing_annotations
             or self.distinct

--- a/tests/aggregation_regress/models.py
+++ b/tests/aggregation_regress/models.py
@@ -89,3 +89,12 @@ class SelfRefFK(models.Model):
     parent = models.ForeignKey(
         "self", models.SET_NULL, null=True, blank=True, related_name="children"
     )
+
+
+class Parent(models.Model):
+    name = models.CharField(max_length=50)
+
+
+class Child(models.Model):
+    parent = models.ForeignKey(Parent, models.CASCADE)
+    amount = models.IntegerField()

--- a/tests/aggregation_regress/tests.py
+++ b/tests/aggregation_regress/tests.py
@@ -32,10 +32,12 @@ from .models import (
     Book,
     Bravo,
     Charlie,
+    Child,
     Clues,
     Entries,
     HardbackBook,
     ItemTag,
+    Parent,
     Publisher,
     SelfRefFK,
     Store,
@@ -1818,6 +1820,51 @@ class AggregationTests(TestCase):
             Q(authors__in=authors) | Q(authors__count__gt=2)
         )
         self.assertEqual(set(books), {self.b1, self.b4})
+
+
+class CountAnnotationHavingTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.alpha = Parent.objects.create(name="alpha")
+        cls.beta = Parent.objects.create(name="beta")
+        cls.gamma = Parent.objects.create(name="gamma")
+        Child.objects.bulk_create(
+            [
+                Child(parent=cls.alpha, amount=5),
+                Child(parent=cls.alpha, amount=-2),
+                Child(parent=cls.beta, amount=1),
+                Child(parent=cls.gamma, amount=-3),
+            ]
+        )
+
+    def _base_queryset(self):
+        return (
+            Parent.objects.annotate(total=Sum("child__amount"))
+            .filter(total__gt=0)
+            .order_by("pk")
+        )
+
+    def _assert_count_matches_length(self, qs):
+        count = qs.count()
+        results = list(qs)
+        self.assertEqual(count, len(results))
+
+    def test_count_with_annotation_filter(self):
+        self._assert_count_matches_length(self._base_queryset())
+
+    def test_count_with_values(self):
+        qs = (
+            Parent.objects.values("name")
+            .annotate(total=Sum("child__amount"))
+            .filter(total__gt=0)
+        )
+        self._assert_count_matches_length(qs)
+
+    def test_count_with_distinct(self):
+        self._assert_count_matches_length(self._base_queryset().distinct())
+
+    def test_count_with_slicing(self):
+        self._assert_count_matches_length(self._base_queryset()[1:])
 
 
 class JoinPromotionTests(TestCase):


### PR DESCRIPTION
## Summary
- add Parent/Child fixtures and regression tests for QuerySet.count() with HAVING/VALUES/DISTINCT/slicing
- extend Query.get_aggregation to treat HAVING or any group_by as requiring a subquery for aggregation
- keep aggregation rewriting so the outer query performs COUNT(*) over the inner grouped subquery

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py aggregation_regress --parallel=1
- .venv/bin/flake8 django/db/models/sql/query.py tests/aggregation_regress/tests.py tests/aggregation_regress/models.py

## Issue
- Fixes #343

## Reproduction
1. Checkout `django__django-15629` before these changes
2. Run `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py aggregation_regress.tests.CountAnnotationHavingTests --parallel=1`
3. Observed failure:
```
FAIL: test_count_with_annotation_filter (aggregation_regress.tests.CountAnnotationHavingTests.test_count_with_annotation_filter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/aggregation_regress/tests.py", line 1853, in test_count_with_annotation_filter
    self._assert_count_matches_length(self._base_queryset())
  File "tests/aggregation_regress/tests.py", line 1850, in _assert_count_matches_length
    self.assertEqual(count, len(results))
AssertionError: 4 != 2
```

## Approach & Cross-backend considerations
- Subquery is now selected whenever HAVING is present or the query has any group_by (including the boolean sentinel used by annotations)
- Ensures COUNT(*) runs against grouped subquery so MySQL/PostgreSQL deliver consistent row counts
- Preserves existing summary annotation rewriting so other aggregates keep working
