### PR TITLE
Fix bulk_create ON CONFLICT to use db_column names (PostgreSQL) — swev-id: django__django-16315

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -794,6 +794,10 @@ class QuerySet(AltersData):
             update_fields,
             unique_fields,
         )
+        if update_fields:
+            update_fields = [opts.get_field(name) for name in update_fields]
+        if unique_fields:
+            unique_fields = [opts.get_field(name) for name in unique_fields]
         self._for_write = True
         fields = opts.concrete_fields
         objs = list(objs)

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -1722,11 +1722,13 @@ class SQLInsertCompiler(SQLCompiler):
 
         placeholder_rows, param_rows = self.assemble_as_sql(fields, value_rows)
 
+        update_columns = [field.column for field in self.query.update_fields]
+        unique_columns = [field.column for field in self.query.unique_fields]
         on_conflict_suffix_sql = self.connection.ops.on_conflict_suffix_sql(
             fields,
             self.query.on_conflict,
-            self.query.update_fields,
-            self.query.unique_fields,
+            update_columns,
+            unique_columns,
         )
         if (
             self.returning_fields

--- a/tests/postgres_tests/migrations/0002_create_test_models.py
+++ b/tests/postgres_tests/migrations/0002_create_test_models.py
@@ -569,4 +569,23 @@ class Migration(migrations.Migration):
                 "required_db_vendor": "postgresql",
             },
         ),
+        migrations.CreateModel(
+            name="MixedCaseColumns",
+            fields=[
+                (
+                    "blacklistid",
+                    models.IntegerField(
+                        db_column="BlacklistID", primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "sectorid",
+                    models.IntegerField(db_column="SectorID"),
+                ),
+            ],
+            options={
+                "db_table": "MixedCaseUpsert",
+                "required_db_vendor": "postgresql",
+            },
+        ),
     ]

--- a/tests/postgres_tests/models.py
+++ b/tests/postgres_tests/models.py
@@ -199,6 +199,14 @@ class NowTestModel(models.Model):
     when = models.DateTimeField(null=True, default=None)
 
 
+class MixedCaseColumns(PostgreSQLModel):
+    blacklistid = models.IntegerField(db_column="BlacklistID", primary_key=True)
+    sectorid = models.IntegerField(db_column="SectorID")
+
+    class Meta:
+        db_table = "MixedCaseUpsert"
+
+
 class UUIDTestModel(models.Model):
     uuid = models.UUIDField(default=None, null=True)
 

--- a/tests/postgres_tests/test_bulk_create_conflict_db_column.py
+++ b/tests/postgres_tests/test_bulk_create_conflict_db_column.py
@@ -1,0 +1,24 @@
+from . import PostgreSQLTestCase
+from .models import MixedCaseColumns
+
+
+class BulkCreateConflictDbColumnTests(PostgreSQLTestCase):
+    def test_bulk_create_updates_with_db_column_names(self):
+        MixedCaseColumns.objects.create(blacklistid=1, sectorid=1)
+
+        MixedCaseColumns.objects.bulk_create(
+            [
+                MixedCaseColumns(blacklistid=1, sectorid=2),
+                MixedCaseColumns(blacklistid=2, sectorid=3),
+            ],
+            update_conflicts=True,
+            update_fields=["sectorid"],
+            unique_fields=["blacklistid"],
+        )
+
+        self.assertSequenceEqual(
+            MixedCaseColumns.objects.order_by("blacklistid").values_list(
+                "blacklistid", "sectorid"
+            ),
+            [(1, 2), (2, 3)],
+        )


### PR DESCRIPTION
Fixes #389.

swev-id: django__django-16315

## Summary
- map QuerySet.bulk_create conflict field lists to Field instances so db_column values are propagated
- ensure SQLInsertCompiler passes db_column names into on_conflict suffix generation
- add MixedCaseColumns model/migration/test verifying PostgreSQL bulk_create conflict updates with mixed-case db_column values

## Testing
- `PYTHONPATH=/workspace/django:/workspace/django/tests python tests/runtests.py --settings=postgres_settings postgres_tests.test_bulk_create_conflict_db_column --parallel=1`
- `flake8 django/db/models/query.py django/db/models/sql/compiler.py tests/postgres_tests/models.py tests/postgres_tests/test_bulk_create_conflict_db_column.py tests/postgres_tests/migrations/0002_create_test_models.py`

## Reproduction Steps (pre-fix)
1. Start local PostgreSQL and configure `postgres_settings.py` for the repo.
2. Run:
   ```bash
   PYTHONPATH=/workspace/django:/workspace/django/tests python reproduce_bulk_conflict.py
   ```

   Script snippet:
   ```python
   MixedCaseConflict.objects.bulk_create(
       [
           MixedCaseConflict(blacklistid=1, sectorid=10),
           MixedCaseConflict(blacklistid=1, sectorid=20),
       ],
       update_conflicts=True,
       update_fields=["sectorid"],
       unique_fields=["blacklistid"],
   )
   ```

## Observed Failure (pre-fix)
```
django.db.utils.ProgrammingError: column "blacklistid" does not exist
LINE 1: ... ON CONFLICT("blacklistid") DO UPDATE SET "sectorid" = EXCLU...
```
