### PR TITLE
Fix duplicate QuerySet.extra selects under aggregation (swev-id: django__django-15741)}

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -194,17 +194,24 @@ class ValuesIterable(BaseIterable):
         query = queryset.query
         compiler = query.get_compiler(queryset.db)
 
+        rows = compiler.results_iter(
+            chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size
+        )
         # extra(select=...) cols are always at the start of the row.
         names = [
             *query.extra_select,
             *query.values_select,
             *query.annotation_select,
         ]
-        indexes = range(len(names))
-        for row in compiler.results_iter(
-            chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size
-        ):
-            yield {names[i]: row[i] for i in indexes}
+        base_index_map = {name: idx for idx, name in enumerate(names)}
+        index_lookup = {}
+        index_lookup.update(getattr(compiler, "extra_select_aliases", {}))
+        index_lookup.update(getattr(compiler, "values_select_map", {}))
+        if compiler.annotation_col_map:
+            index_lookup.update(compiler.annotation_col_map)
+        indexes = [index_lookup.get(name, base_index_map[name]) for name in names]
+        for row in rows:
+            yield {name: row[index] for name, index in zip(names, indexes)}
 
 
 class ValuesListIterable(BaseIterable):
@@ -218,32 +225,42 @@ class ValuesListIterable(BaseIterable):
         query = queryset.query
         compiler = query.get_compiler(queryset.db)
 
-        if queryset._fields:
-            # extra(select=...) cols are always at the start of the row.
-            names = [
-                *query.extra_select,
-                *query.values_select,
-                *query.annotation_select,
-            ]
-            fields = [
-                *queryset._fields,
-                *(f for f in query.annotation_select if f not in queryset._fields),
-            ]
-            if fields != names:
-                # Reorder according to fields.
-                index_map = {name: idx for idx, name in enumerate(names)}
-                rowfactory = operator.itemgetter(*[index_map[f] for f in fields])
-                return map(
-                    rowfactory,
-                    compiler.results_iter(
-                        chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size
-                    ),
-                )
-        return compiler.results_iter(
+        rows = compiler.results_iter(
             tuple_expected=True,
             chunked_fetch=self.chunked_fetch,
             chunk_size=self.chunk_size,
         )
+
+        names = [
+            *query.extra_select,
+            *query.values_select,
+            *query.annotation_select,
+        ]
+        base_index_map = {name: idx for idx, name in enumerate(names)}
+        index_lookup = {}
+        index_lookup.update(getattr(compiler, "extra_select_aliases", {}))
+        index_lookup.update(getattr(compiler, "values_select_map", {}))
+        if compiler.annotation_col_map:
+            index_lookup.update(compiler.annotation_col_map)
+
+        def get_index(name):
+            return index_lookup.get(name, base_index_map[name])
+
+        if queryset._fields:
+            fields = [
+                *queryset._fields,
+                *(f for f in query.annotation_select if f not in queryset._fields),
+            ]
+        else:
+            fields = names
+
+        indexes = [get_index(name) for name in fields]
+
+        def generator():
+            for row in rows:
+                yield tuple(row[index] for index in indexes)
+
+        return generator()
 
 
 class NamedValuesListIterable(ValuesListIterable):
@@ -277,11 +294,29 @@ class FlatValuesListIterable(BaseIterable):
 
     def __iter__(self):
         queryset = self.queryset
-        compiler = queryset.query.get_compiler(queryset.db)
-        for row in compiler.results_iter(
+        query = queryset.query
+        compiler = query.get_compiler(queryset.db)
+        rows = compiler.results_iter(
             chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size
-        ):
-            yield row[0]
+        )
+        names = [
+            *query.extra_select,
+            *query.values_select,
+            *query.annotation_select,
+        ]
+        base_index_map = {name: idx for idx, name in enumerate(names)}
+        index_lookup = {}
+        index_lookup.update(getattr(compiler, "extra_select_aliases", {}))
+        index_lookup.update(getattr(compiler, "values_select_map", {}))
+        if compiler.annotation_col_map:
+            index_lookup.update(compiler.annotation_col_map)
+        if queryset._fields:
+            target_name = queryset._fields[0]
+        else:
+            target_name = names[0]
+        index = index_lookup.get(target_name, base_index_map[target_name])
+        for row in rows:
+            yield row[index]
 
 
 class QuerySet:

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -4,7 +4,7 @@ import re
 from functools import partial
 from itertools import chain
 
-from django.core.exceptions import EmptyResultSet, FieldError
+from django.core.exceptions import EmptyResultSet, FieldDoesNotExist, FieldError
 from django.db import DatabaseError, NotSupportedError
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import F, OrderBy, RawSQL, Ref, Value
@@ -244,12 +244,12 @@ class SQLCompiler:
         select = []
         klass_info = None
         annotations = {}
-        select_idx = 0
-        for alias, (sql, params) in self.query.extra_select.items():
-            annotations[alias] = select_idx
-            select.append((RawSQL(sql, params), alias))
-            select_idx += 1
+        extra_select_items = [
+            (alias, RawSQL(sql, params))
+            for alias, (sql, params) in self.query.extra_select.items()
+        ]
         assert not (self.query.select and self.query.default_cols)
+        select_idx = 0
         if self.query.default_cols:
             cols = self.get_default_columns()
         else:
@@ -267,7 +267,6 @@ class SQLCompiler:
                 "select_fields": select_list,
             }
         for alias, annotation in self.query.annotation_select.items():
-            annotations[alias] = select_idx
             select.append((annotation, alias))
             select_idx += 1
 
@@ -285,8 +284,24 @@ class SQLCompiler:
 
             get_select_from_parent(klass_info)
 
-        ret = []
-        for col, alias in select:
+        def normalize_sql(sql):
+            sql = sql.strip()
+            if sql.startswith("(") and sql.endswith(")"):
+                depth = 0
+                balanced = False
+                for idx, char in enumerate(sql):
+                    if char == "(":
+                        depth += 1
+                    elif char == ")":
+                        depth -= 1
+                        if depth == 0:
+                            balanced = idx == len(sql) - 1
+                            break
+                if balanced:
+                    sql = sql[1:-1].strip()
+            return re.sub(r"\s+", " ", sql)
+
+        def compile_select_expression(col):
             try:
                 sql, params = self.compile(col)
             except EmptyResultSet:
@@ -300,7 +315,149 @@ class SQLCompiler:
                     sql, params = self.compile(Value(empty_result_set_value))
             else:
                 sql, params = col.select_format(self, sql, params)
-            ret.append((col, (sql, params), alias))
+            return sql, params
+
+        has_group_by = bool(self.query.group_by)
+        has_aggregate_annotations = any(
+            getattr(annotation, "contains_aggregate", False)
+            for annotation in chain(
+                self.query.annotation_select.values(),
+                self.query.annotations.values(),
+            )
+        )
+        dedupe_extras = bool(extra_select_items) and (
+            has_group_by or has_aggregate_annotations
+        )
+
+        extra_entries = []
+        extras_seen = {}
+        extras_indices_by_key = collections.defaultdict(list)
+        for alias, expr in extra_select_items:
+            sql, params = compile_select_expression(expr)
+            key = None
+            if dedupe_extras:
+                key = (normalize_sql(sql), make_hashable(params))
+                extras_indices_by_key[key].append(len(extra_entries))
+            entry = {
+                "alias": alias,
+                "expr": expr,
+                "sql": sql,
+                "params": params,
+                "key": key,
+                "keep": True,
+                "dedup_to_extra": None,
+                "dedup_to_base": None,
+                "final_index": None,
+            }
+            if dedupe_extras and key in extras_seen:
+                entry["keep"] = False
+                entry["dedup_to_extra"] = extras_seen[key]
+            elif dedupe_extras and key is not None:
+                extras_seen[key] = len(extra_entries)
+            extra_entries.append(entry)
+
+        base_entries = []
+        for position, (col, alias) in enumerate(select):
+            sql, params = compile_select_expression(col)
+            key = None
+            if dedupe_extras:
+                key = (normalize_sql(sql), make_hashable(params))
+                for extra_idx in extras_indices_by_key.get(key, []):
+                    extra_entries[extra_idx]["keep"] = False
+                    extra_entries[extra_idx]["dedup_to_base"] = position
+            base_entries.append(
+                {
+                    "col": col,
+                    "alias": alias,
+                    "sql": sql,
+                    "params": params,
+                    "key": key,
+                    "position": position,
+                    "final_index": None,
+                }
+            )
+
+        if dedupe_extras:
+            meta = self.query.get_meta()
+            base_alias = self.query.base_table
+            if meta is not None and base_alias is not None:
+                for entry in extra_entries:
+                    if not entry["keep"]:
+                        continue
+                    alias = entry["alias"]
+                    if not alias:
+                        continue
+                    try:
+                        field = meta.get_field(alias)
+                    except FieldDoesNotExist:
+                        continue
+                    if entry["key"] is None:
+                        continue
+                    col_expr = field.get_col(base_alias)
+                    col_sql, col_params = compile_select_expression(col_expr)
+                    col_key = (normalize_sql(col_sql), make_hashable(col_params))
+                    entry_sql_unquoted = entry["key"][0].replace('"', "")
+                    col_sql_unquoted = col_key[0].replace('"', "")
+                    if entry["key"] == col_key or (
+                        entry_sql_unquoted == col_sql_unquoted
+                        and entry["key"][1] == col_key[1]
+                    ):
+                        entry["expr"] = col_expr
+                        entry["sql"] = col_sql
+                        entry["params"] = col_params
+                        entry["key"] = col_key
+
+        extras_keep_count = 0
+        for entry in extra_entries:
+            if entry["keep"]:
+                entry["final_index"] = extras_keep_count
+                extras_keep_count += 1
+
+        for entry in base_entries:
+            entry["final_index"] = extras_keep_count + entry["position"]
+
+        for entry in extra_entries:
+            if entry["keep"]:
+                continue
+            if entry["dedup_to_base"] is not None:
+                entry["final_index"] = extras_keep_count + entry["dedup_to_base"]
+            elif entry["dedup_to_extra"] is not None:
+                entry["final_index"] = extra_entries[entry["dedup_to_extra"]][
+                    "final_index"
+                ]
+
+        if klass_info:
+            def shift_select_fields(info):
+                info["select_fields"] = [
+                    extras_keep_count + index for index in info["select_fields"]
+                ]
+                for related in info.get("related_klass_infos", []):
+                    shift_select_fields(related)
+
+            shift_select_fields(klass_info)
+
+        ret = []
+        annotations = {}
+        for entry in extra_entries:
+            if entry["keep"]:
+                ret.append(
+                    (entry["expr"], (entry["sql"], entry["params"]), entry["alias"])
+                )
+                annotations[entry["alias"]] = len(ret) - 1
+        for entry in base_entries:
+            ret.append((entry["col"], (entry["sql"], entry["params"]), entry["alias"]))
+            if entry["alias"] is not None:
+                annotations[entry["alias"]] = len(ret) - 1
+        for entry in extra_entries:
+            if not entry["keep"]:
+                annotations[entry["alias"]] = entry["final_index"]
+        self.extra_select_aliases = {
+            entry["alias"]: entry["final_index"] for entry in extra_entries
+        }
+        self.values_select_map = {
+            name: extras_keep_count + idx
+            for idx, name in enumerate(getattr(self.query, "values_select", ()))
+        }
         return ret, klass_info, annotations
 
     def _order_by_pairs(self):

--- a/tests/queries/tests.py
+++ b/tests/queries/tests.py
@@ -1,5 +1,6 @@
 import datetime
 import pickle
+import re
 import sys
 import unittest
 from operator import attrgetter
@@ -2749,6 +2750,109 @@ class ValuesQuerysetTests(TestCase):
         value = Number.objects.values_list("num", "other_num", named=True).get()
         self.assertEqual(value, (72, None))
         self.assertEqual(pickle.loads(pickle.dumps(value)), value)
+
+    def _normalize_sql(self, sql):
+        sql = sql.strip()
+        if sql.startswith("(") and sql.endswith(")"):
+            inner = sql[1:-1].strip()
+            if inner.count("(") == inner.count(")"):
+                sql = inner
+        return re.sub(r"\s+", " ", sql)
+
+    def _select_info(self, qs):
+        compiler = qs.query.get_compiler(using="default", connection=connection)
+        select, _, annotations = compiler.get_select()
+        return [
+            (col, self._normalize_sql(sql), tuple(params), alias)
+            for (col, (sql, params), alias) in select
+        ], annotations
+
+    def test_extra_duplicate_select_pruned_with_aggregation(self):
+        qs = (
+            Number.objects.extra(
+                select={
+                    "num_dup": (
+                        f"{connection.ops.quote_name(Number._meta.db_table)}"
+                        f".{connection.ops.quote_name('num')}"
+                    )
+                }
+            )
+            .values("num", "num_dup")
+            .annotate(Count("id"))
+            .order_by("num")
+        )
+        select_info, annotations = self._select_info(qs)
+        seen = {(sql, params) for _, sql, params, _ in select_info}
+        self.assertEqual(len(select_info), len(seen))
+        num_field = Number._meta.get_field("num")
+        base_index = next(
+            idx
+            for idx, (col, _, _, _) in enumerate(select_info)
+            if getattr(col, "target", None) is num_field
+        )
+        self.assertEqual(annotations["num_dup"], base_index)
+        self.assertSequenceEqual(
+            list(qs),
+            [{"num": 72, "num_dup": 72, "id__count": 1}],
+        )
+
+    def test_extra_alias_collision_maps_existing_column(self):
+        qs = (
+            Number.objects.extra(
+                select={
+                    "num": (
+                        f"{connection.ops.quote_name(Number._meta.db_table)}"
+                        f".{connection.ops.quote_name('num')}"
+                    )
+                }
+            )
+            .values("num")
+            .annotate(Count("id"))
+            .order_by("num")
+        )
+        select_info, annotations = self._select_info(qs)
+        seen = {(sql, params) for _, sql, params, _ in select_info}
+        self.assertEqual(len(select_info), len(seen))
+        num_field = Number._meta.get_field("num")
+        base_index = next(
+            idx
+            for idx, (col, _, _, _) in enumerate(select_info)
+            if getattr(col, "target", None) is num_field
+        )
+        self.assertEqual(annotations["num"], base_index)
+        self.assertSequenceEqual(list(qs), [{"num": 72, "id__count": 1}])
+
+    def test_extra_non_equivalent_expression_retained(self):
+        qs = (
+            Number.objects.extra(select={"num_plus_one": "num + 1"})
+            .values("num", "num_plus_one")
+            .annotate(Count("id"))
+            .order_by("num")
+        )
+        select_info, _ = self._select_info(qs)
+        seen = {(sql, params) for _, sql, params, _ in select_info}
+        self.assertEqual(len(select_info), len(seen))
+        self.assertSequenceEqual(
+            list(qs),
+            [{"num": 72, "num_plus_one": 73, "id__count": 1}],
+        )
+
+    def test_extra_duplicate_values_list_named_aliases(self):
+        qs = (
+            Number.objects.extra(
+                select={
+                    "num_dup": (
+                        f"{connection.ops.quote_name(Number._meta.db_table)}"
+                        f".{connection.ops.quote_name('num')}"
+                    )
+                }
+            )
+            .annotate(Count("id"))
+            .values_list("num", "num_dup", named=True)
+        )
+        row = qs.get()
+        self.assertEqual(row._fields, ("num", "num_dup"))
+        self.assertEqual((row.num, row.num_dup), (72, 72))
 
 
 class QuerySetSupportsPythonIdioms(TestCase):


### PR DESCRIPTION
## Summary
Prune redundant RESULT COLUMNS from `QuerySet.extra(select=...)` when aggregation is present. Extras that compile to an equivalent `(sql, params)` as existing SELECT entries are deduped, while aliases still map to the underlying column index.

Reference: swev-id: django__django-15741

## Implementation
- Reworked `django/db/models/sql/compiler.py:get_select()` to dedupe extra-selected expressions under aggregation.
- Added alias → index remapping so `values()/values_list(named=True)` expose aliases without duplicating physical columns.
- Left `GROUP BY` logic intact; reduced SELECT entries naturally decrease noise; grouping remains correct.

## Reproduction Steps (pre-fix)
Run from repo root before applying the fix:

```bash
PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite \
  .venv/bin/python tests/runtests.py \
  queries.tests.ValuesQuerysetTests --parallel=1
```

These tests exercise duplicate-equivalent extras and alias collisions under aggregation.

## Observed Failure (pre-fix stack trace/output)
```
Creating test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
Found 21 test(s).
System check identified no issues (1 silenced).
EF...................
======================================================================
ERROR: test_extra_alias_collision_maps_existing_column (queries.tests.ValuesQuerysetTests.test_extra_alias_collision_maps_existing_column)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/queries/tests.py", line 2803, in test_extra_alias_collision_maps_existing_column
    base_index = next(
                 ^^^^^
StopIteration

======================================================================
FAIL: test_extra_duplicate_select_pruned_with_aggregation (queries.tests.ValuesQuerysetTests.test_extra_duplicate_select_pruned_with_aggregation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/queries/tests.py", line 2786, in test_extra_duplicate_select_pruned_with_aggregation
    self.assertEqual(annotations["num_dup"], base_index)
AssertionError: 0 != 1

----------------------------------------------------------------------
Ran 21 tests in 0.008s

FAILED (failures=1, errors=1)
Destroying test database for alias 'default'...
```

## Post-fix Testing
Executed locally (no CI runs triggered):
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py queries.tests.ValuesQuerysetTests --parallel=1` — 21 passed.
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py queries --parallel=1` — 462 passed, 9 skipped, 2 expected failures.

## Notes
- Base branch: `django__django-15741`.
- Title contains required token.
- No CI was manually triggered.