### PR TITLE
fix(auth): persist m2m selections (swev-id: django__django-16333)

### DIFF
--- a/django/contrib/auth/forms.py
+++ b/django/contrib/auth/forms.py
@@ -141,6 +141,7 @@ class UserCreationForm(forms.ModelForm):
         user.set_password(self.cleaned_data["password1"])
         if commit:
             user.save()
+            self.save_m2m()
         return user
 
 

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -14,7 +14,7 @@ from django.contrib.auth.forms import (
     UserChangeForm,
     UserCreationForm,
 )
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.contrib.auth.signals import user_login_failed
 from django.contrib.sites.models import Site
 from django.core import mail
@@ -109,6 +109,29 @@ class UserCreationFormTest(TestDataMixin, TestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(form["password1"].errors, required_error)
         self.assertEqual(form["password2"].errors, [])
+
+    def test_save_commit_true_persists_many_to_many(self):
+        class UserCreationFormWithGroups(UserCreationForm):
+            class Meta(UserCreationForm.Meta):
+                fields = UserCreationForm.Meta.fields + ("groups",)
+
+        group = Group.objects.create(name="testers")
+        data = {
+            "username": "assign-m2m",
+            "password1": "test12345",
+            "password2": "test12345",
+            "groups": [group.pk],
+        }
+        form = UserCreationFormWithGroups(data)
+        self.assertTrue(form.is_valid())
+
+        user = form.save(commit=True)
+        user.refresh_from_db()
+
+        self.assertEqual(
+            list(user.groups.order_by("pk").values_list("name", flat=True)),
+            ["testers"],
+        )
 
     @mock.patch("django.contrib.auth.password_validation.password_changed")
     def test_success(self, password_changed):


### PR DESCRIPTION
## Summary
- add a regression test showing `UserCreationForm.save(commit=True)` failed to persist `ManyToManyField` selections
- call `save_m2m()` when committing the user so selected relations get written to the database

## Reproduction
```bash
PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py auth_tests.test_forms.UserCreationFormTest.test_save_commit_true_persists_many_to_many --parallel=1
```

## Observed failure (pre-fix)
```
Creating test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
Found 1 test(s).
System check identified no issues (0 silenced).
F
======================================================================
FAIL: test_save_commit_true_persists_many_to_many (auth_tests.test_forms.UserCreationFormTest.test_save_commit_true_persists_many_to_many)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/auth_tests/test_forms.py", line 131, in test_save_commit_true_persists_many_to_many
    self.assertEqual(
AssertionError: Lists differ: [] != ['testers']

Second list contains 1 additional elements.
First extra element 0:
'testers'

- []
+ ['testers']

----------------------------------------------------------------------
Ran 1 test in 0.003s

FAILED (failures=1)
Destroying test database for alias 'default'...
```

## Fix
- rerunning the reproduction command now passes because `save_m2m()` flushes the selected groups.

Closes #391