### PR TITLE
swev-id: django__django-16493 Fix FileField callable storage deconstruct

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -295,8 +295,9 @@ class FileField(Field):
         if kwargs.get("max_length") == 100:
             del kwargs["max_length"]
         kwargs["upload_to"] = self.upload_to
-        if self.storage is not default_storage:
-            kwargs["storage"] = getattr(self, "_storage_callable", self.storage)
+        storage_ref = getattr(self, "_storage_callable", self.storage)
+        if storage_ref is not default_storage:
+            kwargs["storage"] = storage_ref
         return name, path, args, kwargs
 
     def get_internal_type(self):

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -17,6 +17,7 @@ import custom_migration_operations.operations
 
 from django import get_version
 from django.conf import SettingsReference, settings
+from django.core.files.storage import InMemoryStorage, default_storage
 from django.core.validators import EmailValidator, RegexValidator
 from django.db import migrations, models
 from django.db.migrations.serializer import BaseSerializer
@@ -49,6 +50,14 @@ class TestModel1:
         return "/somewhere/dynamic/"
 
     thing = models.FileField(upload_to=upload_to)
+
+
+def storage_callable_default_storage():
+    return default_storage
+
+
+def storage_callable_custom_storage():
+    return InMemoryStorage()
 
 
 class TextEnum(enum.Enum):
@@ -412,6 +421,32 @@ class WriterTests(SimpleTestCase):
                 {"import migrations.test_writer"},
             ),
         )
+
+    def test_serialize_filefield_storage_callable_returns_default_storage_included(
+        self,
+    ):
+        field = models.FileField(storage=storage_callable_default_storage)
+        string, imports = MigrationWriter.serialize(field)
+        self.assertIn(
+            "storage=migrations.test_writer.storage_callable_default_storage",
+            string,
+        )
+        self.assertIn("import migrations.test_writer", imports)
+
+    def test_serialize_filefield_storage_callable_returns_custom_storage_included(self):
+        field = models.FileField(storage=storage_callable_custom_storage)
+        string, imports = MigrationWriter.serialize(field)
+        self.assertIn(
+            "storage=migrations.test_writer.storage_callable_custom_storage",
+            string,
+        )
+        self.assertIn("import migrations.test_writer", imports)
+
+    def test_serialize_filefield_no_callable_default_storage_omitted(self):
+        field = models.FileField(storage=default_storage)
+        string, imports = MigrationWriter.serialize(field)
+        self.assertNotIn("storage=", string)
+        self.assertNotIn("import migrations.test_writer", imports)
 
     def test_serialize_choices(self):
         class TextChoices(models.TextChoices):


### PR DESCRIPTION
## Summary
- add regression coverage for FileField storage callables returning default and non-default backends.
- compare the stored callable in FileField.deconstruct before deciding whether to serialize the storage kwarg.
- keep default-storage instances without callables omitted from deconstruction output.

Fixes #400.

## Reproduction Steps
1. Define a model where `FileField(storage=storage_callable)` uses a callable that randomly returns `default_storage` or another storage, e.g.:
   ```python
   other_storage = FileSystemStorage(location='/media/other')

   def get_storage():
       return random.choice([default_storage, other_storage])

   class MyModel(models.Model):
       my_file = models.FileField(storage=get_storage)
   ```
2. Run `python manage.py makemigrations myapp` repeatedly. Before this change the generated migration nondeterministically alternated between including or omitting `storage=myapp.models.get_storage` depending on the callable's return value.

## Observed failure and stack trace
```
Testing against Django installed in '/workspace/django/django'
Found 55 test(s).
System check identified no issues (0 silenced).
..............................F........................
======================================================================
FAIL: test_serialize_filefield_storage_callable_returns_default_storage_included (migrations.test_writer.WriterTests.test_serialize_filefield_storage_callable_returns_default_storage_included)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/migrations/test_writer.py", line 420, in test_serialize_filefield_storage_callable_returns_default_storage_included
    self.assertIn(
AssertionError: 'storage=migrations.test_writer.storage_callable_default_storage' not found in "models.FileField(upload_to='')"

----------------------------------------------------------------------
Ran 55 tests in 0.015s

FAILED (failures=1)
```

## Testing
- `PYTHONPATH=$PWD:tests DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py migrations.test_writer --parallel=1`
- `black --check django/db/models/fields/files.py tests/migrations/test_writer.py`