### PR TITLE
swev-id: django__django-16560 Add violation error code support

### DIFF
--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -33,6 +33,7 @@ class ExclusionConstraint(BaseConstraint):
         deferrable=None,
         include=None,
         violation_error_message=None,
+        violation_error_code=None,
     ):
         if index_type and index_type.lower() not in {"gist", "spgist"}:
             raise ValueError(
@@ -60,7 +61,11 @@ class ExclusionConstraint(BaseConstraint):
         self.condition = condition
         self.deferrable = deferrable
         self.include = tuple(include) if include else ()
-        super().__init__(name=name, violation_error_message=violation_error_message)
+        super().__init__(
+            name=name,
+            violation_error_message=violation_error_message,
+            violation_error_code=violation_error_code,
+        )
 
     def _get_expressions(self, schema_editor, query):
         expressions = []
@@ -150,6 +155,7 @@ class ExclusionConstraint(BaseConstraint):
                 and self.deferrable == other.deferrable
                 and self.include == other.include
                 and self.violation_error_message == other.violation_error_message
+                and self.violation_error_code == other.violation_error_code
             )
         return super().__eq__(other)
 
@@ -167,6 +173,11 @@ class ExclusionConstraint(BaseConstraint):
                 if self.violation_error_message is None
                 or self.violation_error_message == self.default_violation_error_message
                 else " violation_error_message=%r" % self.violation_error_message
+            )
+            + (
+                ""
+                if self.violation_error_code is None
+                else " violation_error_code=%r" % self.violation_error_code
             ),
         )
 
@@ -204,9 +215,15 @@ class ExclusionConstraint(BaseConstraint):
             queryset = queryset.exclude(pk=model_class_pk)
         if not self.condition:
             if queryset.exists():
-                raise ValidationError(self.get_violation_error_message())
+                raise ValidationError(
+                    self.get_violation_error_message(),
+                    code=self.get_violation_error_code(),
+                )
         else:
             if (self.condition & Exists(queryset.filter(self.condition))).check(
                 replacement_map, using=using
             ):
-                raise ValidationError(self.get_violation_error_message())
+                raise ValidationError(
+                    self.get_violation_error_message(),
+                    code=self.get_violation_error_code(),
+                )

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -22,7 +22,13 @@ class BaseConstraint:
 
     # RemovedInDjango60Warning: When the deprecation ends, replace with:
     # def __init__(self, *, name, violation_error_message=None):
-    def __init__(self, *args, name=None, violation_error_message=None):
+    def __init__(
+        self,
+        *args,
+        name=None,
+        violation_error_message=None,
+        violation_error_code=None,
+    ):
         # RemovedInDjango60Warning.
         if name is None and not args:
             raise TypeError(
@@ -34,6 +40,7 @@ class BaseConstraint:
             self.violation_error_message = violation_error_message
         else:
             self.violation_error_message = self.default_violation_error_message
+        self.violation_error_code = violation_error_code
         # RemovedInDjango60Warning.
         if args:
             warnings.warn(
@@ -65,6 +72,9 @@ class BaseConstraint:
     def get_violation_error_message(self):
         return self.violation_error_message % {"name": self.name}
 
+    def get_violation_error_code(self):
+        return self.violation_error_code
+
     def deconstruct(self):
         path = "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
         path = path.replace("django.db.models.constraints", "django.db.models")
@@ -74,6 +84,8 @@ class BaseConstraint:
             and self.violation_error_message != self.default_violation_error_message
         ):
             kwargs["violation_error_message"] = self.violation_error_message
+        if self.violation_error_code is not None:
+            kwargs["violation_error_code"] = self.violation_error_code
         return (path, (), kwargs)
 
     def clone(self):
@@ -82,13 +94,24 @@ class BaseConstraint:
 
 
 class CheckConstraint(BaseConstraint):
-    def __init__(self, *, check, name, violation_error_message=None):
+    def __init__(
+        self,
+        *,
+        check,
+        name,
+        violation_error_message=None,
+        violation_error_code=None,
+    ):
         self.check = check
         if not getattr(check, "conditional", False):
             raise TypeError(
                 "CheckConstraint.check must be a Q instance or boolean expression."
             )
-        super().__init__(name=name, violation_error_message=violation_error_message)
+        super().__init__(
+            name=name,
+            violation_error_message=violation_error_message,
+            violation_error_code=violation_error_code,
+        )
 
     def _get_check_sql(self, model, schema_editor):
         query = Query(model=model, alias_cols=False)
@@ -112,7 +135,10 @@ class CheckConstraint(BaseConstraint):
         against = instance._get_field_value_map(meta=model._meta, exclude=exclude)
         try:
             if not Q(self.check).check(against, using=using):
-                raise ValidationError(self.get_violation_error_message())
+                raise ValidationError(
+                    self.get_violation_error_message(),
+                    code=self.get_violation_error_code(),
+                )
         except FieldError:
             pass
 
@@ -126,6 +152,11 @@ class CheckConstraint(BaseConstraint):
                 if self.violation_error_message is None
                 or self.violation_error_message == self.default_violation_error_message
                 else " violation_error_message=%r" % self.violation_error_message
+            )
+            + (
+                ""
+                if self.violation_error_code is None
+                else " violation_error_code=%r" % self.violation_error_code
             ),
         )
 
@@ -135,6 +166,7 @@ class CheckConstraint(BaseConstraint):
                 self.name == other.name
                 and self.check == other.check
                 and self.violation_error_message == other.violation_error_message
+                and self.violation_error_code == other.violation_error_code
             )
         return super().__eq__(other)
 
@@ -164,6 +196,7 @@ class UniqueConstraint(BaseConstraint):
         include=None,
         opclasses=(),
         violation_error_message=None,
+        violation_error_code=None,
     ):
         if not name:
             raise ValueError("A unique constraint must be named.")
@@ -213,7 +246,11 @@ class UniqueConstraint(BaseConstraint):
             F(expression) if isinstance(expression, str) else expression
             for expression in expressions
         )
-        super().__init__(name=name, violation_error_message=violation_error_message)
+        super().__init__(
+            name=name,
+            violation_error_message=violation_error_message,
+            violation_error_code=violation_error_code,
+        )
 
     @property
     def contains_expressions(self):
@@ -307,6 +344,11 @@ class UniqueConstraint(BaseConstraint):
                 if self.violation_error_message is None
                 or self.violation_error_message == self.default_violation_error_message
                 else " violation_error_message=%r" % self.violation_error_message
+            )
+            + (
+                ""
+                if self.violation_error_code is None
+                else " violation_error_code=%r" % self.violation_error_code
             ),
         )
 
@@ -321,6 +363,7 @@ class UniqueConstraint(BaseConstraint):
                 and self.opclasses == other.opclasses
                 and self.expressions == other.expressions
                 and self.violation_error_message == other.violation_error_message
+                and self.violation_error_code == other.violation_error_code
             )
         return super().__eq__(other)
 
@@ -385,7 +428,10 @@ class UniqueConstraint(BaseConstraint):
         if not self.condition:
             if queryset.exists():
                 if self.expressions:
-                    raise ValidationError(self.get_violation_error_message())
+                    raise ValidationError(
+                        self.get_violation_error_message(),
+                        code=self.get_violation_error_code(),
+                    )
                 # When fields are defined, use the unique_error_message() for
                 # backward compatibility.
                 for model, constraints in instance.get_constraints():
@@ -400,6 +446,9 @@ class UniqueConstraint(BaseConstraint):
                 if (self.condition & Exists(queryset.filter(self.condition))).check(
                     against, using=using
                 ):
-                    raise ValidationError(self.get_violation_error_message())
+                    raise ValidationError(
+                        self.get_violation_error_message(),
+                        code=self.get_violation_error_code(),
+                    )
             except FieldError:
                 pass

--- a/docs/ref/contrib/postgres/constraints.txt
+++ b/docs/ref/contrib/postgres/constraints.txt
@@ -12,7 +12,7 @@ PostgreSQL supports additional data integrity constraints available from the
 ``ExclusionConstraint``
 =======================
 
-.. class:: ExclusionConstraint(*, name, expressions, index_type=None, condition=None, deferrable=None, include=None, violation_error_message=None)
+.. class:: ExclusionConstraint(*, name, expressions, index_type=None, condition=None, deferrable=None, include=None, violation_error_message=None, violation_error_code=None)
 
     Creates an exclusion constraint in the database. Internally, PostgreSQL
     implements exclusion constraints using indexes. The default index type is
@@ -139,6 +139,13 @@ used for queries that select only included fields
 The error message used when ``ValidationError`` is raised during
 :ref:`model validation <validating-objects>`. Defaults to
 :attr:`.BaseConstraint.violation_error_message`.
+
+``violation_error_code``
+------------------------
+
+The error code used when ``ValidationError`` is raised during
+:ref:`model validation <validating-objects>`. Defaults to
+:attr:`.BaseConstraint.violation_error_code`.
 
 Examples
 --------

--- a/docs/ref/models/constraints.txt
+++ b/docs/ref/models/constraints.txt
@@ -48,7 +48,7 @@ option.
 ``BaseConstraint``
 ==================
 
-.. class:: BaseConstraint(*, name, violation_error_message=None)
+.. class:: BaseConstraint(*, name, violation_error_message=None, violation_error_code=None)
 
     Base class for all constraints. Subclasses must implement
     ``constraint_sql()``, ``create_sql()``, ``remove_sql()`` and
@@ -77,6 +77,15 @@ The error message used when ``ValidationError`` is raised during
 :ref:`model validation <validating-objects>`. Defaults to
 ``"Constraint “%(name)s” is violated."``.
 
+``violation_error_code``
+------------------------
+
+.. attribute:: BaseConstraint.violation_error_code
+
+The error code used when ``ValidationError`` is raised during
+:ref:`model validation <validating-objects>`. Defaults to ``None``. The
+code is only added to errors raised by :meth:`validate() <BaseConstraint.validate>`.
+
 ``validate()``
 --------------
 
@@ -94,7 +103,7 @@ This method must be implemented by a subclass.
 ``CheckConstraint``
 ===================
 
-.. class:: CheckConstraint(*, check, name, violation_error_message=None)
+.. class:: CheckConstraint(*, check, name, violation_error_message=None, violation_error_code=None)
 
     Creates a check constraint in the database.
 
@@ -121,7 +130,7 @@ ensures the age field is never less than 18.
 ``UniqueConstraint``
 ====================
 
-.. class:: UniqueConstraint(*expressions, fields=(), name=None, condition=None, deferrable=None, include=None, opclasses=(), violation_error_message=None)
+.. class:: UniqueConstraint(*expressions, fields=(), name=None, condition=None, deferrable=None, include=None, opclasses=(), violation_error_message=None, violation_error_code=None)
 
     Creates a unique constraint in the database.
 
@@ -257,3 +266,16 @@ This message is *not used* for :class:`UniqueConstraint`\s with
 same message as constraints defined with
 :attr:`.Field.unique` or in
 :attr:`Meta.unique_together <django.db.models.Options.constraints>`.
+
+``violation_error_code``
+------------------------
+
+.. attribute:: UniqueConstraint.violation_error_code
+
+The error code used when ``ValidationError`` is raised during
+:ref:`model validation <validating-objects>`. Defaults to
+:attr:`.BaseConstraint.violation_error_code`. The code is applied to violations
+detected by :meth:`~BaseConstraint.validate` for expression-based constraints
+and conditional checks. When :meth:`~Model.unique_error_message
+<django.db.models.Model.unique_error_message>` is used (for example, field-based
+constraints without conditions), the code from that method takes precedence.

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -61,11 +61,19 @@ class BaseConstraintTests(SimpleTestCase):
             c.get_violation_error_message(), "Constraint “name” is violated."
         )
 
+    def test_default_violation_error_code(self):
+        c = BaseConstraint(name="name")
+        self.assertIsNone(c.get_violation_error_code())
+
     def test_custom_violation_error_message(self):
         c = BaseConstraint(
             name="base_name", violation_error_message="custom %(name)s message"
         )
         self.assertEqual(c.get_violation_error_message(), "custom base_name message")
+
+    def test_custom_violation_error_code(self):
+        c = BaseConstraint(name="base_name", violation_error_code="custom_code")
+        self.assertEqual(c.get_violation_error_code(), "custom_code")
 
     def test_custom_violation_error_message_clone(self):
         constraint = BaseConstraint(
@@ -76,6 +84,13 @@ class BaseConstraintTests(SimpleTestCase):
             constraint.get_violation_error_message(),
             "custom base_name message",
         )
+
+    def test_custom_violation_error_code_clone(self):
+        constraint = BaseConstraint(
+            name="base_name",
+            violation_error_code="custom_code",
+        ).clone()
+        self.assertEqual(constraint.get_violation_error_code(), "custom_code")
 
     def test_deconstruction(self):
         constraint = BaseConstraint(
@@ -88,6 +103,19 @@ class BaseConstraintTests(SimpleTestCase):
         self.assertEqual(
             kwargs,
             {"name": "base_name", "violation_error_message": "custom %(name)s message"},
+        )
+
+    def test_deconstruction_with_violation_error_code(self):
+        constraint = BaseConstraint(
+            name="base_name",
+            violation_error_code="custom_code",
+        )
+        path, args, kwargs = constraint.deconstruct()
+        self.assertEqual(path, "django.db.models.BaseConstraint")
+        self.assertEqual(args, ())
+        self.assertEqual(
+            kwargs,
+            {"name": "base_name", "violation_error_code": "custom_code"},
         )
 
     def test_deprecation(self):
@@ -140,12 +168,34 @@ class CheckConstraintTests(TestCase):
                 check=check1, name="price", violation_error_message="other custom error"
             ),
         )
+        self.assertNotEqual(
+            models.CheckConstraint(check=check1, name="price"),
+            models.CheckConstraint(
+                check=check1, name="price", violation_error_code="code"
+            ),
+        )
         self.assertEqual(
             models.CheckConstraint(
                 check=check1, name="price", violation_error_message="custom error"
             ),
             models.CheckConstraint(
                 check=check1, name="price", violation_error_message="custom error"
+            ),
+        )
+        self.assertNotEqual(
+            models.CheckConstraint(
+                check=check1, name="price", violation_error_code="code"
+            ),
+            models.CheckConstraint(
+                check=check1, name="price", violation_error_code="other-code"
+            ),
+        )
+        self.assertEqual(
+            models.CheckConstraint(
+                check=check1, name="price", violation_error_code="code"
+            ),
+            models.CheckConstraint(
+                check=check1, name="price", violation_error_code="code"
             ),
         )
 
@@ -172,6 +222,18 @@ class CheckConstraintTests(TestCase):
             "violation_error_message='More than 1'>",
         )
 
+    def test_repr_with_violation_error_code(self):
+        constraint = models.CheckConstraint(
+            check=models.Q(price__lt=1),
+            name="price_lt_one",
+            violation_error_code="check_code",
+        )
+        self.assertEqual(
+            repr(constraint),
+            "<CheckConstraint: check=(AND: ('price__lt', 1)) name='price_lt_one' "
+            "violation_error_code='check_code'>",
+        )
+
     def test_invalid_check_types(self):
         msg = "CheckConstraint.check must be a Q instance or boolean expression."
         with self.assertRaisesMessage(TypeError, msg):
@@ -185,6 +247,22 @@ class CheckConstraintTests(TestCase):
         self.assertEqual(path, "django.db.models.CheckConstraint")
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {"check": check, "name": name})
+
+    def test_deconstruction_with_violation_error_code(self):
+        check = models.Q(price__gt=models.F("discounted_price"))
+        name = "price_gt_discounted_price"
+        constraint = models.CheckConstraint(
+            check=check,
+            name=name,
+            violation_error_code="check_code",
+        )
+        path, args, kwargs = constraint.deconstruct()
+        self.assertEqual(path, "django.db.models.CheckConstraint")
+        self.assertEqual(args, ())
+        self.assertEqual(
+            kwargs,
+            {"check": check, "name": name, "violation_error_code": "check_code"},
+        )
 
     @skipUnlessDBFeature("supports_table_check_constraints")
     def test_database_constraint(self):
@@ -236,6 +314,31 @@ class CheckConstraintTests(TestCase):
         )
         # Valid product.
         constraint.validate(Product, Product(price=10, discounted_price=5))
+
+    def test_validate_custom_violation_error_code(self):
+        constraint = models.CheckConstraint(
+            check=models.Q(price__gt=models.F("discounted_price")),
+            name="price",
+            violation_error_code="custom_code",
+        )
+        with self.assertRaises(ValidationError) as caught:
+            constraint.validate(
+                Product,
+                Product(price=10, discounted_price=42),
+            )
+        self.assertEqual(caught.exception.code, "custom_code")
+
+    def test_validate_default_violation_error_code_is_none(self):
+        constraint = models.CheckConstraint(
+            check=models.Q(price__gt=models.F("discounted_price")),
+            name="price",
+        )
+        with self.assertRaises(ValidationError) as caught:
+            constraint.validate(
+                Product,
+                Product(price=10, discounted_price=42),
+            )
+        self.assertIsNone(caught.exception.code)
 
     def test_validate_boolean_expressions(self):
         constraint = models.CheckConstraint(
@@ -318,6 +421,14 @@ class UniqueConstraintTests(TestCase):
             ),
         )
         self.assertNotEqual(
+            models.UniqueConstraint(fields=["foo", "bar"], name="unique"),
+            models.UniqueConstraint(
+                fields=["foo", "bar"],
+                name="unique",
+                violation_error_code="unique_code",
+            ),
+        )
+        self.assertNotEqual(
             models.UniqueConstraint(
                 fields=["foo", "bar"],
                 name="unique",
@@ -339,6 +450,30 @@ class UniqueConstraintTests(TestCase):
                 fields=["foo", "bar"],
                 name="unique",
                 violation_error_message="custom error",
+            ),
+        )
+        self.assertNotEqual(
+            models.UniqueConstraint(
+                fields=["foo", "bar"],
+                name="unique",
+                violation_error_code="unique_code",
+            ),
+            models.UniqueConstraint(
+                fields=["foo", "bar"],
+                name="unique",
+                violation_error_code="other_code",
+            ),
+        )
+        self.assertEqual(
+            models.UniqueConstraint(
+                fields=["foo", "bar"],
+                name="unique",
+                violation_error_code="unique_code",
+            ),
+            models.UniqueConstraint(
+                fields=["foo", "bar"],
+                name="unique",
+                violation_error_code="unique_code",
             ),
         )
 
@@ -512,6 +647,20 @@ class UniqueConstraintTests(TestCase):
             ),
         )
 
+    def test_repr_with_violation_error_code(self):
+        constraint = models.UniqueConstraint(
+            models.F("baz__lower"),
+            name="unique_lower_baz",
+            violation_error_code="unique_code",
+        )
+        self.assertEqual(
+            repr(constraint),
+            (
+                "<UniqueConstraint: expressions=(F(baz__lower),) "
+                "name='unique_lower_baz' violation_error_code='unique_code'>"
+            ),
+        )
+
     def test_deconstruction(self):
         fields = ["foo", "bar"]
         name = "unique_fields"
@@ -520,6 +669,26 @@ class UniqueConstraintTests(TestCase):
         self.assertEqual(path, "django.db.models.UniqueConstraint")
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {"fields": tuple(fields), "name": name})
+
+    def test_deconstruction_with_violation_error_code(self):
+        fields = ["foo", "bar"]
+        name = "unique_fields"
+        constraint = models.UniqueConstraint(
+            fields=fields,
+            name=name,
+            violation_error_code="unique_code",
+        )
+        path, args, kwargs = constraint.deconstruct()
+        self.assertEqual(path, "django.db.models.UniqueConstraint")
+        self.assertEqual(args, ())
+        self.assertEqual(
+            kwargs,
+            {
+                "fields": tuple(fields),
+                "name": name,
+                "violation_error_code": "unique_code",
+            },
+        )
 
     def test_deconstruction_with_condition(self):
         fields = ["foo", "bar"]
@@ -660,8 +829,10 @@ class UniqueConstraintTests(TestCase):
         non_unique_product = UniqueConstraintProduct(
             name=self.p1.name, color=self.p1.color
         )
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(UniqueConstraintProduct, non_unique_product)
+        self.assertEqual(caught.exception.error_list[0].code, "unique_together")
+        self.assertEqual(caught.exception.messages, [msg])
         # Null values are ignored.
         constraint.validate(
             UniqueConstraintProduct,
@@ -686,22 +857,26 @@ class UniqueConstraintTests(TestCase):
             exclude={"name", "color"},
         )
         # Validation on a child instance.
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(
                 UniqueConstraintProduct,
                 ChildUniqueConstraintProduct(name=self.p1.name, color=self.p1.color),
             )
+        self.assertEqual(caught.exception.error_list[0].code, "unique_together")
+        self.assertEqual(caught.exception.messages, [msg])
 
     @skipUnlessDBFeature("supports_partial_indexes")
     def test_validate_condition(self):
         p1 = UniqueConstraintConditionProduct.objects.create(name="p1")
         constraint = UniqueConstraintConditionProduct._meta.constraints[0]
         msg = "Constraint “name_without_color_uniq” is violated."
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(
                 UniqueConstraintConditionProduct,
                 UniqueConstraintConditionProduct(name=p1.name, color=None),
             )
+        self.assertIsNone(caught.exception.code)
+        self.assertEqual(caught.exception.messages, [msg])
         # Values not matching condition are ignored.
         constraint.validate(
             UniqueConstraintConditionProduct,
@@ -719,11 +894,13 @@ class UniqueConstraintTests(TestCase):
     def test_validate_expression(self):
         constraint = models.UniqueConstraint(Lower("name"), name="name_lower_uniq")
         msg = "Constraint “name_lower_uniq” is violated."
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(
                 UniqueConstraintProduct,
                 UniqueConstraintProduct(name=self.p1.name.upper()),
             )
+        self.assertIsNone(caught.exception.code)
+        self.assertEqual(caught.exception.messages, [msg])
         constraint.validate(
             UniqueConstraintProduct,
             UniqueConstraintProduct(name="another-name"),
@@ -737,16 +914,33 @@ class UniqueConstraintTests(TestCase):
             exclude={"name"},
         )
 
+    def test_validate_expression_with_violation_error_code(self):
+        constraint = models.UniqueConstraint(
+            Lower("name"),
+            name="name_lower_uniq",
+            violation_error_code="unique_code",
+        )
+        msg = "Constraint “name_lower_uniq” is violated."
+        with self.assertRaises(ValidationError) as caught:
+            constraint.validate(
+                UniqueConstraintProduct,
+                UniqueConstraintProduct(name=self.p1.name.upper()),
+            )
+        self.assertEqual(caught.exception.code, "unique_code")
+        self.assertEqual(caught.exception.messages, [msg])
+
     def test_validate_ordered_expression(self):
         constraint = models.UniqueConstraint(
             Lower("name").desc(), name="name_lower_uniq_desc"
         )
         msg = "Constraint “name_lower_uniq_desc” is violated."
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(
                 UniqueConstraintProduct,
                 UniqueConstraintProduct(name=self.p1.name.upper()),
             )
+        self.assertIsNone(caught.exception.code)
+        self.assertEqual(caught.exception.messages, [msg])
         constraint.validate(
             UniqueConstraintProduct,
             UniqueConstraintProduct(name="another-name"),
@@ -759,6 +953,20 @@ class UniqueConstraintTests(TestCase):
             UniqueConstraintProduct(name=self.p1.name.upper()),
             exclude={"name"},
         )
+
+    def test_validate_expression_condition_with_violation_error_code(self):
+        constraint = models.UniqueConstraint(
+            Lower("name"),
+            name="name_lower_without_color_uniq",
+            condition=models.Q(color__isnull=True),
+            violation_error_code="condition_code",
+        )
+        non_unique_product = UniqueConstraintProduct(name=self.p2.name.upper())
+        msg = "Constraint “name_lower_without_color_uniq” is violated."
+        with self.assertRaises(ValidationError) as caught:
+            constraint.validate(UniqueConstraintProduct, non_unique_product)
+        self.assertEqual(caught.exception.code, "condition_code")
+        self.assertEqual(caught.exception.messages, [msg])
 
     def test_validate_expression_condition(self):
         constraint = models.UniqueConstraint(
@@ -768,8 +976,10 @@ class UniqueConstraintTests(TestCase):
         )
         non_unique_product = UniqueConstraintProduct(name=self.p2.name.upper())
         msg = "Constraint “name_lower_without_color_uniq” is violated."
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(UniqueConstraintProduct, non_unique_product)
+        self.assertIsNone(caught.exception.code)
+        self.assertEqual(caught.exception.messages, [msg])
         # Values not matching condition are ignored.
         constraint.validate(
             UniqueConstraintProduct,
@@ -793,16 +1003,34 @@ class UniqueConstraintTests(TestCase):
     def test_validate_expression_str(self):
         constraint = models.UniqueConstraint("name", name="name_uniq")
         msg = "Constraint “name_uniq” is violated."
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(
                 UniqueConstraintProduct,
                 UniqueConstraintProduct(name=self.p1.name),
             )
+        self.assertIsNone(caught.exception.code)
+        self.assertEqual(caught.exception.messages, [msg])
         constraint.validate(
             UniqueConstraintProduct,
             UniqueConstraintProduct(name=self.p1.name),
             exclude={"name"},
         )
+
+    def test_validate_condition_with_violation_error_code(self):
+        constraint = models.UniqueConstraint(
+            fields=["name"],
+            name="name_without_color_uniq",
+            condition=models.Q(color__isnull=True),
+            violation_error_code="condition_code",
+        )
+        msg = "Constraint “name_without_color_uniq” is violated."
+        with self.assertRaises(ValidationError) as caught:
+            constraint.validate(
+                UniqueConstraintProduct,
+                UniqueConstraintProduct(name=self.p2.name),
+            )
+        self.assertEqual(caught.exception.code, "condition_code")
+        self.assertEqual(caught.exception.messages, [msg])
 
     def test_name(self):
         constraints = get_constraints(UniqueConstraintProduct._meta.db_table)

--- a/tests/postgres_tests/test_constraints.py
+++ b/tests/postgres_tests/test_constraints.py
@@ -397,6 +397,17 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
             "(F(datespan), '-|-')] name='exclude_overlapping' "
             "violation_error_message='Overlapping must be excluded'>",
         )
+        constraint = ExclusionConstraint(
+            name="exclude_overlapping",
+            expressions=[(F("datespan"), RangeOperators.ADJACENT_TO)],
+            violation_error_code="exclude_code",
+        )
+        self.assertEqual(
+            repr(constraint),
+            "<ExclusionConstraint: index_type='GIST' expressions=["
+            "(F(datespan), '-|-')] name='exclude_overlapping' "
+            "violation_error_code='exclude_code'>",
+        )
 
     def test_eq(self):
         constraint_1 = ExclusionConstraint(
@@ -470,6 +481,24 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
             condition=Q(cancelled=False),
             violation_error_message="other custom error",
         )
+        constraint_12 = ExclusionConstraint(
+            name="exclude_overlapping",
+            expressions=[
+                (F("datespan"), RangeOperators.OVERLAPS),
+                (F("room"), RangeOperators.EQUAL),
+            ],
+            condition=Q(cancelled=False),
+            violation_error_code="exclude_code",
+        )
+        constraint_13 = ExclusionConstraint(
+            name="exclude_overlapping",
+            expressions=[
+                (F("datespan"), RangeOperators.OVERLAPS),
+                (F("room"), RangeOperators.EQUAL),
+            ],
+            condition=Q(cancelled=False),
+            violation_error_code="other_code",
+        )
         self.assertEqual(constraint_1, constraint_1)
         self.assertEqual(constraint_1, mock.ANY)
         self.assertNotEqual(constraint_1, constraint_2)
@@ -484,6 +513,9 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
         self.assertNotEqual(constraint_1, object())
         self.assertNotEqual(constraint_10, constraint_11)
         self.assertEqual(constraint_10, constraint_10)
+        self.assertNotEqual(constraint_1, constraint_12)
+        self.assertNotEqual(constraint_12, constraint_13)
+        self.assertEqual(constraint_12, constraint_12)
 
     def test_deconstruct(self):
         constraint = ExclusionConstraint(
@@ -506,6 +538,32 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
                     ("datespan", RangeOperators.OVERLAPS),
                     ("room", RangeOperators.EQUAL),
                 ],
+            },
+        )
+
+    def test_deconstruct_violation_error_code(self):
+        constraint = ExclusionConstraint(
+            name="exclude_overlapping",
+            expressions=[
+                ("datespan", RangeOperators.OVERLAPS),
+                ("room", RangeOperators.EQUAL),
+            ],
+            violation_error_code="exclude_code",
+        )
+        path, args, kwargs = constraint.deconstruct()
+        self.assertEqual(
+            path, "django.contrib.postgres.constraints.ExclusionConstraint"
+        )
+        self.assertEqual(args, ())
+        self.assertEqual(
+            kwargs,
+            {
+                "name": "exclude_overlapping",
+                "expressions": [
+                    ("datespan", RangeOperators.OVERLAPS),
+                    ("room", RangeOperators.EQUAL),
+                ],
+                "violation_error_code": "exclude_code",
             },
         )
 
@@ -765,11 +823,26 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
         range_obj = RangesModel.objects.create(ints=(20, 50))
         constraint.validate(RangesModel, range_obj)
         msg = "Custom error message."
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertRaises(ValidationError) as caught:
             constraint.validate(RangesModel, RangesModel(ints=(10, 20)))
+        self.assertEqual(caught.exception.messages, [msg])
+        self.assertIsNone(caught.exception.code)
         constraint.validate(RangesModel, RangesModel(ints=(10, 19)))
         constraint.validate(RangesModel, RangesModel(ints=(51, 60)))
         constraint.validate(RangesModel, RangesModel(ints=(10, 20)), exclude={"ints"})
+
+    def test_validate_range_adjacent_violation_error_code(self):
+        constraint = ExclusionConstraint(
+            name="ints_adjacent",
+            expressions=[("ints", RangeOperators.ADJACENT_TO)],
+            violation_error_code="exclude_code",
+        )
+        RangesModel.objects.create(ints=(20, 50))
+        msg = f"Constraint “{constraint.name}” is violated."
+        with self.assertRaises(ValidationError) as caught:
+            constraint.validate(RangesModel, RangesModel(ints=(10, 20)))
+        self.assertEqual(caught.exception.messages, [msg])
+        self.assertEqual(caught.exception.code, "exclude_code")
 
     def test_expressions_with_params(self):
         constraint_name = "scene_left_equal"


### PR DESCRIPTION
## Summary
- add `violation_error_code` plumbing to `BaseConstraint`, `CheckConstraint`, `UniqueConstraint`, and Postgres `ExclusionConstraint`
- propagate custom codes through validation, deconstruction, repr, and equality while keeping field-based unique constraints on legacy `unique`/`unique_together` codes
- expand constraint tests and docs to cover custom violation codes

Fixes #406

## Reproduction
1. nix profile add nixpkgs#python311
2. python3.11 -m venv /workspace/.venv
3. /workspace/.venv/bin/pip install --upgrade pip && /workspace/.venv/bin/pip install asgiref sqlparse pytz
4. PYTHONPATH=$PWD /workspace/.venv/bin/python tests/runtests.py constraints --parallel=1

Observed failure:
```
FAIL: test_validate_custom_violation_error_code (constraints.tests.CheckConstraintTests.test_validate_custom_violation_error_code)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/constraints/tests.py", line 251, in test_validate_custom_violation_error_code
    self.assertEqual(caught.exception.code, "custom_code")
AssertionError: None != 'custom_code'
```

## Testing
- PYTHONPATH=$PWD /workspace/.venv/bin/python tests/runtests.py constraints --parallel=1
- PYTHONPATH=$PWD /workspace/.venv/bin/python tests/runtests.py postgres_tests.test_constraints.ExclusionConstraintTests --parallel=1
- PYTHONPATH=$PWD /workspace/.venv/bin/flake8 django/db/models/constraints.py django/contrib/postgres/constraints.py tests/constraints/tests.py tests/postgres_tests/test_constraints.py

_No CI was run per instructions._