### PR TITLE
fix(forms): honor Meta formfield callback defaults (swev-id: django__django-15916)

### DIFF
--- a/django/contrib/contenttypes/forms.py
+++ b/django/contrib/contenttypes/forms.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.forms import ModelForm, modelformset_factory
-from django.forms.models import BaseModelFormSet
+from django.forms.models import BaseModelFormSet, _DEFAULT
 
 
 class BaseGenericInlineFormSet(BaseModelFormSet):
@@ -86,7 +86,7 @@ def generic_inlineformset_factory(
     can_order=False,
     can_delete=True,
     max_num=None,
-    formfield_callback=None,
+    formfield_callback=_DEFAULT,
     validate_max=False,
     for_concrete_model=True,
     min_num=None,

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -41,6 +41,8 @@ __all__ = (
 
 ALL_FIELDS = "__all__"
 
+_DEFAULT = object()
+
 
 def construct_instance(form, instance, fields=None, exclude=None):
     """
@@ -565,7 +567,7 @@ def modelform_factory(
     form=ModelForm,
     fields=None,
     exclude=None,
-    formfield_callback=None,
+    formfield_callback=_DEFAULT,
     widgets=None,
     localized_fields=None,
     labels=None,
@@ -630,14 +632,14 @@ def modelform_factory(
     # creating needs to inherit from the parent's inner meta.
     bases = (form.Meta,) if hasattr(form, "Meta") else ()
     Meta = type("Meta", bases, attrs)
-    if formfield_callback is not None:
+    if callable(formfield_callback):
         Meta.formfield_callback = staticmethod(formfield_callback)
     # Give this new form class a reasonable name.
     class_name = model.__name__ + "Form"
 
     # Class attributes for the new form class.
     form_class_attrs = {"Meta": Meta}
-    if formfield_callback is not None:
+    if formfield_callback is not _DEFAULT:
         form_class_attrs["formfield_callback"] = formfield_callback
 
     if getattr(Meta, "fields", None) is None and getattr(Meta, "exclude", None) is None:
@@ -1008,7 +1010,7 @@ class BaseModelFormSet(BaseFormSet):
 def modelformset_factory(
     model,
     form=ModelForm,
-    formfield_callback=None,
+    formfield_callback=_DEFAULT,
     formset=BaseModelFormSet,
     extra=1,
     can_delete=False,
@@ -1278,7 +1280,7 @@ def inlineformset_factory(
     can_order=False,
     can_delete=True,
     max_num=None,
-    formfield_callback=None,
+    formfield_callback=_DEFAULT,
     widgets=None,
     validate_max=False,
     localized_fields=None,

--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -630,13 +630,15 @@ def modelform_factory(
     # creating needs to inherit from the parent's inner meta.
     bases = (form.Meta,) if hasattr(form, "Meta") else ()
     Meta = type("Meta", bases, attrs)
-    if formfield_callback:
+    if formfield_callback is not None:
         Meta.formfield_callback = staticmethod(formfield_callback)
     # Give this new form class a reasonable name.
     class_name = model.__name__ + "Form"
 
     # Class attributes for the new form class.
-    form_class_attrs = {"Meta": Meta, "formfield_callback": formfield_callback}
+    form_class_attrs = {"Meta": Meta}
+    if formfield_callback is not None:
+        form_class_attrs["formfield_callback"] = formfield_callback
 
     if getattr(Meta, "fields", None) is None and getattr(Meta, "exclude", None) is None:
         raise ImproperlyConfigured(

--- a/docs/ref/forms/models.txt
+++ b/docs/ref/forms/models.txt
@@ -27,6 +27,13 @@ Model Form API reference. For introductory material about model forms, see the
     ``formfield_callback`` is a callable that takes a model field and returns
     a form field.
 
+    .. note::
+
+        If the supplied ``form`` defines ``Meta.formfield_callback`` and you
+        omit the ``formfield_callback`` argument, that callback is used.
+        Pass ``formfield_callback=None`` to suppress the ``Meta`` callback and
+        fall back to Django's default conversion.
+
     ``widgets`` is a dictionary of model field names mapped to a widget.
 
     ``localized_fields`` is a list of names of fields which should be localized.
@@ -61,6 +68,13 @@ Model Form API reference. For introductory material about model forms, see the
     ``help_texts``, ``error_messages``, and ``field_classes`` are all passed
     through to :func:`~django.forms.models.modelform_factory`.
 
+    .. note::
+
+        When the supplied ``form`` defines ``Meta.formfield_callback`` and you
+        omit this argument, that callback is used for every model field. Pass
+        ``formfield_callback=None`` to prevent inheriting the ``Meta`` callback
+        and use Django's default conversion.
+
     Arguments ``formset``, ``extra``, ``can_delete``, ``can_order``,
     ``max_num``, ``validate_max``, ``min_num``, ``validate_min``,
     ``absolute_max``, ``can_delete_extra``, and ``renderer`` are passed
@@ -84,6 +98,13 @@ Model Form API reference. For introductory material about model forms, see the
     Returns an ``InlineFormSet`` using :func:`modelformset_factory` with
     defaults of ``formset=``:class:`~django.forms.models.BaseInlineFormSet`,
     ``can_delete=True``, and ``extra=3``.
+
+    .. note::
+
+        If the inline form's ``Meta`` class defines ``formfield_callback`` and
+        you leave this argument unset, that callback is used. Provide
+        ``formfield_callback=None`` to disable it and fall back to default
+        model field handling.
 
     If your model has more than one :class:`~django.db.models.ForeignKey` to
     the ``parent_model``, you must specify a ``fk_name``.

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -19,6 +19,7 @@ from django.forms.models import (
     fields_for_model,
     model_to_dict,
     modelform_factory,
+    modelformset_factory,
 )
 from django.template import Context, Template
 from django.test import SimpleTestCase, TestCase, skipUnlessDBFeature
@@ -3495,6 +3496,120 @@ class FormFieldCallbackTests(SimpleTestCase):
                 type(InheritedForm.base_fields[name].widget),
                 type(NewForm.base_fields[name].widget),
             )
+
+    def test_modelform_factory_honors_meta_formfield_callback(self):
+        callback_calls = []
+
+        def require_all_fields(db_field, **kwargs):
+            formfield = db_field.formfield(**kwargs)
+            if formfield is not None:
+                callback_calls.append(db_field.name)
+                formfield.required = True
+            return formfield
+
+        class MetaCallbackForm(forms.ModelForm):
+            class Meta:
+                model = Document
+                fields = "__all__"
+                formfield_callback = staticmethod(require_all_fields)
+
+        callback_calls.clear()
+
+        FactoryForm = modelform_factory(Document, form=MetaCallbackForm)
+        self.assertEqual(callback_calls, ["myfile"])
+        self.assertTrue(FactoryForm.base_fields["myfile"].required)
+
+    def test_modelform_factory_kwarg_overrides_meta_formfield_callback(self):
+        meta_calls = []
+        kwarg_calls = []
+
+        def meta_callback(db_field, **kwargs):
+            formfield = db_field.formfield(**kwargs)
+            if formfield is not None:
+                meta_calls.append(db_field.name)
+                formfield.required = True
+            return formfield
+
+        def override_callback(db_field, **kwargs):
+            formfield = db_field.formfield(**kwargs)
+            if formfield is not None:
+                kwarg_calls.append(db_field.name)
+                formfield.required = False
+            return formfield
+
+        class MetaCallbackForm(forms.ModelForm):
+            class Meta:
+                model = Document
+                fields = "__all__"
+                formfield_callback = staticmethod(meta_callback)
+
+        meta_calls.clear()
+        kwarg_calls.clear()
+
+        FactoryForm = modelform_factory(
+            Document,
+            form=MetaCallbackForm,
+            formfield_callback=override_callback,
+        )
+        self.assertEqual(meta_calls, [])
+        self.assertEqual(kwarg_calls, ["myfile"])
+        self.assertFalse(FactoryForm.base_fields["myfile"].required)
+
+    def test_modelform_factory_no_callback_uses_default_formfield(self):
+        class NoCallbackForm(forms.ModelForm):
+            class Meta:
+                model = Document
+                fields = "__all__"
+
+        FactoryForm = modelform_factory(Document, form=NoCallbackForm)
+        self.assertFalse(FactoryForm.base_fields["myfile"].required)
+
+    @isolate_apps("model_forms")
+    def test_formfield_callback_invocation_count_blank_null_fields(self):
+        callback_calls = []
+
+        class CallbackModel(models.Model):
+            active = models.BooleanField()
+            name = models.CharField(max_length=64, blank=True, null=True)
+
+        def record_callback(db_field, **kwargs):
+            formfield = db_field.formfield(**kwargs)
+            if formfield is not None:
+                callback_calls.append(db_field.name)
+            return formfield
+
+        class MetaCallbackForm(forms.ModelForm):
+            class Meta:
+                model = CallbackModel
+                fields = ["active", "name"]
+                formfield_callback = staticmethod(record_callback)
+
+        callback_calls.clear()
+
+        modelform_factory(CallbackModel, form=MetaCallbackForm)
+        self.assertEqual(callback_calls, ["active", "name"])
+
+    def test_modelformset_factory_honors_meta_formfield_callback(self):
+        callback_calls = []
+
+        def require_all_fields(db_field, **kwargs):
+            formfield = db_field.formfield(**kwargs)
+            if formfield is not None:
+                callback_calls.append(db_field.name)
+                formfield.required = True
+            return formfield
+
+        class MetaCallbackForm(forms.ModelForm):
+            class Meta:
+                model = Document
+                fields = "__all__"
+                formfield_callback = staticmethod(require_all_fields)
+
+        callback_calls.clear()
+
+        FormSet = modelformset_factory(Document, form=MetaCallbackForm, extra=0)
+        self.assertEqual(callback_calls, ["myfile"])
+        self.assertTrue(FormSet.form.base_fields["myfile"].required)
 
 
 class LocalizedModelFormTest(TestCase):

--- a/tests/model_forms/tests.py
+++ b/tests/model_forms/tests.py
@@ -3564,6 +3564,32 @@ class FormFieldCallbackTests(SimpleTestCase):
         FactoryForm = modelform_factory(Document, form=NoCallbackForm)
         self.assertFalse(FactoryForm.base_fields["myfile"].required)
 
+    def test_modelform_factory_explicit_none_suppresses_meta_callback(self):
+        meta_calls = []
+
+        def meta_callback(db_field, **kwargs):
+            formfield = db_field.formfield(**kwargs)
+            if formfield is not None:
+                meta_calls.append(db_field.name)
+                formfield.required = True
+            return formfield
+
+        class MetaCallbackForm(forms.ModelForm):
+            class Meta:
+                model = Document
+                fields = "__all__"
+                formfield_callback = staticmethod(meta_callback)
+
+        meta_calls.clear()
+
+        FactoryForm = modelform_factory(
+            Document,
+            form=MetaCallbackForm,
+            formfield_callback=None,
+        )
+        self.assertEqual(meta_calls, [])
+        self.assertFalse(FactoryForm.base_fields["myfile"].required)
+
     @isolate_apps("model_forms")
     def test_formfield_callback_invocation_count_blank_null_fields(self):
         callback_calls = []

--- a/tests/model_formsets_regress/tests.py
+++ b/tests/model_formsets_regress/tests.py
@@ -401,6 +401,26 @@ class FormfieldCallbackTests(TestCase):
         modelformset_factory(UserSite, form=UserSiteForm, formfield_callback=callback)
         self.assertCallbackCalled(callback)
 
+    def test_modelformset_factory_explicit_none_suppresses_meta_callback(self):
+        callback_calls = []
+
+        def meta_callback(db_field, **kwargs):
+            formfield = db_field.formfield(**kwargs)
+            if formfield is not None:
+                callback_calls.append(db_field.name)
+            return formfield
+
+        class MetaCallbackForm(UserSiteForm):
+            class Meta(UserSiteForm.Meta):
+                formfield_callback = staticmethod(meta_callback)
+
+        modelformset_factory(
+            UserSite,
+            form=MetaCallbackForm,
+            formfield_callback=None,
+        )
+        self.assertEqual(callback_calls, [])
+
 
 class BaseCustomDeleteFormSet(BaseFormSet):
     """


### PR DESCRIPTION
## Summary
- honor `Meta.formfield_callback` when `forms.modelform_factory()` is called without an explicit `formfield_callback`
- ensure `modelformset_factory()` inherits the same behavior and add regression coverage for default, override, and invocation counts
- adjust tests to assert callback precedence and default fallbacks

## Reproduction
1. Checkout `django__django-15916`.
2. Apply the test changes from this PR.
3. Run:
   ```
   PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py model_forms.tests.FormFieldCallbackTests --parallel=1
   ```

## Observed Failure (pre-fix)
```
....F.F....F
======================================================================
FAIL: test_formfield_callback_invocation_count_blank_null_fields (model_forms.tests.FormFieldCallbackTests.test_formfield_callback_invocation_count_blank_null_fields)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/tests.py", line 3590, in test_formfield_callback_invocation_count_blank_null_fields
    self.assertEqual(callback_calls, ["active", "name"])
AssertionError: Lists differ: [] != ['active', 'name']

======================================================================
FAIL: test_modelform_factory_honors_meta_formfield_callback (model_forms.tests.FormFieldCallbackTests.test_modelform_factory_honors_meta_formfield_callback)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/tests.py", line 3519, in test_modelform_factory_honors_meta_formfield_callback
    self.assertEqual(callback_calls, ["myfile"])
AssertionError: Lists differ: [] != ['myfile']

======================================================================
FAIL: test_modelformset_factory_honors_meta_formfield_callback (model_forms.tests.FormFieldCallbackTests.test_modelformset_factory_honors_meta_formfield_callback)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/model_forms/tests.py", line 3611, in test_modelformset_factory_honors_meta_formfield_callback
    self.assertEqual(callback_calls, ["myfile"])
AssertionError: Lists differ: [] != ['myfile']
```

## Testing
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py model_forms.tests.FormFieldCallbackTests --parallel=1`
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py model_forms --parallel=1`
- `.venv/bin/flake8 django/forms/models.py tests/model_forms/tests.py`

## Notes
- Explicit `formfield_callback` kwargs continue to take precedence over `Meta.formfield_callback`.
- ModelFormSets (and InlineFormSets via delegation) now inherit `Meta.formfield_callback` when the kwarg is omitted, matching ModelForm behavior.
- No backward incompatibilities for callers that relied on passing `None`; existing defaults still apply.

Closes #359.