### PR TITLE
Fix floatformat Decimal precision (swev-id: django__django-15863)

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -151,7 +151,7 @@ def floatformat(text, arg=-1):
             use_l10n = False
             arg = arg[:-1] or -1
     try:
-        input_val = repr(text)
+        input_val = str(text)
         d = Decimal(input_val)
     except InvalidOperation:
         try:

--- a/tests/template_tests/filter_tests/test_floatformat.py
+++ b/tests/template_tests/filter_tests/test_floatformat.py
@@ -74,6 +74,14 @@ class FunctionTests(SimpleTestCase):
         self.assertEqual(floatformat(1.5e-15, -20), "0.00000000000000150000")
         self.assertEqual(floatformat(1.00000000000000015, 16), "1.0000000000000002")
 
+    def test_decimal_precision_preserved(self):
+        high_precision = Decimal("42.12345678901234567890")
+        self.assertEqual(floatformat(high_precision, 20), "42.12345678901234567890")
+        extended_precision = Decimal("0.1234567890123456789012345")
+        self.assertEqual(
+            floatformat(extended_precision, 25), "0.1234567890123456789012345"
+        )
+
     def test_force_grouping(self):
         with translation.override("en"):
             self.assertEqual(floatformat(10000, "g"), "10,000")


### PR DESCRIPTION
## Summary
Preserve precision for Decimal inputs in `floatformat` by avoiding float conversion.

Change:
- In `django/template/defaultfilters.py`, replace `input_val = repr(text)` with `input_val = str(text)` before `Decimal(input_val)`.
- Add regression tests for high-precision Decimal values.

Upstream reference: https://github.com/django/django/pull/15863
Issue: https://github.com/agyn-sandbox/django/issues/358

## Reproduction Steps
Run the following minimal example:

```python
from decimal import Decimal
from django import setup
from django.conf import settings
from django.template import Template, Context

TEMPLATES = [
    {
        'BACKEND': 'django.template.backends.django.DjangoTemplates',
    },
]
settings.configure(TEMPLATES=TEMPLATES)
setup()

t = Template('{{ value|floatformat:20 }}')
c = Context({'value': Decimal('42.12345678901234567890')})
print(t.render(c))  # Before fix: 42.12345678901234400000
```

## Observed Failure
- Precision drops when formatting high-precision Decimal values, e.g., `42.12345678901234567890` with `floatformat:20` yields `42.12345678901234400000`. Root cause is the float conversion fallback triggered by parsing `repr(Decimal(...))`.

## Stack Trace
- None. This is a correctness bug (precision loss), not an exception.

## Tests
- Added `test_decimal_precision_preserved` in `tests/template_tests/filter_tests/test_floatformat.py` to assert precision is preserved.

## Notes
- Base branch: `django__django-15863`. No direct changes to the base branch.
- CI: Not manually triggered; local tests for `template_tests.filter_tests.test_floatformat` pass.

swev-id: django__django-15863