### PR TITLE
swev-id: django__django-15814 — Fix admin save crash with SimpleLazyObject and nested Subquery FK annotation

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -10,7 +10,7 @@ from django.db.models.lookups import (
     LessThanOrEqual,
 )
 from django.utils.deprecation import RemovedInDjango50Warning
-from django.utils.functional import LazyObject
+from django.utils.functional import LazyObject, empty
 
 
 class MultiColSource:
@@ -44,8 +44,9 @@ def get_normalized_value(value, lhs):
     from django.db.models import Model
 
     if isinstance(value, LazyObject):
-        value._setup()
-        value = getattr(value, "_wrapped", value)
+        if getattr(value, "_wrapped", empty) is empty:
+            value._setup()
+        value = value._wrapped
 
     if isinstance(value, Model):
         if value.pk is None:

--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -10,6 +10,7 @@ from django.db.models.lookups import (
     LessThanOrEqual,
 )
 from django.utils.deprecation import RemovedInDjango50Warning
+from django.utils.functional import LazyObject
 
 
 class MultiColSource:
@@ -41,6 +42,10 @@ class MultiColSource:
 
 def get_normalized_value(value, lhs):
     from django.db.models import Model
+
+    if isinstance(value, LazyObject):
+        value._setup()
+        value = getattr(value, "_wrapped", value)
 
     if isinstance(value, Model):
         if value.pk is None:

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -13,7 +13,7 @@ from django.db.models.fields import (
 )
 from django.db.models.query_utils import RegisterLookupMixin
 from django.utils.datastructures import OrderedSet
-from django.utils.functional import cached_property
+from django.utils.functional import LazyObject, cached_property
 from django.utils.hashable import make_hashable
 
 
@@ -80,12 +80,28 @@ class Lookup(Expression):
     def get_prep_lookup(self):
         if not self.prepare_rhs or hasattr(self.rhs, "resolve_expression"):
             return self.rhs
-        if hasattr(self.lhs, "output_field"):
-            if hasattr(self.lhs.output_field, "get_prep_value"):
-                return self.lhs.output_field.get_prep_value(self.rhs)
-        elif self.rhs_is_direct_value():
-            return Value(self.rhs)
-        return self.rhs
+        rhs = self.rhs
+        if isinstance(rhs, LazyObject):
+            rhs._setup()
+            rhs = getattr(rhs, "_wrapped", rhs)
+        try:
+            from django.db.models import Model
+        except ImportError:  # pragma: no cover - defensive during app loading
+            Model = None
+        output_field = getattr(self.lhs, "output_field", None)
+        if (
+            Model is not None
+            and isinstance(rhs, Model)
+            and isinstance(output_field, Field)
+            and not getattr(output_field, "many_to_many", False)
+        ):
+            rhs = rhs.pk
+        self.rhs = rhs
+        if output_field is not None and hasattr(output_field, "get_prep_value"):
+            return output_field.get_prep_value(rhs)
+        if self.rhs_is_direct_value():
+            return Value(rhs)
+        return rhs
 
     def get_prep_lhs(self):
         if hasattr(self.lhs, "resolve_expression"):

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -13,7 +13,7 @@ from django.db.models.fields import (
 )
 from django.db.models.query_utils import RegisterLookupMixin
 from django.utils.datastructures import OrderedSet
-from django.utils.functional import LazyObject, cached_property
+from django.utils.functional import LazyObject, cached_property, empty
 from django.utils.hashable import make_hashable
 
 
@@ -82,8 +82,9 @@ class Lookup(Expression):
             return self.rhs
         rhs = self.rhs
         if isinstance(rhs, LazyObject):
-            rhs._setup()
-            rhs = getattr(rhs, "_wrapped", rhs)
+            if getattr(rhs, "_wrapped", empty) is empty:
+                rhs._setup()
+            rhs = rhs._wrapped
         try:
             from django.db.models import Model
         except ImportError:  # pragma: no cover - defensive during app loading

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -259,7 +259,13 @@ class Query(BaseExpression):
     def output_field(self):
         if len(self.select) == 1:
             select = self.select[0]
-            return getattr(select, "target", None) or select.field
+            output_field = getattr(select, "output_field", None)
+            if output_field is not None:
+                return output_field
+            target = getattr(select, "target", None)
+            if target is not None:
+                return target
+            return getattr(select, "field", None)
         elif len(self.annotation_select) == 1:
             return next(iter(self.annotation_select.values())).output_field
 

--- a/tests/expressions/test_lazy_subquery_fk.py
+++ b/tests/expressions/test_lazy_subquery_fk.py
@@ -1,0 +1,70 @@
+import sys
+import types
+
+from django.db import connection, models
+from django.db.models import OuterRef, Subquery
+from django.test import TransactionTestCase
+from django.test.utils import isolate_apps
+from django.utils.functional import SimpleLazyObject
+
+
+class LazyObjectNestedSubqueryFKTests(TransactionTestCase):
+    databases = {"default"}
+    available_apps = None
+
+    def test_lazy_object_nested_subquery_foreign_key(self):
+        module_name = "expressions_tests"
+        module = types.ModuleType(module_name)
+        module.__file__ = __file__
+        sys.modules[module_name] = module
+        self.addCleanup(lambda: sys.modules.pop(module_name, None))
+
+        with isolate_apps(module_name):
+
+            class Employee(models.Model):
+                name = models.CharField(max_length=100)
+
+                class Meta:
+                    app_label = "expressions_tests"
+
+            class Company(models.Model):
+                name = models.CharField(max_length=100)
+                ceo = models.ForeignKey(Employee, on_delete=models.CASCADE)
+
+                class Meta:
+                    app_label = "expressions_tests"
+
+            with connection.schema_editor() as editor:
+                editor.create_model(Employee)
+                editor.create_model(Company)
+
+            def cleanup():
+                with connection.schema_editor() as editor:
+                    editor.delete_model(Company)
+                    editor.delete_model(Employee)
+
+            self.addCleanup(cleanup)
+
+            ceo = Employee.objects.create(name="Alice")
+            company = Company.objects.create(name="ACME", ceo=ceo)
+
+            lazy_ceo = SimpleLazyObject(lambda: Employee.objects.get(pk=ceo.pk))
+
+            inner_ceo = Subquery(
+                Company.objects.filter(pk=OuterRef("pk")).values("ceo")[:1]
+            )
+            nested_ceo = Subquery(
+                Company.objects.filter(pk=OuterRef("pk"))
+                .annotate(inner=inner_ceo)
+                .values("inner")[:1]
+            )
+
+            qs = Company.objects.annotate(nested_ceo=nested_ceo).filter(
+                nested_ceo=lazy_ceo
+            )
+
+            self.assertEqual(list(qs), [company])
+            self.assertIs(
+                qs.query.annotations["nested_ceo"].output_field,
+                Employee._meta.get_field("id"),
+            )


### PR DESCRIPTION
Issue: Admin form save fails when SimpleLazyObject wraps user and nested subquery annotation targets output_field.

Description
Admin form save() crashes if request.user is a SimpleLazyObject and a nested subquery annotation uses output_field targeting lazy attributes. Fix is to unwrap SimpleLazyObject for permission checks and align subquery output_field materialization.

Observed failure & stack trace
See attached reproduction; TypeError occurs:

$(cat /workspace/django/repro_stacktrace.txt)

Reproduction steps
- Run `python repro_lazy_subquery_fk.py`
- It sets up in-memory sqlite, dynamic Employee/Company models, creates fixtures, builds nested Subquery selecting the FK, and filters with `SimpleLazyObject(Employee)`.

Fix summary
- Preserve expression.output_field for single-select query output to maintain ForeignKey-aware lookups in nested Subquery annotations.
- Unwrap LazyObject in related lookups normalization and generic lookup path to prevent `int(SimpleLazyObject)` TypeErrors; coerce Model RHS to pk when appropriate.

Risks/regression considerations
- LazyObject evaluation during filter construction is acceptable. Fallbacks keep output_field behavior stable for non-expression selects. Tested locally with provided repro.