### PR TITLE
feat: prune unused annotations for count()/exists() (swev-id: django__django-16263)

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -693,10 +693,19 @@ class Query(BaseExpression):
             return
 
         to_remove = set(self.annotations).difference(to_keep)
+        keep_alias_refs = set()
+        for alias in to_keep:
+            expression = self.annotations[alias]
+            for ref_alias in self._gen_col_aliases([expression]):
+                if ref_alias in self.alias_refcount:
+                    keep_alias_refs.add(ref_alias)
         for alias in to_remove:
             expression = self.annotations.pop(alias)
             for ref_alias in self._gen_col_aliases([expression]):
-                if ref_alias in self.alias_refcount:
+                if (
+                    ref_alias in self.alias_refcount
+                    and ref_alias not in keep_alias_refs
+                ):
                     self.unref_alias(ref_alias)
         if self.annotation_select_mask is not None:
             self.annotation_select_mask.difference_update(to_remove)

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -545,11 +545,169 @@ class Query(BaseExpression):
 
         return dict(zip(outer_query.annotation_select, result))
 
+    def _scan_expression_for_annotation_refs(
+        self,
+        expression,
+        alias_by_id,
+        *,
+        skip_alias=None,
+        refs=None,
+        seen=None,
+    ):
+        if refs is None:
+            refs = set()
+        if seen is None:
+            seen = set()
+
+        def scan(node):
+            if node is None:
+                return
+            if isinstance(node, (list, tuple, set)):
+                for child in node:
+                    scan(child)
+                return
+            if isinstance(node, Mapping):
+                for child in node.values():
+                    scan(child)
+                return
+            node_id = id(node)
+            if node_id in seen:
+                return
+            seen.add(node_id)
+            if isinstance(node, Ref):
+                if node.refs in self.annotations:
+                    refs.add(node.refs)
+            alias = alias_by_id.get(node_id)
+            if alias is not None and alias != skip_alias:
+                refs.add(alias)
+            if hasattr(node, "get_source_expressions"):
+                for source in node.get_source_expressions() or []:
+                    scan(source)
+
+        scan(expression)
+        return refs
+
+    def _annotation_dependency_graph(self):
+        alias_by_id = {
+            id(expression): alias for alias, expression in self.annotations.items()
+        }
+        dependencies = {alias: set() for alias in self.annotations}
+        for alias, expression in self.annotations.items():
+            refs = self._scan_expression_for_annotation_refs(
+                expression,
+                alias_by_id,
+                skip_alias=alias,
+            )
+            dependencies[alias] = {
+                ref for ref in refs if ref in self.annotations and ref != alias
+            }
+        return dependencies
+
+    def _collect_annotation_references(self, context):
+        alias_by_id = {
+            id(expression): alias for alias, expression in self.annotations.items()
+        }
+        if not alias_by_id:
+            return set()
+
+        references = set()
+
+        if self.where:
+            where, having, qualify = self.where.split_having_qualify(
+                must_group_by=self.group_by is not None
+            )
+            for node in (where, having, qualify):
+                if node is not None:
+                    self._scan_expression_for_annotation_refs(
+                        node,
+                        alias_by_id,
+                        refs=references,
+                    )
+
+        if isinstance(self.group_by, tuple):
+            for expression in self.group_by:
+                self._scan_expression_for_annotation_refs(
+                    expression,
+                    alias_by_id,
+                    refs=references,
+                )
+
+        for distinct_field in self.distinct_fields:
+            if isinstance(distinct_field, str):
+                if distinct_field in self.annotations:
+                    references.add(distinct_field)
+            else:
+                self._scan_expression_for_annotation_refs(
+                    distinct_field,
+                    alias_by_id,
+                    refs=references,
+                )
+
+        if context == "count":
+            for name in self.values_select:
+                if name in self.annotations:
+                    references.add(name)
+            if self.annotation_select_mask is not None:
+                references.update(
+                    alias
+                    for alias in self.annotation_select_mask
+                    if alias in self.annotations
+                )
+
+        return {ref for ref in references if ref in self.annotations}
+
+    def _annotations_requiring_grouping(self):
+        required = set()
+        for alias, annotation in self.annotations.items():
+            if getattr(annotation, "contains_aggregate", False):
+                continue
+            for col in self._gen_cols([annotation], include_external=True):
+                if getattr(col, "possibly_multivalued", False):
+                    required.add(alias)
+                    break
+        return required
+
+    def prune_unused_annotations(self, context):
+        if context not in {"count", "exists"}:
+            raise ValueError("Unsupported pruning context: %s" % context)
+        if not self.annotations:
+            return
+
+        required = self._collect_annotation_references(context)
+        required.update(self._annotations_requiring_grouping())
+        dependency_graph = self._annotation_dependency_graph()
+
+        to_keep = set()
+        stack = [alias for alias in required if alias in dependency_graph]
+        while stack:
+            alias = stack.pop()
+            if alias in to_keep:
+                continue
+            to_keep.add(alias)
+            for dependency in dependency_graph.get(alias, ()):  # pragma: no branch
+                if dependency not in to_keep:
+                    stack.append(dependency)
+
+        to_keep &= set(self.annotations)
+        if len(to_keep) == len(self.annotations):
+            return
+
+        to_remove = set(self.annotations).difference(to_keep)
+        for alias in to_remove:
+            expression = self.annotations.pop(alias)
+            for ref_alias in self._gen_col_aliases([expression]):
+                if ref_alias in self.alias_refcount:
+                    self.unref_alias(ref_alias)
+        if self.annotation_select_mask is not None:
+            self.annotation_select_mask.difference_update(to_remove)
+        self._annotation_select_cache = None
+
     def get_count(self, using):
         """
         Perform a COUNT() query using the current filter constraints.
         """
         obj = self.clone()
+        obj.prune_unused_annotations("count")
         obj.add_annotation(Count("*"), alias="__count", is_summary=True)
         return obj.get_aggregation(using, ["__count"])["__count"]
 
@@ -573,6 +731,7 @@ class Query(BaseExpression):
                 for combined_query in q.combined_queries
             )
         q.clear_ordering(force=True)
+        q.prune_unused_annotations("exists")
         if limit:
             q.set_limits(high=1)
         q.add_annotation(Value(1), "a")

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -28,6 +28,7 @@ from django.db.models import (
     Value,
     Variance,
     When,
+    Window,
 )
 from django.db.models.expressions import Func, RawSQL
 from django.db.models.functions import (
@@ -36,6 +37,7 @@ from django.db.models.functions import (
     Greatest,
     Now,
     Pi,
+    RowNumber,
     TruncDate,
     TruncHour,
 )
@@ -2068,6 +2070,114 @@ class AggregateTestCase(TestCase):
             exists=Exists(Author.objects.none()),
         )
         self.assertEqual(len(qs), 6)
+
+
+class AnnotationPruningTests(AggregateTestCase):
+    def _run_and_capture(self, queryset, method):
+        with CaptureQueriesContext(connection) as ctx:
+            result = getattr(queryset, method)()
+        self.assertGreaterEqual(len(ctx.captured_queries), 1)
+        return result, ctx.captured_queries[-1]["sql"]
+
+    def _assert_alias_absent(self, sql, alias):
+        self.assertNotIn(alias, sql)
+        self.assertNotIn(f'"{alias}"', sql)
+
+    def _assert_alias_present(self, sql, alias):
+        self.assertTrue(
+            alias in sql or f'"{alias}"' in sql,
+            msg=f"Expected alias {alias!r} in SQL {sql!r}",
+        )
+
+    def test_count_prunes_unused_annotation(self):
+        qs = Book.objects.annotate(num_authors=Count("authors"))
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, Book.objects.count())
+        self._assert_alias_absent(sql, "num_authors")
+        self.assertNotIn("GROUP BY", sql)
+
+    def test_exists_prunes_unused_annotation(self):
+        qs = Book.objects.annotate(num_authors=Count("authors"))
+        result, sql = self._run_and_capture(qs, "exists")
+        self.assertTrue(result)
+        self._assert_alias_absent(sql, "num_authors")
+
+    def test_count_retains_annotation_used_in_filter(self):
+        qs = Book.objects.annotate(num_authors=Count("authors")).filter(
+            num_authors__gt=1
+        )
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, 3)
+        self._assert_alias_present(sql, "num_authors")
+        self.assertIn("HAVING", sql)
+
+    def test_count_prunes_order_by_only_annotation(self):
+        qs = Book.objects.annotate(num_authors=Count("authors")).order_by(
+            "num_authors"
+        )
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, Book.objects.count())
+        self._assert_alias_absent(sql, "num_authors")
+        self.assertNotIn("ORDER BY", sql)
+
+    def test_count_retains_transitive_annotation_dependency(self):
+        qs = Book.objects.annotate(
+            num_authors=Count("authors"),
+            doubled=F("num_authors") * 2,
+        ).filter(doubled__gt=2)
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, 3)
+        self._assert_alias_present(sql, "doubled")
+        self._assert_alias_present(sql, "num_authors")
+
+    def test_values_list_count_keeps_annotation(self):
+        qs = Book.objects.annotate(num_authors=Count("authors")).values(
+            "pk", "num_authors"
+        )
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, Book.objects.count())
+        self._assert_alias_present(sql, "num_authors")
+        self.assertIn("GROUP BY", sql)
+
+    def test_values_pk_count_prunes_annotation(self):
+        qs = Book.objects.annotate(num_authors=Count("authors")).values("pk")
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, Book.objects.count())
+        self._assert_alias_absent(sql, "num_authors")
+
+    def test_distinct_count_prunes_annotation(self):
+        qs = Book.objects.annotate(num_authors=Count("authors")).distinct()
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, Book.objects.count())
+        self._assert_alias_absent(sql, "num_authors")
+
+    @skipUnlessDBFeature("supports_distinct_on_fields")
+    def test_distinct_on_fields_keeps_annotation(self):
+        qs = Book.objects.annotate(num_authors=Count("authors")).distinct("num_authors")
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, Book.objects.count())
+        self._assert_alias_present(sql, "num_authors")
+
+    def test_exists_retains_annotation_dependencies(self):
+        qs = Book.objects.annotate(num_authors=Count("authors")).filter(
+            num_authors__gt=1
+        )
+        result, sql = self._run_and_capture(qs, "exists")
+        self.assertTrue(result)
+        self.assertIn("HAVING", sql)
+        self.assertIn("COUNT(", sql)
+
+    @skipUnlessDBFeature("supports_over_clause")
+    def test_count_retains_window_function_annotation(self):
+        qs = Book.objects.annotate(
+            row_number=Window(
+                expression=RowNumber(),
+                order_by=F("id").asc(),
+            )
+        ).filter(row_number__lte=1)
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, 1)
+        self._assert_alias_present(sql, "row_number")
 
     def test_alias_sql_injection(self):
         crafted_alias = """injected_name" from "aggregation_author"; --"""

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -2167,6 +2167,16 @@ class AnnotationPruningTests(AggregateTestCase):
         self.assertIn("HAVING", sql)
         self.assertIn("COUNT(", sql)
 
+    def test_count_keeps_join_alias_for_retained_annotation(self):
+        qs = Book.objects.annotate(
+            num_authors=Count("authors"),
+            doubled=F("num_authors") * 2,
+        ).values("num_authors")
+        result, sql = self._run_and_capture(qs, "count")
+        self.assertEqual(result, Book.objects.count())
+        self._assert_alias_absent(sql, "doubled")
+        self.assertIn("aggregation_book_authors", sql)
+
     @skipUnlessDBFeature("supports_over_clause")
     def test_count_retains_window_function_annotation(self):
         qs = Book.objects.annotate(


### PR DESCRIPTION
## Summary
- prune Query annotations unused by count()/exists() and adjust alias refcounts
- track annotation dependencies (filters, values/select, distinct, grouping) and multi-valued subqueries
- add aggregation regression coverage for count()/exists() SQL pruning, including window and distinct cases

## Testing
- PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.11 tests/runtests.py aggregation --parallel=1
- PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.11 tests/runtests.py queries --parallel=1
- flake8 django/db/models/sql/query.py tests/aggregation/tests.py

swev-id: 387

Resolves #387