### PR TITLE
Fix UserAdmin password link for to_field — swev-id: django__django-16139

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -163,7 +163,12 @@ class UserChangeForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         password = self.fields.get("password")
         if password:
-            password.help_text = password.help_text.format("../password/")
+            pk = getattr(self.instance, "pk", None)
+            if pk is None:
+                password_link = "../password/"
+            else:
+                password_link = f"../../{pk}/password/"
+            password.help_text = password.help_text.format(password_link)
         user_permissions = self.fields.get("user_permissions")
         if user_permissions:
             user_permissions.queryset = user_permissions.queryset.select_related(

--- a/tests/auth_tests/test_views.py
+++ b/tests/auth_tests/test_views.py
@@ -1471,6 +1471,32 @@ class ChangelistTests(AuthViewsTestCase):
         self.logout()
         self.login(password="password1")
 
+    def test_user_change_password_link_with_to_field_username(self):
+        user_change_url = reverse(
+            "auth_test_admin:auth_user_change", args=(self.admin.username,)
+        )
+        to_field_url = f"{user_change_url}?_to_field=username"
+        with mock.patch(
+            "django.contrib.auth.admin.UserAdmin.to_field_allowed", return_value=True
+        ):
+            response = self.client.get(to_field_url)
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        password_change_url = reverse(
+            "auth_test_admin:auth_user_password_change", args=(self.admin.pk,)
+        )
+
+        match = re.search(
+            r'you can change the password using <a href="([^"]*)">this form</a>',
+            response.content.decode(),
+        )
+        self.assertIsNotNone(match, response.content.decode())
+        rel_link = match[1]
+        resolved_link = urljoin(to_field_url, rel_link)
+        self.assertEqual(resolved_link, password_change_url)
+
+        password_response = self.client.get(resolved_link)
+        self.assertEqual(password_response.status_code, 200)
+
     def test_user_change_different_user_password(self):
         u = User.objects.get(email="staffmember@example.com")
         response = self.client.post(


### PR DESCRIPTION
## Summary
- Ensure UserChangeForm password help text uses instance pk when available so the password link is correct under `_to_field` lookups.
- Add regression coverage for change view accessed with `_to_field=username`, verifying the link resolves to the password form.

## Reproduction steps and observed failure
1) Ensure contrib.admin and contrib.auth are installed; create a staff user, e.g., `alice`.
2) Visit `/admin/auth/user/alice/change/?_to_field=username`.
3) Click the “this form” link in the Password field help text.

Observed:
- Navigates to `/admin/auth/user/alice/password/` and returns 404.
- The password change view (`UserAdmin.user_change_password`) expects the primary key; typical debug output: `User object with primary key 'alice' does not exist.`

Expected:
- The link should go to `/admin/auth/user/<pk>/password/` and load the password change form.

## Implementation notes
- In `django/contrib/auth/forms.py`, `UserChangeForm.__init__` now formats the help_text link with the user’s pk:
  - `../../{self.instance.pk}/password/`
- This preserves behavior for pk-based change views and fixes the `_to_field` scenario.

## Testing
- Targeted tests:
  - `auth_tests.test_views.ChangelistTests` (pass).
  - Added `test_user_change_password_link_with_to_field_username` to verify correct link resolution and successful GET of the password form when accessed via `_to_field=username`.
- Full `auth_tests` run may fail on some hosts if system DES `crypt()` support is unavailable; this is environmental and unrelated to this change. The new regression test passes locally.

Closes #378
Reference: swev-id: django__django-16139