### PR TITLE
fix(postgresql): order dbshell args (swev-id: django__django-15851)

### DIFF
--- a/django/db/backends/postgresql/client.py
+++ b/django/db/backends/postgresql/client.py
@@ -32,9 +32,9 @@ class DatabaseClient(BaseDatabaseClient):
             args += ["-h", host]
         if port:
             args += ["-p", str(port)]
-        if dbname:
-            args += [dbname]
         args.extend(parameters)
+        if dbname:
+            args.append(dbname)
 
         env = {}
         if passwd:

--- a/tests/backends/postgresql/test_client.py
+++ b/tests/backends/postgresql/test_client.py
@@ -1,0 +1,118 @@
+from django.db.backends.postgresql.client import DatabaseClient
+from django.test import SimpleTestCase
+
+
+class PostgreSQLDatabaseClientTests(SimpleTestCase):
+    def test_parameters_inserted_before_dbname(self):
+        settings_dict = {
+            "HOST": "localhost",
+            "PORT": "5432",
+            "NAME": "example",
+            "USER": "alice",
+            "PASSWORD": "secret",
+            "OPTIONS": {},
+        }
+        parameters = ["-c", "SELECT 1"]
+
+        args, env = DatabaseClient.settings_to_cmd_args_env(settings_dict, parameters)
+
+        self.assertEqual(
+            args,
+            [
+                "psql",
+                "-U",
+                "alice",
+                "-h",
+                "localhost",
+                "-p",
+                "5432",
+                "-c",
+                "SELECT 1",
+                "example",
+            ],
+        )
+        self.assertEqual(env, {"PGPASSWORD": "secret"})
+
+    def test_service_connection_without_dbname(self):
+        settings_dict = {
+            "HOST": "localhost",
+            "NAME": "",
+            "USER": "alice",
+            "PASSWORD": "secret",
+            "OPTIONS": {"service": "primary"},
+        }
+        parameters = ["--set", "ON_ERROR_STOP=1"]
+
+        args, env = DatabaseClient.settings_to_cmd_args_env(settings_dict, parameters)
+
+        self.assertEqual(
+            args,
+            [
+                "psql",
+                "-U",
+                "alice",
+                "-h",
+                "localhost",
+                "--set",
+                "ON_ERROR_STOP=1",
+            ],
+        )
+        self.assertEqual(
+            env,
+            {
+                "PGPASSWORD": "secret",
+                "PGSERVICE": "primary",
+            },
+        )
+
+    def test_unix_socket_host_kept_before_parameters(self):
+        settings_dict = {
+            "HOST": "/var/run/postgresql",
+            "NAME": "example",
+            "USER": "alice",
+            "OPTIONS": {},
+        }
+        parameters = ["-c", "SELECT 1"]
+
+        args, env = DatabaseClient.settings_to_cmd_args_env(settings_dict, parameters)
+
+        self.assertEqual(
+            args,
+            [
+                "psql",
+                "-U",
+                "alice",
+                "-h",
+                "/var/run/postgresql",
+                "-c",
+                "SELECT 1",
+                "example",
+            ],
+        )
+        self.assertIsNone(env)
+
+    def test_default_dbname_appended_last(self):
+        settings_dict = {
+            "HOST": "localhost",
+            "NAME": "",
+            "USER": "alice",
+            "OPTIONS": {},
+        }
+        parameters = ["-c", "SELECT 1"]
+
+        args, env = DatabaseClient.settings_to_cmd_args_env(settings_dict, parameters)
+
+        self.assertEqual(
+            args,
+            [
+                "psql",
+                "-U",
+                "alice",
+                "-h",
+                "localhost",
+                "-c",
+                "SELECT 1",
+                "postgres",
+            ],
+        )
+        self.assertIsNone(env)


### PR DESCRIPTION
## Summary
- ensure PostgreSQL dbshell parameters precede the database name while keeping env handling unchanged
- add unit tests covering dbshell argument ordering scenarios

## Issue
- Closes #353

## Reproduction
1. Configure a PostgreSQL-backed project (NAME, USER, PASSWORD, HOST, PORT).
2. Run `python manage.py dbshell -- -c "SELECT 1"`.
3. Observe that `psql` ignores `-c` and emits warnings.

Observed warnings:
- `psql: warning: extra command-line argument "-c" ignored`
- `psql: warning: extra command-line argument "SELECT 1" ignored`

## Stack path
- `django/core/management/commands/dbshell.py`
- `django/db/backends/base/client.py`
- `django/db/backends/postgresql/client.py`

## Testing
- `PYTHONPATH=/workspace/django python tests/runtests.py backends.postgresql.test_client --parallel=1`
- `flake8 django/db/backends/postgresql/client.py tests/backends/postgresql/test_client.py`