### PR TITLE
swev-id: django__django-16032 - fix RHS select enforcement

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -90,10 +90,10 @@ class RelatedIn(In):
                         -1
                     ]
                     self.rhs = [target_field.get_prep_value(v) for v in self.rhs]
-            elif not getattr(self.rhs, "has_select_fields", True) and not getattr(
-                self.lhs.field.target_field, "primary_key", False
+            elif (
+                not getattr(self.rhs, "has_select_fields", True)
+                and not getattr(self.lhs.field.target_field, "primary_key", False)
             ):
-                self.rhs.clear_select_clause()
                 if (
                     getattr(self.lhs.output_field, "primary_key", False)
                     and self.lhs.output_field.model == self.rhs.model
@@ -105,7 +105,7 @@ class RelatedIn(In):
                     target_field = self.lhs.field.name
                 else:
                     target_field = self.lhs.field.target_field.name
-                self.rhs.add_fields([target_field], True)
+                self.rhs.set_values([target_field])
         return super().get_prep_lookup()
 
     def as_sql(self, compiler, connection):

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -331,8 +331,7 @@ class Exact(FieldGetDbPrepValueMixin, BuiltinLookup):
         if isinstance(self.rhs, Query):
             if self.rhs.has_limit_one():
                 if not self.rhs.has_select_fields:
-                    self.rhs.clear_select_clause()
-                    self.rhs.add_fields(["pk"])
+                    self.rhs.set_values(["pk"])
             else:
                 raise ValueError(
                     "The QuerySet value for an exact lookup must be limited to "
@@ -421,8 +420,7 @@ class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
         if isinstance(self.rhs, Query):
             self.rhs.clear_ordering(clear_default=True)
             if not self.rhs.has_select_fields:
-                self.rhs.clear_select_clause()
-                self.rhs.add_fields(["pk"])
+                self.rhs.set_values(["pk"])
         return super().get_prep_lookup()
 
     def process_rhs(self, compiler, connection):

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1814,6 +1814,7 @@ class SQLDeleteCompiler(SQLCompiler):
         innerq.clear_select_clause()
         pk = self.query.model._meta.pk
         innerq.select = [pk.get_col(self.query.get_initial_alias())]
+        innerq.has_select_fields = True
         outerq = Query(self.query.model)
         if not self.connection.features.update_can_self_select:
             # Force the materialization of the inner query to allow reference
@@ -1931,6 +1932,7 @@ class SQLUpdateCompiler(SQLCompiler):
         query.clear_ordering(force=True)
         query.extra = {}
         query.select = []
+        query.has_select_fields = False
         meta = query.get_meta()
         fields = [meta.pk.name]
         related_ids_index = []

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -254,6 +254,7 @@ class Query(BaseExpression):
         self.extra = {}  # Maps col_alias -> (col_sql, params).
 
         self._filtered_relations = {}
+        self.has_select_fields = False
 
     @property
     def output_field(self):
@@ -262,12 +263,6 @@ class Query(BaseExpression):
             return getattr(select, "target", None) or select.field
         elif len(self.annotation_select) == 1:
             return next(iter(self.annotation_select.values())).output_field
-
-    @property
-    def has_select_fields(self):
-        return bool(
-            self.select or self.annotation_select_mask or self.extra_select_mask
-        )
 
     @cached_property
     def base_table(self):
@@ -2096,6 +2091,7 @@ class Query(BaseExpression):
         self.select_related = False
         self.set_extra_mask(())
         self.set_annotation_mask(())
+        self.has_select_fields = False
 
     def clear_select_fields(self):
         """
@@ -2105,14 +2101,18 @@ class Query(BaseExpression):
         """
         self.select = ()
         self.values_select = ()
+        self.has_select_fields = False
 
     def add_select_col(self, col, name):
         self.select += (col,)
         self.values_select += (name,)
+        if self.select:
+            self.has_select_fields = True
 
     def set_select(self, cols):
         self.default_cols = False
         self.select = tuple(cols)
+        self.has_select_fields = bool(self.select)
 
     def add_distinct_fields(self, *field_names):
         """
@@ -2430,6 +2430,7 @@ class Query(BaseExpression):
 
         self.values_select = tuple(field_names)
         self.add_fields(field_names, True)
+        self.has_select_fields = True
 
     @property
     def annotation_select(self):

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -520,9 +520,11 @@ class Query(BaseExpression):
                 inner_query.select = (
                     self.model._meta.pk.get_col(inner_query.get_initial_alias()),
                 )
+                inner_query.has_select_fields = True
         else:
             outer_query = self
             self.select = ()
+            self.has_select_fields = False
             self.default_cols = False
             self.extra = {}
 
@@ -688,6 +690,7 @@ class Query(BaseExpression):
             self.set_select([col.relabeled_clone(change_map) for col in rhs.select])
         else:
             self.select = ()
+            self.has_select_fields = False
 
         if connector == OR:
             # It would be nice to be able to handle this, but the queries don't
@@ -2106,13 +2109,10 @@ class Query(BaseExpression):
     def add_select_col(self, col, name):
         self.select += (col,)
         self.values_select += (name,)
-        if self.select:
-            self.has_select_fields = True
 
     def set_select(self, cols):
         self.default_cols = False
         self.select = tuple(cols)
-        self.has_select_fields = bool(self.select)
 
     def add_distinct_fields(self, *field_names):
         """

--- a/tests/annotations/tests.py
+++ b/tests/annotations/tests.py
@@ -989,6 +989,27 @@ class NonAggregateAnnotationTestCase(TestCase):
             publisher_books_qs, [{"name": "Sams"}, {"name": "Morgan Kaufmann"}]
         )
 
+    def test_annotation_and_alias_filter_in_subquery(self):
+        long_books_qs = (
+            Book.objects.filter(
+                pages__gt=400,
+            )
+            .annotate(book_annotate=Value(1))
+            .alias(book_alias=Value(1))
+        )
+        publisher_books_qs = (
+            Publisher.objects.filter(book__in=long_books_qs).values("name")
+        )
+        self.assertCountEqual(
+            publisher_books_qs,
+            [
+                {"name": "Apress"},
+                {"name": "Sams"},
+                {"name": "Prentice Hall"},
+                {"name": "Morgan Kaufmann"},
+            ],
+        )
+
     def test_annotation_exists_aggregate_values_chaining(self):
         qs = (
             Book.objects.values("publisher")


### PR DESCRIPTION
## Summary
- convert Query.has_select_fields into a boolean attribute set via Query.set_values()
- route related and scalar lookups through Query.set_values() when enforcing pk selection on RHS subqueries
- add regression coverage for annotate()+alias() mixes filtered via book__in subquery on Publisher

## Reproduction
1. Checkout `django__django-16032`.
2. Apply the regression test added in this patch (`tests/annotations/tests.py::NonAggregateAnnotationTestCase.test_annotation_and_alias_filter_in_subquery`).
3. Run `PYTHONPATH=/workspace/django python tests/runtests.py annotations.tests.NonAggregateAnnotationTestCase.test_annotation_and_alias_filter_in_subquery --parallel=1`.

### Observed failure (pre-fix)
```
Creating test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
Found 1 test(s).
System check identified no issues (0 silenced).
E
======================================================================
ERROR: test_annotation_and_alias_filter_in_subquery (annotations.tests.NonAggregateAnnotationTestCase.test_annotation_and_alias_filter_in_subquery)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/backends/sqlite3/base.py", line 369, in execute
    return Database.Cursor.execute(self, query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: sub-select returns 10 columns - expected 1

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/workspace/django/tests/annotations/tests.py", line 1003, in test_annotation_and_alias_filter_in_subquery
    self.assertCountEqual(
  File "/root/.nix-profile/lib/python3.11/unittest/case.py", line 1215, in assertCountEqual
    first_seq, second_seq = list(first), list(second)
                            ^^^^^^^^^^^
  File "/workspace/django/django/db/models/query.py", line 394, in __iter__
    self._fetch_all()
  File "/workspace/django/django/db/models/query.py", line 1876, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/models/query.py", line 204, in __iter__
    for row in compiler.results_iter(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/models/sql/compiler.py", line 1427, in results_iter
    results = self.execute_sql(
              ^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/models/sql/compiler.py", line 1476, in execute_sql
    cursor.execute(sql, params)
  File "/workspace/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/workspace/django/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/workspace/django/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/db/backends/sqlite3/base.py", line 369, in execute
    return Database.Cursor.execute(self, query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.OperationalError: sub-select returns 10 columns - expected 1

----------------------------------------------------------------------
Ran 1 test in 0.008s

FAILED (errors=1)
Destroying test database for alias 'default'...
```

## Testing
- `PYTHONPATH=/workspace/django python tests/runtests.py annotations --parallel=1`
- `PYTHONPATH=/workspace/django python tests/runtests.py queries --parallel=1`
- `flake8 django/db/models/fields/related_lookups.py django/db/models/lookups.py django/db/models/sql/query.py tests/annotations/tests.py`

Fixes #379