### PR TITLE
fix: swev-id: django__django-15957 disallow sliced Prefetch querysets

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -2155,6 +2155,16 @@ class Prefetch:
             raise ValueError(
                 "Prefetch querysets cannot use raw(), values(), and values_list()."
             )
+        if (
+            queryset is not None
+            and hasattr(queryset, "query")
+            and queryset.query.is_sliced
+        ):
+            raise ValueError(
+                "Prefetch querysets cannot be sliced (limit/offset). Use an "
+                "unsliced queryset and apply limits via window functions, "
+                "Subquery/OuterRef per parent, or slice in-memory via to_attr."
+            )
         if to_attr:
             self.prefetch_to = LOOKUP_SEP.join(
                 lookup.split(LOOKUP_SEP)[:-1] + [to_attr]

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -1116,6 +1116,14 @@ must be restricted to a homogeneous set of results. For example, prefetching
 objects referenced by a ``GenericForeignKey`` is only supported if the query
 is restricted to one ``ContentType``.
 
+.. warning::
+
+    Prefetch querysets cannot be sliced (limit/offset). Use an unsliced
+    queryset and apply limits via window functions,
+    :class:`~django.db.models.Subquery`/:class:`~django.db.models.OuterRef`
+    per parent, or slice in-memory via :class:`~django.db.models.Prefetch`'s
+    ``to_attr``.
+
 For example, suppose you have these models::
 
     from django.db import models
@@ -4006,6 +4014,14 @@ relation, hence reducing the number of queries even further:
     >>> prefetch = Prefetch('choice_set', queryset=voted_choices)
     >>> Question.objects.prefetch_related(prefetch).get().choice_set.all()
     <QuerySet [<Choice: The sky>]>
+
+.. warning::
+
+    Prefetch querysets cannot be sliced (limit/offset). Use an unsliced
+    queryset and apply limits via window functions,
+    :class:`~django.db.models.Subquery`/:class:`~django.db.models.OuterRef`
+    per parent, or slice in-memory via :class:`~django.db.models.Prefetch`'s
+    ``to_attr``.
 
 The ``to_attr`` argument sets the result of the prefetch operation to a custom
 attribute:

--- a/docs/topics/db/optimization.txt
+++ b/docs/topics/db/optimization.txt
@@ -211,6 +211,31 @@ them:
 * in view code or other layers, possibly making use of
   :func:`~django.db.models.prefetch_related_objects` where needed.
 
+.. warning::
+
+    Prefetch querysets cannot be sliced (limit/offset). Use an unsliced
+    queryset and apply limits via window functions,
+    :class:`~django.db.models.Subquery`/:class:`~django.db.models.OuterRef`
+    per parent, or slice in-memory via :class:`~django.db.models.Prefetch`'s
+    ``to_attr``.
+
+For example, to prefetch the three newest comments per post without slicing::
+
+    from django.db.models import F, Prefetch, Window
+    from django.db.models.functions import RowNumber
+
+    top_comments = Comment.objects.annotate(
+        row_number=Window(
+            expression=RowNumber(),
+            partition_by=[F("post_id")],
+            order_by=[F("created_at").desc()],
+        )
+    ).filter(row_number__lte=3)
+
+    Post.objects.prefetch_related(
+        Prefetch("comments", queryset=top_comments, to_attr="top_comments"),
+    )
+
 Don't retrieve things you don't need
 ====================================
 

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1004,6 +1004,34 @@ class CustomPrefetchTests(TestCase):
         with self.assertRaisesMessage(ValueError, msg):
             Prefetch("houses", House.objects.raw("select pk from house"))
 
+    def test_prefetch_disallows_sliced_queryset_m2m(self):
+        msg = (
+            "Prefetch querysets cannot be sliced (limit/offset). Use an unsliced "
+            "queryset and apply limits via window functions, "
+            "Subquery/OuterRef per parent, or slice in-memory via to_attr."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Book.objects.prefetch_related(
+                Prefetch(
+                    "authors",
+                    queryset=Author.objects.order_by("name")[:2],
+                )
+            )
+
+    def test_prefetch_disallows_sliced_queryset_reverse_fk(self):
+        msg = (
+            "Prefetch querysets cannot be sliced (limit/offset). Use an unsliced "
+            "queryset and apply limits via window functions, "
+            "Subquery/OuterRef per parent, or slice in-memory via to_attr."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            Author.objects.prefetch_related(
+                Prefetch(
+                    "books",
+                    queryset=Book.objects.order_by("title")[:1],
+                )
+            )
+
     def test_to_attr_doesnt_cache_through_attr_as_list(self):
         house = House.objects.prefetch_related(
             Prefetch("rooms", queryset=Room.objects.all(), to_attr="to_rooms"),


### PR DESCRIPTION
## Summary
- raise a ValueError when Prefetch receives a sliced queryset
- document the slicing restriction and point to window/subquery alternatives
- add regression tests covering m2m and reverse fk Prefetch usage

## Testing
- PYTHONPATH=/workspace/django python3 tests/runtests.py prefetch_related --parallel=1

Closes #364