### PR TITLE
Fix FormSet add_fields() when index=None and can_delete_extra=False (empty_form) — swev-id: django__django-16569

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -490,7 +490,11 @@ class BaseFormSet(RenderableFormMixin):
                     required=False,
                     widget=self.get_ordering_widget(),
                 )
-        if self.can_delete and (self.can_delete_extra or index < initial_form_count):
+        # Only compare index with initial_form_count when index is not None.
+        if self.can_delete and (
+            self.can_delete_extra
+            or (index is not None and index < initial_form_count)
+        ):
             form.fields[DELETION_FIELD_NAME] = BooleanField(
                 label=_("Delete"),
                 required=False,

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1507,6 +1507,21 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertIs(formset._should_delete_form(formset.forms[1]), False)
         self.assertIs(formset._should_delete_form(formset.forms[2]), False)
 
+    def test_empty_form_delete_field_respects_can_delete_extra(self):
+        for can_delete_extra, assertion in (
+            (False, self.assertNotIn),
+            (True, self.assertIn),
+        ):
+            with self.subTest(can_delete_extra=can_delete_extra):
+                choice_formset = formset_factory(
+                    Choice,
+                    can_delete=True,
+                    can_delete_extra=can_delete_extra,
+                    extra=2,
+                )
+                empty_form = choice_formset().empty_form
+                assertion("DELETE", empty_form.fields)
+
     def test_template_name_uses_renderer_value(self):
         class CustomRenderer(TemplatesSetting):
             formset_template_name = "a/custom/formset/template.html"


### PR DESCRIPTION
Fixes #407

## Reproduction
1. From the issue branch, run:
   ```
   tox -e py3 -- forms_tests.tests.test_formsets.FormsFormsetTestCase.test_empty_form_delete_field_respects_can_delete_extra
   ```
2. Observe the failure:
   ```
   Traceback (most recent call last):
     File "/workspace/django/tests/runtests.py", line 770, in <module>
       failures = django_tests(
     File "/workspace/django/tests/runtests.py", line 429, in django_tests
       failures = test_runner.run_tests(test_labels)
     File "/workspace/django/django/test/runner.py", line 1031, in run_tests
       suite = self.build_suite(test_labels)
     File "/workspace/django/django/test/runner.py", line 889, in build_suite
       tests = self.load_tests_for_label(label, discover_kwargs)
     File "/workspace/django/django/test/runner.py", line 847, in load_tests_for_label
       tests = self.test_loader.loadTestsFromName(label)
     File "/nix/store/kbyysxq0ry8vqbpkdwld118fi92wvqsf-python3-3.11.14/lib/python3.11/unittest/loader.py", line 217, in loadTestsFromName
       test = obj()
     File "/workspace/django/tests/forms_tests/tests/test_formsets.py", line 1620, in test_empty_form_delete_field_respects_can_delete_extra
       empty_form = choice_formset().empty_form
     File "/workspace/django/django/forms/formsets.py", line 267, in empty_form
       self.add_fields(form, None)
     File "/workspace/django/django/forms/formsets.py", line 493, in add_fields
       if self.can_delete and (self.can_delete_extra or index < initial_form_count):
   TypeError: '<' not supported between instances of 'NoneType' and 'int'
   ```

## Summary
- Guard `BaseFormSet.add_fields()` against comparing `None` with `initial_form_count` so empty forms respect `can_delete_extra`.
- Add regression coverage for `empty_form` when `can_delete_extra` is toggled.

## Testing
- `tox -e py3 -- forms_tests.tests.test_formsets.FormsFormsetTestCase.test_empty_form_delete_field_respects_can_delete_extra`
- `tox -e py3 -- forms_tests`
- `flake8 django/forms/formsets.py tests/forms_tests/tests/test_formsets.py`