### PR TITLE
Fix async wrappers for related managers — swev-id: django__django-16256

### DIFF
--- a/django/contrib/contenttypes/fields.py
+++ b/django/contrib/contenttypes/fields.py
@@ -2,6 +2,8 @@ import functools
 import itertools
 from collections import defaultdict
 
+from asgiref.sync import sync_to_async
+
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
@@ -747,6 +749,11 @@ def create_generic_related_manager(superclass, rel):
 
         create.alters_data = True
 
+        async def acreate(self, **kwargs):
+            return await sync_to_async(self.create)(**kwargs)
+
+        acreate.alters_data = True
+
         def get_or_create(self, **kwargs):
             kwargs[self.content_type_field_name] = self.content_type
             kwargs[self.object_id_field_name] = self.pk_val
@@ -755,6 +762,11 @@ def create_generic_related_manager(superclass, rel):
 
         get_or_create.alters_data = True
 
+        async def aget_or_create(self, **kwargs):
+            return await sync_to_async(self.get_or_create)(**kwargs)
+
+        aget_or_create.alters_data = True
+
         def update_or_create(self, **kwargs):
             kwargs[self.content_type_field_name] = self.content_type
             kwargs[self.object_id_field_name] = self.pk_val
@@ -762,5 +774,10 @@ def create_generic_related_manager(superclass, rel):
             return super().using(db).update_or_create(**kwargs)
 
         update_or_create.alters_data = True
+
+        async def aupdate_or_create(self, **kwargs):
+            return await sync_to_async(self.update_or_create)(**kwargs)
+
+        aupdate_or_create.alters_data = True
 
     return GenericRelatedObjectManager

--- a/django/db/models/fields/related_descriptors.py
+++ b/django/db/models/fields/related_descriptors.py
@@ -63,6 +63,8 @@ and two directions (forward and reverse) for a total of six combinations.
    ``ReverseManyToManyDescriptor``, use ``ManyToManyDescriptor`` instead.
 """
 
+from asgiref.sync import sync_to_async
+
 from django.core.exceptions import FieldError
 from django.db import (
     DEFAULT_DB_ALIAS,
@@ -793,6 +795,11 @@ def create_reverse_many_to_one_manager(superclass, rel):
 
         create.alters_data = True
 
+        async def acreate(self, **kwargs):
+            return await sync_to_async(self.create)(**kwargs)
+
+        acreate.alters_data = True
+
         def get_or_create(self, **kwargs):
             self._check_fk_val()
             kwargs[self.field.name] = self.instance
@@ -801,6 +808,11 @@ def create_reverse_many_to_one_manager(superclass, rel):
 
         get_or_create.alters_data = True
 
+        async def aget_or_create(self, **kwargs):
+            return await sync_to_async(self.get_or_create)(**kwargs)
+
+        aget_or_create.alters_data = True
+
         def update_or_create(self, **kwargs):
             self._check_fk_val()
             kwargs[self.field.name] = self.instance
@@ -808,6 +820,11 @@ def create_reverse_many_to_one_manager(superclass, rel):
             return super(RelatedManager, self.db_manager(db)).update_or_create(**kwargs)
 
         update_or_create.alters_data = True
+
+        async def aupdate_or_create(self, **kwargs):
+            return await sync_to_async(self.update_or_create)(**kwargs)
+
+        aupdate_or_create.alters_data = True
 
         # remove() and clear() are only provided if the ForeignKey can have a
         # value of null.
@@ -1191,6 +1208,13 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
 
         create.alters_data = True
 
+        async def acreate(self, *, through_defaults=None, **kwargs):
+            return await sync_to_async(self.create)(
+                through_defaults=through_defaults, **kwargs
+            )
+
+        acreate.alters_data = True
+
         def get_or_create(self, *, through_defaults=None, **kwargs):
             db = router.db_for_write(self.instance.__class__, instance=self.instance)
             obj, created = super(ManyRelatedManager, self.db_manager(db)).get_or_create(
@@ -1204,6 +1228,13 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
 
         get_or_create.alters_data = True
 
+        async def aget_or_create(self, *, through_defaults=None, **kwargs):
+            return await sync_to_async(self.get_or_create)(
+                through_defaults=through_defaults, **kwargs
+            )
+
+        aget_or_create.alters_data = True
+
         def update_or_create(self, *, through_defaults=None, **kwargs):
             db = router.db_for_write(self.instance.__class__, instance=self.instance)
             obj, created = super(
@@ -1216,6 +1247,13 @@ def create_forward_many_to_many_manager(superclass, rel, reverse):
             return obj, created
 
         update_or_create.alters_data = True
+
+        async def aupdate_or_create(self, *, through_defaults=None, **kwargs):
+            return await sync_to_async(self.update_or_create)(
+                through_defaults=through_defaults, **kwargs
+            )
+
+        aupdate_or_create.alters_data = True
 
         def _get_target_ids(self, target_field_name, objs):
             """

--- a/tests/async/models.py
+++ b/tests/async/models.py
@@ -1,3 +1,5 @@
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils import timezone
 
@@ -9,3 +11,46 @@ class RelatedModel(models.Model):
 class SimpleModel(models.Model):
     field = models.IntegerField()
     created = models.DateTimeField(default=timezone.now)
+
+
+class AsyncAuthor(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class AsyncBook(models.Model):
+    author = models.ForeignKey(AsyncAuthor, models.CASCADE, related_name="books")
+    title = models.CharField(max_length=100)
+    pages = models.IntegerField(default=0)
+
+
+class AsyncGroup(models.Model):
+    name = models.CharField(max_length=100)
+    members = models.ManyToManyField(
+        "AsyncMember",
+        through="GroupMembership",
+        related_name="groups",
+    )
+
+
+class AsyncMember(models.Model):
+    name = models.CharField(max_length=100)
+    title = models.CharField(max_length=100, blank=True)
+
+
+class GroupMembership(models.Model):
+    group = models.ForeignKey(AsyncGroup, models.CASCADE)
+    member = models.ForeignKey(AsyncMember, models.CASCADE)
+    note = models.CharField(max_length=100, blank=True)
+
+
+class GenericNote(models.Model):
+    content_type = models.ForeignKey(ContentType, models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey()
+    message = models.CharField(max_length=100)
+    extra = models.CharField(max_length=100, blank=True)
+
+
+class GenericArticle(models.Model):
+    name = models.CharField(max_length=100)
+    notes = GenericRelation(GenericNote, related_query_name="articles")

--- a/tests/async/test_async_related_managers.py
+++ b/tests/async/test_async_related_managers.py
@@ -1,0 +1,172 @@
+from asgiref.sync import sync_to_async
+from django.test import TestCase
+
+from .models import (
+    AsyncAuthor,
+    AsyncBook,
+    AsyncGroup,
+    GenericArticle,
+    GenericNote,
+    GroupMembership,
+)
+
+
+class AsyncRelatedManagerTests(TestCase):
+    async def test_reverse_fk_acreate_injects_foreign_key(self):
+        author = await AsyncAuthor.objects.acreate(name="Author")
+
+        book = await author.books.acreate(title="Async Book", pages=200)
+
+        self.assertEqual(book.author_id, author.pk)
+        stored = await AsyncBook.objects.aget(pk=book.pk)
+        self.assertEqual(stored.author_id, author.pk)
+        self.assertEqual(stored.pages, 200)
+
+    async def test_reverse_fk_acreate_unsaved_parent_error(self):
+        author = AsyncAuthor(name="Ghost")
+        msg = (
+            f'"{author!r}" needs to have a value for field "id" before '
+            "this relationship can be used."
+        )
+        with self.assertRaisesMessage(ValueError, msg):
+            await author.books.acreate(title="Should fail")
+
+    async def test_reverse_fk_aget_or_create_respects_relation(self):
+        author = await AsyncAuthor.objects.acreate(name="Author")
+
+        book, created = await author.books.aget_or_create(title="Existing Book")
+        self.assertIs(created, True)
+        self.assertEqual(book.author_id, author.pk)
+
+        same_book, created_again = await author.books.aget_or_create(
+            title="Existing Book"
+        )
+        self.assertIs(created_again, False)
+        self.assertEqual(same_book.pk, book.pk)
+
+    async def test_reverse_fk_aupdate_or_create_updates_instance(self):
+        author = await AsyncAuthor.objects.acreate(name="Author")
+
+        book, created = await author.books.aupdate_or_create(
+            title="Versioned Book", defaults={"pages": 150}
+        )
+        self.assertIs(created, True)
+        self.assertEqual(book.author_id, author.pk)
+        self.assertEqual(book.pages, 150)
+
+        updated_book, created_again = await author.books.aupdate_or_create(
+            title="Versioned Book", defaults={"pages": 175}
+        )
+        self.assertIs(created_again, False)
+        self.assertEqual(updated_book.pk, book.pk)
+        self.assertEqual(updated_book.pages, 175)
+        refreshed = await AsyncBook.objects.aget(pk=book.pk)
+        self.assertEqual(refreshed.pages, 175)
+        self.assertEqual(refreshed.author_id, author.pk)
+
+    async def test_m2m_acreate_links_instance_and_through_defaults(self):
+        group = await AsyncGroup.objects.acreate(name="Group")
+
+        member = await group.members.acreate(
+            name="Alice", title="Engineer", through_defaults={"note": "invite"}
+        )
+
+        self.assertEqual(member.title, "Engineer")
+        self.assertEqual(await group.members.acount(), 1)
+        membership = await GroupMembership.objects.aget(group=group, member=member)
+        self.assertEqual(membership.note, "invite")
+
+    async def test_m2m_aget_or_create_retains_existing_membership(self):
+        group = await AsyncGroup.objects.acreate(name="Group")
+
+        member, created = await group.members.aget_or_create(
+            name="Bob",
+            defaults={"title": "Member"},
+            through_defaults={"note": "init"},
+        )
+        self.assertIs(created, True)
+
+        membership = await GroupMembership.objects.aget(group=group, member=member)
+        self.assertEqual(membership.note, "init")
+
+        same_member, created_again = await group.members.aget_or_create(
+            name="Bob",
+            defaults={"title": "Member"},
+            through_defaults={"note": "ignored"},
+        )
+        self.assertIs(created_again, False)
+        self.assertEqual(same_member.pk, member.pk)
+        self.assertEqual(await group.members.acount(), 1)
+        membership_refreshed = await GroupMembership.objects.aget(
+            group=group, member=member
+        )
+        self.assertEqual(membership_refreshed.note, "init")
+
+    async def test_m2m_aupdate_or_create_updates_member_and_keeps_relation(self):
+        group = await AsyncGroup.objects.acreate(name="Group")
+
+        member, created = await group.members.aupdate_or_create(
+            name="Cara",
+            defaults={"title": "Member"},
+            through_defaults={"note": "initial"},
+        )
+        self.assertIs(created, True)
+
+        membership = await GroupMembership.objects.aget(group=group, member=member)
+        self.assertEqual(membership.note, "initial")
+
+        updated_member, created_again = await group.members.aupdate_or_create(
+            name="Cara",
+            defaults={"title": "Lead"},
+            through_defaults={"note": "later"},
+        )
+        self.assertIs(created_again, False)
+        self.assertEqual(updated_member.pk, member.pk)
+        self.assertEqual(updated_member.title, "Lead")
+        self.assertEqual(await group.members.acount(), 1)
+        preserved_membership = await GroupMembership.objects.aget(
+            group=group, member=member
+        )
+        self.assertEqual(preserved_membership.note, "initial")
+
+    async def test_generic_acreate_sets_content_fields(self):
+        article = await GenericArticle.objects.acreate(name="Article")
+        notes_manager = await sync_to_async(getattr)(article, "notes")
+
+        note = await notes_manager.acreate(message="hello", extra="first")
+
+        self.assertEqual(await notes_manager.acount(), 1)
+        stored = await GenericNote.objects.aget(pk=note.pk)
+        self.assertEqual(stored.object_id, article.pk)
+        related = await notes_manager.aget(pk=note.pk)
+        self.assertEqual(related.pk, note.pk)
+
+    async def test_generic_aget_or_create_returns_existing(self):
+        article = await GenericArticle.objects.acreate(name="Article")
+        notes_manager = await sync_to_async(getattr)(article, "notes")
+
+        note, created = await notes_manager.aget_or_create(message="unique")
+        self.assertIs(created, True)
+
+        same_note, created_again = await notes_manager.aget_or_create(message="unique")
+        self.assertIs(created_again, False)
+        self.assertEqual(same_note.pk, note.pk)
+
+    async def test_generic_aupdate_or_create_updates_existing(self):
+        article = await GenericArticle.objects.acreate(name="Article")
+        notes_manager = await sync_to_async(getattr)(article, "notes")
+
+        note, created = await notes_manager.aupdate_or_create(
+            message="tracked", defaults={"extra": "v1"}
+        )
+        self.assertIs(created, True)
+        self.assertEqual(note.extra, "v1")
+
+        updated_note, created_again = await notes_manager.aupdate_or_create(
+            message="tracked", defaults={"extra": "v2"}
+        )
+        self.assertIs(created_again, False)
+        self.assertEqual(updated_note.pk, note.pk)
+        self.assertEqual(updated_note.extra, "v2")
+        stored = await notes_manager.aget(message="tracked")
+        self.assertEqual(stored.extra, "v2")


### PR DESCRIPTION
## Summary
- add async wrappers for reverse FK, M2M, generic related managers
- cover regression cases for reverse FK, M2M, and generic relations
- extend async test models for new fixtures

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py async --parallel=1
- .venv/bin/flake8 tests/async/test_async_related_managers.py django/db/models/fields/related_descriptors.py django/contrib/contenttypes/fields.py

Fixes #385