### PR TITLE
fix(sitemaps): handle empty callable lastmods (swev-id: django__django-16255)

### DIFF
--- a/django/contrib/sitemaps/__init__.py
+++ b/django/contrib/sitemaps/__init__.py
@@ -167,7 +167,9 @@ class Sitemap:
             return None
         if callable(self.lastmod):
             try:
-                return max([self.lastmod(item) for item in self.items()])
+                return max(
+                    (self.lastmod(item) for item in self.items()), default=None
+                )
             except TypeError:
                 return None
         else:

--- a/tests/sitemaps_tests/test_http.py
+++ b/tests/sitemaps_tests/test_http.py
@@ -231,6 +231,16 @@ class HTTPSitemapTests(SitemapTestsBase):
         response = self.client.get("/lastmod/get-latest-lastmod-none-sitemap.xml")
         self.assertNotContains(response, "<lastmod>")
 
+    def test_callable_lastmod_empty_index(self):
+        response = self.client.get("/callable-lastmod-empty/index.xml")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "<lastmod>")
+
+    def test_callable_lastmod_empty_sitemap(self):
+        response = self.client.get("/callable-lastmod-empty/sitemap.xml")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "<lastmod>")
+
     def test_sitemap_get_latest_lastmod(self):
         """
         sitemapindex.lastmod is included when Sitemap.lastmod is

--- a/tests/sitemaps_tests/urls/http.py
+++ b/tests/sitemaps_tests/urls/http.py
@@ -98,6 +98,16 @@ class CallableLastmodPartialSitemap(Sitemap):
         return obj.lastmod
 
 
+class CallableLastmodEmptySitemap(Sitemap):
+    location = "/location/"
+
+    def items(self):
+        return []
+
+    def lastmod(self, obj):
+        return datetime(2013, 3, 13, 10, 0, 0)
+
+
 class CallableLastmodFullSitemap(Sitemap):
     """All items have `lastmod`."""
 
@@ -227,6 +237,10 @@ generic_sitemaps_lastmod = {
 
 callable_lastmod_partial_sitemap = {
     "callable-lastmod": CallableLastmodPartialSitemap,
+}
+
+callable_lastmod_empty_sitemap = {
+    "callable-lastmod-empty": CallableLastmodEmptySitemap,
 }
 
 callable_lastmod_full_sitemap = {
@@ -406,6 +420,16 @@ urlpatterns = [
         "callable-lastmod-partial/sitemap.xml",
         views.sitemap,
         {"sitemaps": callable_lastmod_partial_sitemap},
+    ),
+    path(
+        "callable-lastmod-empty/index.xml",
+        views.index,
+        {"sitemaps": callable_lastmod_empty_sitemap},
+    ),
+    path(
+        "callable-lastmod-empty/sitemap.xml",
+        views.sitemap,
+        {"sitemaps": callable_lastmod_empty_sitemap},
     ),
     path(
         "callable-lastmod-full/index.xml",


### PR DESCRIPTION
## Summary
- implement Emerson’s guidance by using `max(..., default=None)` in `Sitemap.get_latest_lastmod()`
- add regression coverage for sitemap index and sitemap views when `items()` is empty and `lastmod` is callable
- ensure the sitemap responses omit `<lastmod>` for that case while preserving the existing `TypeError` guard

## Issue
Fixes #383

## Reproduction
1. Check out `django__django-16255` and add the empty callable sitemap from this patch, or revert the fix commit in this branch.
2. Run `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py sitemaps_tests.test_http.HTTPSitemapTests.test_callable_lastmod_empty_index --parallel=1`.

### Observed failure
```
Traceback (most recent call last):
  File "/workspace/django/tests/sitemaps_tests/test_http.py", line 235, in test_callable_lastmod_empty_index
    response = self.client.get("/callable-lastmod-empty/index.xml")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/test/client.py", line 839, in get
    response = super().get(path, data=data, secure=secure, **extra)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/test/client.py", line 427, in get
    return self.generic(
           ^^^^^^^^^^^^^
  File "/workspace/django/django/test/client.py", line 544, in generic
    return self.request(**r)
           ^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/test/client.py", line 813, in request
    self.check_exception(response)
  File "/workspace/django/django/test/client.py", line 666, in check_exception
    raise exc_value
  File "/workspace/django/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/contrib/sitemaps/views.py", line 34, in inner
    response = func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/contrib/sitemaps/views.py", line 76, in index
    site_lastmod = site.get_latest_lastmod()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/contrib/sitemaps/__init__.py", line 170, in get_latest_lastmod
    return max([self.lastmod(item) for item in self.items()])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: max() arg is an empty sequence
```

## Fix
- call `max(..., default=None)` so empty iterables return `None` instead of raising `ValueError`
- leave the existing `TypeError` handling intact
- extend the sitemap URLconf and HTTP tests to assert 200 responses and absence of `<lastmod>` for the empty callable sitemap

## Testing
- `flake8 django/contrib/sitemaps/__init__.py tests/sitemaps_tests/test_http.py tests/sitemaps_tests/urls/http.py`
- `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py sitemaps_tests --parallel=1`