### PR TITLE
Propagate CommandParser formatting to subparsers (swev-id: django__django-16454)

### DIFF
--- a/django/core/management/base.py
+++ b/django/core/management/base.py
@@ -71,6 +71,26 @@ class CommandParser(ArgumentParser):
         else:
             raise CommandError("Error: %s" % message)
 
+    def add_subparsers(self, **kwargs):
+        kwargs.setdefault("parser_class", CommandParser)
+        default_parser_class = kwargs["parser_class"]
+        action = super().add_subparsers(**kwargs)
+        parent_called = self.called_from_command_line
+        parent_formatter = self.formatter_class
+        original_add_parser = action.add_parser
+
+        def add_parser(name, **parser_kwargs):
+            parser_class = parser_kwargs.get("parser_class", default_parser_class)
+            if parser_class and issubclass(parser_class, CommandParser):
+                parser_kwargs.setdefault(
+                    "called_from_command_line", parent_called
+                )
+                parser_kwargs.setdefault("formatter_class", parent_formatter)
+            return original_add_parser(name, **parser_kwargs)
+
+        action.add_parser = add_parser
+        return action
+
 
 def handle_default_options(options):
     """

--- a/tests/admin_scripts/tests.py
+++ b/tests/admin_scripts/tests.py
@@ -51,6 +51,7 @@ class AdminScriptTestCase(SimpleTestCase):
         # where `/var` is a symlink to `/private/var`.
         self.test_dir = os.path.realpath(os.path.join(tmpdir.name, "test_project"))
         os.mkdir(self.test_dir)
+        self.last_returncode = None
 
     def write_settings(self, filename, apps=None, is_dir=False, sdict=None, extra=None):
         if is_dir:
@@ -137,6 +138,7 @@ class AdminScriptTestCase(SimpleTestCase):
             text=True,
             umask=umask,
         )
+        self.last_returncode = p.returncode
         return p.stdout, p.stderr
 
     def run_django_admin(self, args, settings_file=None, umask=-1):

--- a/tests/user_commands/management/commands/subparser_required_name.py
+++ b/tests/user_commands/management/commands/subparser_required_name.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Command with subparser requiring a positional argument."
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers(dest="action", required=True)
+        create_parser = subparsers.add_parser("create")
+        create_parser.add_argument("name")
+
+    def handle(self, *args, **options):
+        return None

--- a/tests/user_commands/tests.py
+++ b/tests/user_commands/tests.py
@@ -406,6 +406,11 @@ class CommandTests(SimpleTestCase):
         with self.assertRaisesMessage(CommandError, msg):
             management.call_command("subparser_dest", subcommand="foo", bar=12)
 
+    def test_subparser_missing_positional_programmatic(self):
+        msg = "Error: the following arguments are required: name"
+        with self.assertRaisesMessage(CommandError, msg):
+            management.call_command("subparser_required_name", "create")
+
     def test_create_parser_kwargs(self):
         """BaseCommand.create_parser() passes kwargs to CommandParser."""
         epilog = "some epilog text"
@@ -467,6 +472,15 @@ class CommandRunTests(AdminScriptTestCase):
         out, err = self.run_manage(["set_option", "--skip-checks", "--set", "foo"])
         self.assertNoOutput(err)
         self.assertEqual(out.strip(), "Set foo")
+
+    def test_subparser_missing_positional_cli(self):
+        self.write_settings("settings.py", apps=["user_commands"])
+        out, err = self.run_manage(["subparser_required_name", "create"])
+        self.assertNoOutput(out)
+        self.assertIn("usage:", err)
+        self.assertIn("error: the following arguments are required: name", err)
+        self.assertNotIn("Traceback", err)
+        self.assertEqual(self.last_returncode, 2)
 
 
 class UtilsTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- ensure subparser actions default to Django's CommandParser
- propagate formatter and called_from_command_line flags to subparsers
- cover regression with programmatic and CLI tests plus harness support

## Reproduction Steps
1. Create a management command that defines a subparser with a required positional argument (`create` with a `name` as in the issue description).
2. Run `./manage.py <command> create` without providing the required `name` argument.
3. Observe that Django emits a traceback instead of the formatted usage/error output.

## Observed Failure Stack Trace
```
Traceback (most recent call last):
  File "/Users/chainz/tmp/subparserstest/./manage.py", line 21, in <module>
    main()
...
  File "/Users/chainz/Documents/Projects/django/django/core/management/base.py", line 72, in error
    raise CommandError("Error: %s" % message)
CommandError: Error: the following arguments are required: name
```

## Fix Details
- override `CommandParser.add_subparsers()` to default `parser_class` to `CommandParser`
- wrap the returned action's `add_parser()` to set default `called_from_command_line` and `formatter_class` when instantiating Django parsers
- extend `AdminScriptTestCase` to expose the subprocess return code for CLI assertions

## Tests Added
- `tests.user_commands.tests.CommandTests.test_subparser_missing_positional_programmatic`
- `tests.user_commands.tests.CommandRunTests.test_subparser_missing_positional_cli`

## Verification
- `PYTHONPATH=$PWD:$PWD/tests:$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.11 tests/runtests.py user_commands admin_scripts --parallel=1`
- `PYTHONPATH=$PWD:$PWD/tests:$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages python3.11 -m flake8 django/core/management/base.py tests/admin_scripts/tests.py tests/user_commands/tests.py tests/user_commands/management/commands/subparser_required_name.py`

## References
- Fixes #395
- Google Group discussion: https://groups.google.com/g/django-developers/c/oWcaxkxQ-KI/m/4NUhLjddBwAJ