### PR TITLE
fix: ensure cross-app through dependencies (swev-id: django__django-15973)

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -12,6 +12,7 @@ from django.db.backends.ddl_references import (
     Table,
 )
 from django.db.backends.utils import names_digest, split_identifier
+from django.db.migrations.utils import resolve_relation
 from django.db.models import Deferrable, Index
 from django.db.models.sql import Query
 from django.db.transaction import TransactionManagementError, atomic
@@ -197,6 +198,16 @@ class BaseDatabaseSchemaEditor:
         else:
             with self.connection.cursor() as cursor:
                 cursor.execute(sql, params)
+
+    def _resolve_through_model(self, model, through):
+        if isinstance(through, str):
+            app_label, object_name = resolve_relation(
+                through,
+                model._meta.app_label,
+                model._meta.object_name,
+            )
+            return model._meta.apps.get_model(app_label, object_name)
+        return through
 
     def quote_name(self, name):
         return self.connection.ops.quote_name(name)
@@ -451,8 +462,7 @@ class BaseDatabaseSchemaEditor:
         # Make M2M tables
         for field in model._meta.local_many_to_many:
             through = field.remote_field.through
-            if isinstance(through, str):
-                through = model._meta.apps.get_model(through)
+            through = self._resolve_through_model(model, through)
             if through._meta.auto_created:
                 self.create_model(through)
 
@@ -461,8 +471,7 @@ class BaseDatabaseSchemaEditor:
         # Handle auto-created intermediary models
         for field in model._meta.local_many_to_many:
             through = field.remote_field.through
-            if isinstance(through, str):
-                through = model._meta.apps.get_model(through)
+            through = self._resolve_through_model(model, through)
             if through._meta.auto_created:
                 self.delete_model(through)
 
@@ -638,8 +647,7 @@ class BaseDatabaseSchemaEditor:
         # Special-case implicit M2M tables
         if field.many_to_many:
             through = field.remote_field.through
-            if isinstance(through, str):
-                through = model._meta.apps.get_model(through)
+            through = self._resolve_through_model(model, through)
             if through._meta.auto_created:
                 return self.create_model(through)
         # Get the column's definition
@@ -716,8 +724,7 @@ class BaseDatabaseSchemaEditor:
         # Special-case implicit M2M tables
         if field.many_to_many:
             through = field.remote_field.through
-            if isinstance(through, str):
-                through = model._meta.apps.get_model(through)
+            through = self._resolve_through_model(model, through)
             if through._meta.auto_created:
                 return self.delete_model(through)
         # It might not actually have a column behind it
@@ -756,12 +763,14 @@ class BaseDatabaseSchemaEditor:
             return
         if old_field.remote_field and getattr(old_field.remote_field, "through", None):
             old_through = old_field.remote_field.through
-            if isinstance(old_through, str):
-                old_field.remote_field.through = model._meta.apps.get_model(old_through)
+            old_field.remote_field.through = self._resolve_through_model(
+                model, old_through
+            )
         if new_field.remote_field and getattr(new_field.remote_field, "through", None):
             new_through = new_field.remote_field.through
-            if isinstance(new_through, str):
-                new_field.remote_field.through = model._meta.apps.get_model(new_through)
+            new_field.remote_field.through = self._resolve_through_model(
+                model, new_through
+            )
         # Ensure this field is even column-based
         old_db_params = old_field.db_parameters(connection=self.connection)
         old_type = old_db_params["type"]

--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -450,15 +450,21 @@ class BaseDatabaseSchemaEditor:
 
         # Make M2M tables
         for field in model._meta.local_many_to_many:
-            if field.remote_field.through._meta.auto_created:
-                self.create_model(field.remote_field.through)
+            through = field.remote_field.through
+            if isinstance(through, str):
+                through = model._meta.apps.get_model(through)
+            if through._meta.auto_created:
+                self.create_model(through)
 
     def delete_model(self, model):
         """Delete a model from the database."""
         # Handle auto-created intermediary models
         for field in model._meta.local_many_to_many:
-            if field.remote_field.through._meta.auto_created:
-                self.delete_model(field.remote_field.through)
+            through = field.remote_field.through
+            if isinstance(through, str):
+                through = model._meta.apps.get_model(through)
+            if through._meta.auto_created:
+                self.delete_model(through)
 
         # Delete the table
         self.execute(
@@ -630,8 +636,12 @@ class BaseDatabaseSchemaEditor:
         involve adding a table instead (for M2M fields).
         """
         # Special-case implicit M2M tables
-        if field.many_to_many and field.remote_field.through._meta.auto_created:
-            return self.create_model(field.remote_field.through)
+        if field.many_to_many:
+            through = field.remote_field.through
+            if isinstance(through, str):
+                through = model._meta.apps.get_model(through)
+            if through._meta.auto_created:
+                return self.create_model(through)
         # Get the column's definition
         definition, params = self.column_sql(model, field, include_default=True)
         # It might not actually have a column behind it
@@ -658,9 +668,9 @@ class BaseDatabaseSchemaEditor:
                 namespace, _ = split_identifier(model._meta.db_table)
                 definition += " " + self.sql_create_column_inline_fk % {
                     "name": self._fk_constraint_name(model, field, constraint_suffix),
-                    "namespace": "%s." % self.quote_name(namespace)
-                    if namespace
-                    else "",
+                    "namespace": (
+                        "%s." % self.quote_name(namespace) if namespace else ""
+                    ),
                     "column": self.quote_name(field.column),
                     "to_table": self.quote_name(to_table),
                     "to_column": self.quote_name(to_column),
@@ -704,8 +714,12 @@ class BaseDatabaseSchemaEditor:
         but for M2Ms may involve deleting a table.
         """
         # Special-case implicit M2M tables
-        if field.many_to_many and field.remote_field.through._meta.auto_created:
-            return self.delete_model(field.remote_field.through)
+        if field.many_to_many:
+            through = field.remote_field.through
+            if isinstance(through, str):
+                through = model._meta.apps.get_model(through)
+            if through._meta.auto_created:
+                return self.delete_model(through)
         # It might not actually have a column behind it
         if field.db_parameters(connection=self.connection)["type"] is None:
             return
@@ -740,6 +754,14 @@ class BaseDatabaseSchemaEditor:
         """
         if not self._field_should_be_altered(old_field, new_field):
             return
+        if old_field.remote_field and getattr(old_field.remote_field, "through", None):
+            old_through = old_field.remote_field.through
+            if isinstance(old_through, str):
+                old_field.remote_field.through = model._meta.apps.get_model(old_through)
+        if new_field.remote_field and getattr(new_field.remote_field, "through", None):
+            new_through = new_field.remote_field.through
+            if isinstance(new_through, str):
+                new_field.remote_field.through = model._meta.apps.get_model(new_through)
         # Ensure this field is even column-based
         old_db_params = old_field.db_parameters(connection=self.connection)
         old_type = old_db_params["type"]
@@ -1237,9 +1259,9 @@ class BaseDatabaseSchemaEditor:
             % {
                 "column": self.quote_name(new_field.column),
                 "type": new_type,
-                "collation": " " + self._collate_sql(new_collation)
-                if new_collation
-                else "",
+                "collation": (
+                    " " + self._collate_sql(new_collation) if new_collation else ""
+                ),
             },
             [],
         )

--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -570,11 +570,12 @@ class MigrationAutodetector:
                                 rem_model_state.app_label,
                                 rem_model_state.name_lower,
                             )
-                            self.renamed_models_rel[
-                                renamed_models_rel_key
-                            ] = "%s.%s" % (
-                                model_state.app_label,
-                                model_state.name_lower,
+                            self.renamed_models_rel[renamed_models_rel_key] = (
+                                "%s.%s"
+                                % (
+                                    model_state.app_label,
+                                    model_state.name_lower,
+                                )
                             )
                             self.old_model_keys.remove((rem_app_label, rem_model_name))
                             self.old_model_keys.add((app_label, model_name))
@@ -975,9 +976,9 @@ class MigrationAutodetector:
                                 (rem_app_label, rem_model_name, rem_field_name)
                             )
                             old_field_keys.add((app_label, model_name, field_name))
-                            self.renamed_fields[
-                                app_label, model_name, field_name
-                            ] = rem_field_name
+                            self.renamed_fields[app_label, model_name, field_name] = (
+                                rem_field_name
+                            )
                             break
 
     def generate_renamed_fields(self):
@@ -1420,9 +1421,12 @@ class MigrationAutodetector:
                 model_name,
             )
         dependencies = [(dep_app_label, dep_object_name, None, True)]
-        if getattr(field.remote_field, "through", None):
+        through_model = getattr(field.remote_field, "through", None)
+        if through_model and not (
+            hasattr(through_model, "_meta") and through_model._meta.auto_created
+        ):
             through_app_label, through_object_name = resolve_relation(
-                remote_field_model,
+                through_model,
                 app_label,
                 model_name,
             )

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -976,6 +976,34 @@ class AutodetectorTests(BaseAutodetectorTests):
             ("title", models.CharField(max_length=200)),
         ],
     )
+    cross_app_target = ModelState(
+        "app_b",
+        "Target",
+        [("id", models.AutoField(primary_key=True))],
+    )
+    cross_app_link = ModelState(
+        "app_c",
+        "Link",
+        [
+            ("id", models.AutoField(primary_key=True)),
+            ("source", models.ForeignKey("app_a.Source", models.CASCADE)),
+            ("target", models.ForeignKey("app_b.Target", models.CASCADE)),
+        ],
+    )
+    cross_app_source = ModelState(
+        "app_a",
+        "Source",
+        [
+            ("id", models.AutoField(primary_key=True)),
+            (
+                "targets",
+                models.ManyToManyField(
+                    "app_b.Target",
+                    through="app_c.Link",
+                ),
+            ),
+        ],
+    )
     book_indexes = ModelState(
         "otherapp",
         "Book",
@@ -3583,6 +3611,42 @@ class AutodetectorTests(BaseAutodetectorTests):
         self.assertOperationAttributes(changes, "testapp", 0, 2, name="Contract")
         self.assertOperationAttributes(
             changes, "testapp", 0, 3, model_name="author", name="publishers"
+        )
+
+    def test_cross_app_custom_through_dependency(self):
+        changes = self.get_changes(
+            [],
+            [
+                self.cross_app_source,
+                self.cross_app_target,
+                self.cross_app_link,
+            ],
+        )
+        self.assertNumberMigrations(changes, "app_a", 2)
+        self.assertOperationTypes(changes, "app_a", 0, ["CreateModel"])
+        self.assertOperationTypes(changes, "app_a", 1, ["AddField"])
+        self.assertMigrationDependencies(
+            changes,
+            "app_a",
+            1,
+            [
+                ("app_a", "auto_1"),
+                ("app_b", "auto_1"),
+                ("app_c", "auto_1"),
+            ],
+        )
+        self.assertNumberMigrations(changes, "app_b", 1)
+        self.assertOperationTypes(changes, "app_b", 0, ["CreateModel"])
+        self.assertNumberMigrations(changes, "app_c", 1)
+        self.assertOperationTypes(changes, "app_c", 0, ["CreateModel"])
+        self.assertMigrationDependencies(
+            changes,
+            "app_c",
+            0,
+            [
+                ("app_a", "auto_1"),
+                ("app_b", "auto_1"),
+            ],
         )
 
     def test_many_to_many_removed_before_through_model(self):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1651,6 +1651,59 @@ class OperationTests(OperationTestBase):
         ]
         self.apply_operations("test_rmflmmwt", project_state, operations=operations)
 
+    def test_add_field_m2m_with_relative_through(self):
+        app_label = "test_m2mrelthrough"
+        project_state = ProjectState()
+        project_state = self.apply_operations(
+            app_label,
+            project_state,
+            operations=[
+                migrations.CreateModel(
+                    "Source",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                    ],
+                ),
+                migrations.CreateModel(
+                    "Target",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                    ],
+                ),
+                migrations.CreateModel(
+                    "Link",
+                    fields=[
+                        ("id", models.AutoField(primary_key=True)),
+                        (
+                            "source",
+                            models.ForeignKey("Source", models.CASCADE),
+                        ),
+                        (
+                            "target",
+                            models.ForeignKey("Target", models.CASCADE),
+                        ),
+                    ],
+                ),
+                migrations.AddField(
+                    "Source",
+                    "targets",
+                    models.ManyToManyField("Target", through="Link"),
+                ),
+            ],
+        )
+        self.assertTableExists(f"{app_label}_link")
+        self.assertTableNotExists(f"{app_label}_source_targets")
+
+        project_state = self.apply_operations(
+            app_label,
+            project_state,
+            operations=[
+                migrations.RemoveField("Source", "targets"),
+                migrations.DeleteModel("Link"),
+            ],
+        )
+        self.assertTableNotExists(f"{app_label}_link")
+
     def test_remove_field(self):
         """
         Tests the RemoveField operation.


### PR DESCRIPTION
## Summary
- add migration autodetector dependency tracking for custom through models
- resolve string-based through references in schema editor helpers before touching _meta
- add regression coverage for cross-app many-to-many through ordering

## Observed Failure
- Error: `AttributeError: 'str' object has no attribute '_meta'` while running `migrate`.
- Stack trace excerpt:
  ```
  Applying fonte.0001_initial...Traceback (most recent call last):
    ...
    File "/.../django/db/backends/base/schema.py", line 453, in create_model
      if field.remote_field.through._meta.auto_created:
  AttributeError: 'str' object has no attribute '_meta'
  ```

## Reproduction Steps
1. Create apps `fonte`, `variavel`, and `fonte_variavel`.
2. Define `FonteModel` with `variaveis = ManyToManyField("variavel.VariavelModel", through="fonte_variavel.FonteVariavelModel")`.
3. Define `VariavelModel` in `variavel` and `FonteVariavelModel` with foreign keys to both models in `fonte_variavel`.
4. Run `makemigrations` (migration for `fonte` depends only on `variavel`).
5. Run `migrate` and observe the AttributeError above.

Fixes #366

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py migrations.test_autodetector --parallel=1
- .venv/bin/black --check django/db/migrations/autodetector.py django/db/backends/base/schema.py tests/migrations/test_autodetector.py