### PR TITLE
swev-id: django__django-16485 - Clamp floatformat precision for zero

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -184,6 +184,8 @@ def floatformat(text, arg=-1):
     units = len(tupl[1])
     units += -tupl[2] if m else tupl[2]
     prec = abs(p) + units + 1
+    if prec < 1:
+        prec = 1
 
     # Avoid conversion to scientific notation by accessing `sign`, `digits`,
     # and `exponent` from Decimal.as_tuple() directly.

--- a/tests/template_tests/filter_tests/test_floatformat.py
+++ b/tests/template_tests/filter_tests/test_floatformat.py
@@ -112,6 +112,16 @@ class FunctionTests(SimpleTestCase):
             floatformat(0.000000000000000000015, 20), "0.00000000000000000002"
         )
 
+    def test_zero_precision_zero(self):
+        self.assertEqual(floatformat("0.00", 0), "0")
+        self.assertEqual(floatformat(Decimal("0.00"), 0), "0")
+        self.assertEqual(floatformat("-0.00", 0), "0")
+        self.assertEqual(floatformat(Decimal("-0.00"), 0), "0")
+        self.assertEqual(floatformat("0.00", "0g"), "0")
+        self.assertEqual(floatformat("0.00", "0u"), "0")
+        self.assertEqual(floatformat(0.5, 0), "1")
+        self.assertEqual(floatformat(-0.5, 0), "-1")
+
     def test_negative_zero_values(self):
         tests = [
             (-0.01, -1, "0.0"),


### PR DESCRIPTION
## Summary
- clamp the calculated precision in `floatformat()` to a minimum of 1 before creating the `Decimal` context, preventing `ValueError` on zero inputs
- add regression coverage for zero-valued inputs, suffix variants, and half-up rounding to ensure behaviour stays consistent

Resolves #398.

## Reproduction Steps
1. Checkout `django__django-16485` and ensure `asgiref` and `sqlparse` are available on `PYTHONPATH`
2. Run a Python shell and execute:
   ```python
   from django.template.defaultfilters import floatformat
   from decimal import Decimal
   floatformat("0.00", 0)
   floatformat(Decimal("0.00"), 0)
   ```

## Observed Failure
Both calls raise `ValueError: valid range for prec is [1, MAX_PREC]`:
```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "django/template/defaultfilters.py", line 190, in floatformat
    rounded_d = d.quantize(exp, ROUND_HALF_UP, Context(prec=prec))
                                               ^^^^^^^^^^^^^^^^^^
ValueError: valid range for prec is [1, MAX_PREC]
```

## Testing
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py template_tests --parallel=1` *(fails: template_tests.filter_tests.test_timeuntil.TimeuntilTests.test_timeuntil10, template_tests.filter_tests.test_timeuntil.TimeuntilTests.test_timeuntil11, template_tests.test_loaders.FileSystemLoaderTests.test_permissions_error — existing failures on the base branch)*
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages flake8 django/template/defaultfilters.py tests/template_tests/filter_tests/test_floatformat.py`