### PR TITLE
swev-id: django__django-16136 Fix: make http_method_not_allowed async-aware to avoid TypeError when awaiting HttpResponseNotAllowed

### DIFF
--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -148,9 +148,23 @@ class View:
             request.path,
             extra={"status_code": 405, "request": request},
         )
-        return HttpResponseNotAllowed(self._allowed_methods())
+        response = HttpResponseNotAllowed(self._allowed_methods())
 
-    def options(self, request, *args, **kwargs):
+        # If the view has async handlers, the callback returned by as_view()
+        # is marked as a coroutine and will be awaited. Ensure the response is
+        # delivered as an awaitable in that case, mirroring the behavior in
+        # options(). This avoids TypeError when dispatching to the sync
+        # http_method_not_allowed from an async view.
+        if self.view_is_async:
+
+            async def func():
+                return response
+
+            return func()
+        else:
+            return response
+
+    def options(self, request, *args, **kwargs):self, request, *args, **kwargs):
         """Handle responding to requests for the OPTIONS HTTP verb."""
         response = HttpResponse()
         response.headers["Allow"] = ", ".join(self._allowed_methods())

--- a/django/views/generic/base.py
+++ b/django/views/generic/base.py
@@ -164,7 +164,7 @@ class View:
         else:
             return response
 
-    def options(self, request, *args, **kwargs):self, request, *args, **kwargs):
+    def options(self, request, *args, **kwargs):
         """Handle responding to requests for the OPTIONS HTTP verb."""
         response = HttpResponse()
         response.headers["Allow"] = ", ".join(self._allowed_methods())

--- a/tests/async/tests.py
+++ b/tests/async/tests.py
@@ -73,6 +73,7 @@ class AsyncView(View):
     async def get(self, request, *args, **kwargs):
         return HttpResponse("Hello (async) world!")
 
+
 class AsyncPostOnlyView(View):
     async def post(self, request, *args, **kwargs):
         return HttpResponse("ok")
@@ -125,7 +126,7 @@ class ViewTests(SimpleTestCase):
 
     def test_http_method_not_allowed_responds_correctly(self):
         tests = [
-            (SyncView, False, "GET"),
+            (SyncView, False, "POST"),
             (AsyncPostOnlyView, True, "GET"),
         ]
         rf = RequestFactory()

--- a/tests/async/tests.py
+++ b/tests/async/tests.py
@@ -7,7 +7,7 @@ from asgiref.sync import async_to_sync
 from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from django.core.exceptions import ImproperlyConfigured, SynchronousOnlyOperation
 from django.http import HttpResponse
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, RequestFactory
 from django.utils.asyncio import async_unsafe
 from django.views.generic.base import View
 
@@ -73,6 +73,10 @@ class AsyncView(View):
     async def get(self, request, *args, **kwargs):
         return HttpResponse("Hello (async) world!")
 
+class AsyncPostOnlyView(View):
+    async def post(self, request, *args, **kwargs):
+        return HttpResponse("ok")
+
 
 class ViewTests(SimpleTestCase):
     def test_views_are_correctly_marked(self):
@@ -118,6 +122,22 @@ class ViewTests(SimpleTestCase):
                     response = asyncio.run(response)
 
                 self.assertIsInstance(response, HttpResponse)
+
+    def test_http_method_not_allowed_responds_correctly(self):
+        tests = [
+            (SyncView, False, "GET"),
+            (AsyncPostOnlyView, True, "GET"),
+        ]
+        rf = RequestFactory()
+        for view_cls, is_coroutine, method in tests:
+            with self.subTest(view_cls=view_cls, is_coroutine=is_coroutine):
+                instance = view_cls()
+                request = getattr(rf, method.lower())("/demo")
+                response = instance.dispatch(request)
+                self.assertIs(asyncio.iscoroutine(response), is_coroutine)
+                if is_coroutine:
+                    response = asyncio.run(response)
+                self.assertEqual(response.status_code, 405)
 
     def test_base_view_class_is_sync(self):
         """


### PR DESCRIPTION
Summary
- Adjust View.http_method_not_allowed() to return an awaitable when view_is_async is True, mirroring options(). This prevents TypeError: object HttpResponseNotAllowed can't be used in 'await' expression for async-only views receiving disallowed methods.
- Add regression test under tests/async verifying dispatch(GET) returns a coroutine for async-only views and resolves to 405.

Issue reference
- Addresses: https://github.com/agyn-sandbox/django/issues/374

Observed failure, stack trace, and reproduction steps
- See issue for full details. In brief:

```
[29/Sep/2022 07:50:48] "GET /demo HTTP/1.1" 500 81134
Method Not Allowed (GET): /demo
Internal Server Error: /demo
Traceback (most recent call last):
  ...
TypeError: object HttpResponseNotAllowed can't be used in 'await' expression
```

Repro:
1. Async-only view implementing `async def post()`
2. URL: path("demo", Demo.as_view())
3. GET /demo -> 500 with TypeError

Notes
- Regression in 9ffd4eae2ce7a7100c98f681e2b6ab818df384a4.
- Full ASGI lifecycle tests are feasible but not required; dispatch-level coverage aligns with existing tests.

Reference to this task: swev-id: django__django-16136