### PR TITLE
Fix optional group handling in admindocs and translate_url — swev-id: django__django-15732

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -204,13 +204,14 @@ def replace_named_groups(pattern):
     3. ^(?P<a>\w+)/b/(\w+) ==> ^<a>/b/(\w+)
     4. ^(?P<a>\w+)/b/(?P<c>\w+) ==> ^<a>/b/<c>
     """
-    group_pattern_and_name = [
-        (pattern[start:end], match[1])
-        for start, end, match in _find_groups(pattern, named_group_matcher)
-    ]
-    for group_pattern, group_name in group_pattern_and_name:
-        pattern = pattern.replace(group_pattern, group_name)
-    return pattern
+    parts = []
+    prev_end = 0
+    for start, end, match in _find_groups(pattern, named_group_matcher):
+        parts.append(pattern[prev_end:start])
+        parts.append(match[1])
+        prev_end = end
+    parts.append(pattern[prev_end:])
+    return "".join(parts)
 
 
 def replace_unnamed_groups(pattern):
@@ -221,13 +222,14 @@ def replace_unnamed_groups(pattern):
     3. ^(?P<a>\w+)/b/(\w+) ==> ^(?P<a>\w+)/b/<var>
     4. ^(?P<a>\w+)/b/((x|y)\w+) ==> ^(?P<a>\w+)/b/<var>
     """
-    final_pattern, prev_end = "", None
+    parts = []
+    prev_end = 0
     for start, end, _ in _find_groups(pattern, unnamed_group_matcher):
-        if prev_end:
-            final_pattern += pattern[prev_end:start]
-        final_pattern += pattern[:start] + "<var>"
+        parts.append(pattern[prev_end:start])
+        parts.append("<var>")
         prev_end = end
-    return final_pattern + pattern[prev_end:]
+    parts.append(pattern[prev_end:])
+    return "".join(parts)
 
 
 def remove_non_capturing_groups(pattern):
@@ -237,12 +239,16 @@ def remove_non_capturing_groups(pattern):
     2. ^(?:\w+(?:\w+))a => ^a
     3. ^a(?:\w+)/b(?:\w+) => ^a/b
     """
-    group_start_end_indices = _find_groups(pattern, non_capturing_group_matcher)
-    final_pattern, prev_end = "", None
-    for start, end, _ in group_start_end_indices:
-        final_pattern += pattern[prev_end:start]
+    parts = []
+    prev_end = 0
+    for start, end, match in _find_groups(pattern, non_capturing_group_matcher):
+        parts.append(pattern[prev_end:start])
+        inner = pattern[match.end(0) : end - 1]
+        if not re.search(r"[.^$*+?{}\[\]|\\]", inner):
+            parts.append(inner)
         prev_end = end
-    return final_pattern + pattern[prev_end:]
+    parts.append(pattern[prev_end:])
+    return "".join(parts)
 
 
 # Callback strings are cached in a dictionary for every urlconf.

--- a/django/urls/base.py
+++ b/django/urls/base.py
@@ -177,7 +177,12 @@ def translate_url(url, lang_code):
         )
         with override(lang_code):
             try:
-                url = reverse(to_be_reversed, args=match.args, kwargs=match.kwargs)
+                safe_kwargs = {
+                    key: value
+                    for key, value in match.kwargs.items()
+                    if value is not None
+                }
+                url = reverse(to_be_reversed, args=match.args, kwargs=safe_kwargs)
             except NoReverseMatch:
                 pass
             else:

--- a/tests/admin_docs/test_views.py
+++ b/tests/admin_docs/test_views.py
@@ -566,3 +566,21 @@ class AdminDocViewFunctionsTests(SimpleTestCase):
         for pattern, output in tests:
             with self.subTest(pattern=pattern):
                 self.assertEqual(simplify_regex(pattern), output)
+
+    def test_simplify_regex_trailing_optional_non_capturing(self):
+        self.assertEqual(
+            simplify_regex(r"^x/(\w+)/y/(\d+)/(?:z)?$"),
+            "/x/<var>/y/<var>/z",
+        )
+
+    def test_simplify_regex_named_and_unnamed_trailing(self):
+        self.assertEqual(
+            simplify_regex(r"^(?P<slug>\w+)/items/(\d+)/(?:detail)?$"),
+            "/<slug>/items/<var>/detail",
+        )
+
+    def test_simplify_regex_repeated_named_groups_no_overreplace(self):
+        self.assertEqual(
+            simplify_regex(r"^(?P<id>\d+)-(?P<id>\d+)/(\w+)$"),
+            "/<id>-<id>/<var>",
+        )

--- a/tests/db_models/test_query.py
+++ b/tests/db_models/test_query.py
@@ -1,0 +1,29 @@
+from django.db import models
+from django.db.models import Q
+from django.test import TestCase
+from django.test.utils import isolate_apps
+
+
+class NestedQNoneRenderingTests(TestCase):
+    @isolate_apps("db_models")
+    def test_nested_q_groups_none_is_null(self):
+        class Profile(models.Model):
+            bio = models.TextField(null=True, blank=True)
+
+        class Person(models.Model):
+            username = models.CharField(max_length=32)
+            email = models.EmailField(null=True, blank=True)
+            profile = models.ForeignKey(
+                "Profile", models.SET_NULL, null=True, blank=True
+            )
+
+        condition = Q(username__icontains="john") & (
+            Q(profile_id=None) | Q(email=None)
+        )
+        queryset = Person.objects.filter(condition)
+
+        sql = str(queryset.query)
+        self.assertIn("IS NULL", sql)
+        self.assertNotIn("= NULL", sql)
+        self.assertIn("(", sql)
+        self.assertIn(" OR ", sql)

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -198,6 +198,14 @@ class URLTranslationTests(URLTestCaseBase):
             self.assertEqual(translate_url("/nl/gebruikers/", "en"), "/en/users/")
             self.assertEqual(translation.get_language(), "nl")
 
+    @override_settings(ROOT_URLCONF="i18n.patterns.urls.optional_group")
+    def test_translate_url_optional_trailing_group(self):
+        with translation.override("en"):
+            self.assertEqual(
+                translate_url("/en/account/john/", "nl"),
+                "/nl/account/john/",
+            )
+
     def test_reverse_translated_with_captured_kwargs(self):
         with translation.override("en"):
             match = resolve("/translated/apo/")

--- a/tests/i18n/patterns/urls/optional_group.py
+++ b/tests/i18n/patterns/urls/optional_group.py
@@ -1,0 +1,28 @@
+from django.urls import path
+from django.views.generic import TemplateView
+
+view = TemplateView.as_view(template_name="dummy.html")
+
+urlpatterns = [
+    path(
+        "en/account/<slug:slug>/",
+        view,
+        {"section": None},
+        name="account-optional",
+    ),
+    path(
+        "en/account/<slug:slug>/section/<slug:section>/",
+        view,
+        name="account-optional",
+    ),
+    path(
+        "nl/account/<slug:slug>/",
+        view,
+        name="account-optional",
+    ),
+    path(
+        "nl/account/<slug:slug>/section/<slug:section>/",
+        view,
+        name="account-optional",
+    ),
+]

--- a/tests/view_tests/tests/test_i18n.py
+++ b/tests/view_tests/tests/test_i18n.py
@@ -100,6 +100,24 @@ class SetLanguageTests(TestCase):
             self.client.cookies[settings.LANGUAGE_COOKIE_NAME].value, lang_code
         )
 
+    @override_settings(
+        LANGUAGE_CODE="en",
+        LANGUAGES=[("en", "English"), ("nl", "Dutch")],
+        ROOT_URLCONF="view_tests.urls_optional_group",
+    )
+    def test_set_language_redirect_with_optional_trailing_group(self):
+        post_data = {"language": "nl"}
+        response = self.client.post(
+            "/i18n/setlang/",
+            post_data,
+            HTTP_REFERER="/en/account/jane/",
+        )
+        self.assertRedirects(
+            response,
+            "/nl/account/jane/",
+            fetch_redirect_response=False,
+        )
+
     def test_setlang_default_redirect(self):
         """
         The set_language view redirects to '/' when there isn't a referer or

--- a/tests/view_tests/urls_optional_group.py
+++ b/tests/view_tests/urls_optional_group.py
@@ -1,0 +1,28 @@
+from django.urls import include, path
+
+from . import views
+
+urlpatterns = [
+    path("i18n/", include("django.conf.urls.i18n")),
+    path(
+        "en/account/<slug:slug>/",
+        views.index_page,
+        {"section": None},
+        name="i18n_account_optional",
+    ),
+    path(
+        "en/account/<slug:slug>/section/<slug:section>/",
+        views.index_page,
+        name="i18n_account_optional",
+    ),
+    path(
+        "nl/account/<slug:slug>/",
+        views.index_page,
+        name="i18n_account_optional",
+    ),
+    path(
+        "nl/account/<slug:slug>/section/<slug:section>/",
+        views.index_page,
+        name="i18n_account_optional",
+    ),
+]


### PR DESCRIPTION
## Summary
- rewrite admindocs group replacement helpers to operate on spans so optional segments are preserved only once
- filter out None kwargs before reversing during translate_url and cover optional-trailing-group redirects
- add regression coverage for nested Q Null checks to assert OR grouping renders IS NULL

## Pre-fix failure evidence
<details>
<summary>admin_docs</summary>

```
Testing against Django installed in '/workspace/django/django'
Found 66 test(s).
System check identified no issues (0 silenced).
............................................................F.F...
======================================================================
FAIL: test_simplify_regex_trailing_optional_non_capturing (admin_docs.test_views.AdminDocViewFunctionsTests.test_simplify_regex_trailing_optional_non_capturing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/admin_docs/test_views.py", line 571, in test_simplify_regex_trailing_optional_non_capturing
    self.assertEqual(
AssertionError: '/x/<var>/y/<var>/' != '/x/<var>/y/<var>/z'
- /x/<var>/y/<var>/
+ /x/<var>/y/<var>/z
?                  +

======================================================================
FAIL: test_simplify_regex_named_and_unnamed_trailing (admin_docs.test_views.AdminDocViewFunctionsTests.test_simplify_regex_named_and_unnamed_trailing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/admin_docs/test_views.py", line 577, in test_simplify_regex_named_and_unnamed_trailing
    self.assertEqual(
AssertionError: '/<slug>/items/<var>/' != '/<slug>/items/<var>/detail'
- /<slug>/items/<var>/
+ /<slug>/items/<var>/detail
?                     ++++++

----------------------------------------------------------------------
Ran 66 tests in 0.728s

FAILED (failures=2)
```
</details>

<details>
<summary>i18n.patterns</summary>

```
Testing against Django installed in '/workspace/django/django'
Found 39 test(s).
System check identified no issues (0 silenced).
..................................F....
======================================================================
FAIL: test_translate_url_optional_trailing_group (i18n.patterns.tests.URLTranslationTests.test_translate_url_optional_trailing_group)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/django/test/utils.py", line 460, in inner
    return func(*args, **kwargs)
  File "/workspace/django/tests/i18n/patterns/tests.py", line 204, in test_translate_url_optional_trailing_group
    self.assertEqual(
AssertionError: '/nl/account/john/section/None/' != '/nl/account/john/'
- /nl/account/john/section/None/
+ /nl/account/john/

----------------------------------------------------------------------
Ran 39 tests in 0.031s

FAILED (failures=1)
```
</details>

<details>
<summary>view_tests.tests.test_i18n</summary>

```
Creating test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
Found 34 test(s).
System check identified no issues (0 silenced).
.F..............................ss
======================================================================
FAIL: test_set_language_redirect_with_optional_trailing_group (view_tests.tests.test_i18n.SetLanguageTests.test_set_language_redirect_with_optional_trailing_group)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/django/test/utils.py", line 460, in inner
    return func(*args, **kwargs)
  File "/workspace/django/tests/view_tests/tests/test_i18n.py", line 115, in test_set_language_redirect_with_optional_trailing_group
    self.assertRedirects(
  File "/workspace/django/django/test/testcases.py", line 564, in assertRedirects
    self.assertURLEqual(
  File "/workspace/django/django/test/testcases.py", line 589, in assertURLEqual
    self.assertEqual(
AssertionError: '/nl/account/jane/section/None/' != '/nl/account/jane/'
- /nl/account/jane/section/None/
+ /nl/account/jane/
 : Response redirected to '/nl/account/jane/section/None/', expected '/nl/account/jane/'Expected '/nl/account/jane/section/None/' to equal '/nl/account/jane/'.

----------------------------------------------------------------------
Ran 34 tests in 0.043s

FAILED (failures=1, skipped=2)
Destroying test database for alias 'default'...
```
</details>

## Testing
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py admin_docs --parallel=1
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py i18n.patterns --parallel=1
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py view_tests.tests.test_i18n --parallel=1
- PYTHONPATH=$PWD .venv/bin/python tests/runtests.py db_models.test_query --parallel=1
- .venv/bin/flake8 django/urls/base.py django/contrib/admindocs/utils.py tests/i18n/patterns/tests.py tests/i18n/patterns/urls/optional_group.py tests/view_tests/tests/test_i18n.py tests/view_tests/urls_optional_group.py tests/db_models/test_query.py
