### PR TITLE
swev-id: django__django-16116 – Make makemigrations --check non-writing; align behavior

### DIFF
--- a/django/core/management/commands/makemigrations.py
+++ b/django/core/management/commands/makemigrations.py
@@ -111,6 +111,8 @@ class Command(BaseCommand):
             raise CommandError("The migration name must be a valid Python identifier.")
         self.include_header = options["include_header"]
         check_changes = options["check_changes"]
+        if check_changes:
+            self.dry_run = True
         self.scriptable = options["scriptable"]
         self.update = options["update"]
         # If logs and prompts are diverted to stderr, remove the ERROR style.

--- a/docs/man/django-admin.1
+++ b/docs/man/django-admin.1
@@ -1155,8 +1155,8 @@ Generate migration files without Django version and timestamp header.
 .B \-\-check
 .UNINDENT
 .sp
-Makes \fBmakemigrations\fP exit with a non\-zero status when model changes without
-migrations are detected.
+Runs \fBmakemigrations\fP in dry\-run mode and exits with a non\-zero status when
+model changes without migrations are detected.
 .INDENT 0.0
 .TP
 .B \-\-scriptable

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -822,8 +822,8 @@ Generate migration files without Django version and timestamp header.
 
 .. django-admin-option:: --check
 
-Makes ``makemigrations`` exit with a non-zero status when model changes without
-migrations are detected.
+Runs ``makemigrations`` in dry-run mode and exits with a non-zero status when
+model changes without migrations are detected.
 
 .. django-admin-option:: --scriptable
 

--- a/tests/migrations/test_commands.py
+++ b/tests/migrations/test_commands.py
@@ -1427,6 +1427,15 @@ class MakeMigrationsTests(MigrationTestBase):
     Tests running the makemigrations command.
     """
 
+    def _migration_file_names(self, path):
+        if not os.path.isdir(path):
+            return set()
+        return {
+            name
+            for name in os.listdir(path)
+            if name.endswith(".py") and name != "__init__.py"
+        }
+
     def setUp(self):
         super().setUp()
         self._old_models = apps.app_configs["migrations"].models.copy()
@@ -2391,14 +2400,41 @@ class MakeMigrationsTests(MigrationTestBase):
         makemigrations --check should exit with a non-zero status when
         there are changes to an app requiring migrations.
         """
-        with self.temporary_migration_module():
-            with self.assertRaises(SystemExit):
-                call_command("makemigrations", "--check", "migrations", verbosity=0)
+        with self.temporary_migration_module() as migration_dir:
+            initial_files = self._migration_file_names(migration_dir)
+            with self.assertRaises(SystemExit) as cm:
+                call_command(
+                    "makemigrations", "--check", "migrations", verbosity=0
+                )
+            self.assertEqual(cm.exception.code, 1)
+            self.assertEqual(
+                initial_files, self._migration_file_names(migration_dir)
+            )
 
         with self.temporary_migration_module(
             module="migrations.test_migrations_no_changes"
-        ):
+        ) as migration_dir:
+            initial_files = self._migration_file_names(migration_dir)
             call_command("makemigrations", "--check", "migrations", verbosity=0)
+            self.assertEqual(
+                initial_files, self._migration_file_names(migration_dir)
+            )
+
+    def test_makemigrations_check_does_not_write_files(self):
+        with self.temporary_migration_module() as migration_dir:
+            for name in self._migration_file_names(migration_dir):
+                os.remove(os.path.join(migration_dir, name))
+            pycache_path = os.path.join(migration_dir, "__pycache__")
+            if os.path.isdir(pycache_path):
+                shutil.rmtree(pycache_path)
+
+            self.assertEqual(self._migration_file_names(migration_dir), set())
+            with self.assertRaises(SystemExit) as cm:
+                call_command(
+                    "makemigrations", "--check", "migrations", verbosity=0
+                )
+            self.assertEqual(cm.exception.code, 1)
+            self.assertEqual(self._migration_file_names(migration_dir), set())
 
     def test_makemigrations_migration_path_output(self):
         """


### PR DESCRIPTION
## Issue Body
Task: Implement researcher’s specification so that `manage.py makemigrations --check` is non-writing (equivalent to dry-run), exiting with code 1 when changes would be made and 0 when none. Do not change the base branch directly; create a feature branch and open a PR targeting `django__django-16116`. Include the Issue body and research spec in the PR description. Avoid triggering CI; include `[skip ci]` in commit messages.

Scope:
1) Code change:
   - File: `django/core/management/commands/makemigrations.py`
   - In `Command.handle(self, *app_labels, **options)`, after reading options:
     - `self.dry_run = options["dry_run"]`
     - `check_changes = options["check_changes"]`
     - Add: `if check_changes: self.dry_run = True`
   - Preserve exit behavior: when changes exist, exit code 1; else 0.
2) Tests:
   - File: `tests/migrations/test_commands.py`
   - Update `test_makemigrations_check` to assert no files are created under `--check`.
   - Add `test_makemigrations_check_does_not_write_files` confirming non-writing under `--check` when changes exist (assert SystemExit 1 and empty migrations dir).
   - Optional: add test for `--check --update` non-writing exit.
3) Docs:
   - `docs/ref/django-admin.txt`: update `--check` description to clarify non-writing behavior.
   - `docs/man/django-admin.1`: update the `--check` section accordingly.

Reproduction and failure capture:
- Set up a minimal test project in the workspace using the current Django branch (e.g., `pip install -e .` inside the repo, or use PYTHONPATH).
- Create a simple app with a model to produce pending migrations.
- Run: `python manage.py makemigrations --check <app>` using the current (pre-fix) code.
- Record observed behavior: migration files are written (list the files and logs). Capture output and any trace; if no stack trace, report the log lines showing file creation.
- After implementing the fix, rerun the same command to show that no files are written and the exit code is 1 when changes exist.

## Research Spec
- Enforce `--check` as a dry-run regardless of explicit `--dry-run` usage.
- Guard against accidental file creation during `--check` execution.
- Extend regression coverage for the non-writing guarantee and exit codes.
- Document the behavior so admins know `--check` is safe to run in CI or guardrails.

## Summary
- Force `makemigrations --check` to reuse dry-run handling so no files are emitted.
- Extend `MakeMigrationsTests` to assert the directory contents remain unchanged under `--check` and add a regression for empty migration modules.
- Document the clarified behavior in both the admin reference and man page.

## Reproduction
### Baseline (buggy)
```
$ python manage.py makemigrations --check demoapp
Migrations for 'demoapp':
  demoapp/migrations/0002_item_description.py
    - Add field description to item

$ ls demoapp/migrations
0001_initial.py
0002_item_description.py
__init__.py
__pycache__
```

### Fixed
```
$ python manage.py makemigrations --check demoapp
Migrations for 'demoapp':
  demoapp/migrations/0002_item_description.py
    - Add field description to item

$ ls demoapp/migrations
0001_initial.py
__init__.py
__pycache__
```

- Both runs exit with status code 1 when pending changes are detected.
- After the fix, no new migration files are written.

## Testing
- `PYTHONPATH=/workspace/django/tests:/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.11 tests/runtests.py migrations.test_commands --parallel=1`
- `flake8 django/core/management/commands/makemigrations.py tests/migrations/test_commands.py`