### PR TITLE
swev-id: django__django-15930 Fix Case(When) for negated empty IN

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1299,6 +1299,10 @@ class When(Expression):
         template_params = extra_context
         sql_params = []
         condition_sql, condition_params = compiler.compile(self.condition)
+        if not condition_sql:
+            from django.db.models.lookups import Exact
+
+            condition_sql, condition_params = compiler.compile(Exact(1, 1))
         template_params["condition"] = condition_sql
         sql_params.extend(condition_params)
         result_sql, result_params = compiler.compile(self.result)

--- a/tests/expressions_case/tests.py
+++ b/tests/expressions_case/tests.py
@@ -218,6 +218,21 @@ class CaseExpressionTests(TestCase):
             transform=attrgetter("integer", "join_test"),
         )
 
+    def test_negated_empty_in_condition(self):
+        queryset = CaseTestModel.objects.annotate(
+            always_true=Case(
+                When(~Q(pk__in=[]), then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField(),
+            )
+        ).order_by("pk")
+        compiled_sql = str(queryset.query)
+        self.assertIn("CASE WHEN", compiled_sql)
+        self.assertNotIn("CASE WHEN  THEN", compiled_sql)
+        values = list(queryset.values_list("always_true", flat=True))
+        self.assertTrue(values)
+        self.assertTrue(all(values))
+
     def test_annotate_with_annotation_in_value(self):
         self.assertQuerysetEqual(
             CaseTestModel.objects.annotate(


### PR DESCRIPTION
## Summary
- replace empty When condition SQL with an Exact(1, 1) tautology during compilation
- add regression coverage for Case with ~Q(pk__in=[]) to ensure valid SQL and results

Fixes #362

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py expressions_case --parallel=1