### PR TITLE
swev-id: django__django-16145 display 0.0.0.0 in runserver banner

### DIFF
--- a/django/core/management/commands/runserver.py
+++ b/django/core/management/commands/runserver.py
@@ -137,6 +137,13 @@ class Command(BaseCommand):
         self.check_migrations()
         now = datetime.now().strftime("%B %d, %Y - %X")
         self.stdout.write(now)
+        if self._raw_ipv6:
+            addr = f"[{self.addr}]"
+        elif self.addr == "0":
+            addr = "0.0.0.0"
+        else:
+            addr = self.addr
+
         self.stdout.write(
             (
                 "Django version %(version)s, using settings %(settings)r\n"
@@ -147,7 +154,7 @@ class Command(BaseCommand):
                 "version": self.get_version(),
                 "settings": settings.SETTINGS_MODULE,
                 "protocol": self.protocol,
-                "addr": "[%s]" % self.addr if self._raw_ipv6 else self.addr,
+                "addr": addr,
                 "port": self.port,
                 "quit_command": quit_command,
             }

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -1654,6 +1654,24 @@ class ManageRunserver(SimpleTestCase):
 
     @mock.patch("django.core.management.commands.runserver.run")
     @mock.patch("django.core.management.base.BaseCommand.check_migrations")
+    def test_startup_message_zero_address(
+        self, _mock_check_migrations, _mock_run
+    ):
+        output = StringIO()
+        call_command(
+            "runserver",
+            use_reloader=False,
+            skip_checks=True,
+            addrport="0:8000",
+            stdout=output,
+        )
+        self.assertIn(
+            "Starting development server at http://0.0.0.0:8000/",
+            output.getvalue(),
+        )
+
+    @mock.patch("django.core.management.commands.runserver.run")
+    @mock.patch("django.core.management.base.BaseCommand.check_migrations")
     @mock.patch("django.core.management.base.BaseCommand.check")
     def test_skip_checks(self, mocked_check, *mocked_objects):
         call_command(


### PR DESCRIPTION
## Summary
- normalize runserver display when binding to host 0
- ensure http://0.0.0.0:8000/ is shown instead of http://0:8000/
- add regression test covering zero-address startup message

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py admin_scripts.tests.ManageRunserver.test_startup_message_zero_address --parallel=1
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py admin_scripts.tests.ManageRunserver --parallel=1
- PYTHONPATH=$PWD .venv/bin/flake8 django/core/management/commands/runserver.py tests/admin_scripts/tests.py

Fixes #380