### PR TITLE
swev-id: django__django-16595 collapse consecutive AlterField reductions

### DIFF
--- a/django/db/migrations/operations/fields.py
+++ b/django/db/migrations/operations/fields.py
@@ -247,6 +247,10 @@ class AlterField(FieldOperation):
         return "alter_%s_%s" % (self.model_name_lower, self.name_lower)
 
     def reduce(self, operation, app_label):
+        if isinstance(operation, AlterField) and self.is_same_field_operation(
+            operation
+        ):
+            return [operation]
         if isinstance(operation, RemoveField) and self.is_same_field_operation(
             operation
         ):

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -796,6 +796,71 @@ class OptimizerTests(SimpleTestCase):
             ],
         )
 
+    def test_reduce_consecutive_alterfield_same_field_to_final(self):
+        self.assertOptimizesTo(
+            [
+                migrations.AlterField("Foo", "age", models.IntegerField()),
+                migrations.AlterField("Foo", "age", models.FloatField()),
+                migrations.AlterField(
+                    "Foo",
+                    "age",
+                    models.DecimalField(max_digits=5, decimal_places=2),
+                ),
+            ],
+            [
+                migrations.AlterField(
+                    "Foo",
+                    "age",
+                    models.DecimalField(max_digits=5, decimal_places=2),
+                ),
+            ],
+        )
+
+    def test_addfield_separated_by_barrier_then_alterfields_collapse_only_after_barrier(
+        self,
+    ):
+        self.assertOptimizesTo(
+            [
+                migrations.AddField("Foo", "age", models.IntegerField()),
+                migrations.RunPython(migrations.RunPython.noop),
+                migrations.AlterField("Foo", "age", models.FloatField()),
+                migrations.AlterField(
+                    "Foo",
+                    "age",
+                    models.DecimalField(max_digits=5, decimal_places=2),
+                ),
+            ],
+            [
+                migrations.AddField("Foo", "age", models.IntegerField()),
+                migrations.RunPython(migrations.RunPython.noop),
+                migrations.AlterField(
+                    "Foo",
+                    "age",
+                    models.DecimalField(max_digits=5, decimal_places=2),
+                ),
+            ],
+        )
+
+    def test_addfield_then_chained_alterfields_merge_to_addfield_final(self):
+        self.assertOptimizesTo(
+            [
+                migrations.AddField("Foo", "age", models.IntegerField()),
+                migrations.AlterField("Foo", "age", models.FloatField()),
+                migrations.AlterField(
+                    "Foo",
+                    "age",
+                    models.DecimalField(max_digits=5, decimal_places=2),
+                ),
+            ],
+            [
+                migrations.AddField(
+                    "Foo",
+                    name="age",
+                    field=models.DecimalField(max_digits=5, decimal_places=2),
+                ),
+            ],
+        )
+
     def test_add_field_delete_field(self):
         """
         RemoveField should cancel AddField


### PR DESCRIPTION
## Summary
- collapse back-to-back AlterField operations on the same field to the latest mutation
- ensure optimizer keeps barriers intact while merging trailing AlterField steps
- extend coverage for AddField followed by chained AlterField updates

## Reproduction Steps
1. source the virtualenv
2. run:
   ```bash
   PYTHONPATH=/workspace/django \
   DJANGO_SETTINGS_MODULE=tests.test_sqlite \
   python tests/runtests.py migrations.test_optimizer.OptimizerTests --parallel=1
   ```

## Observed Failure
```text
Testing against Django installed in '/workspace/django/django'
Found 40 test(s).
System check identified no issues (0 silenced).
...F...............................F....
======================================================================
FAIL: test_addfield_separated_by_barrier_then_alterfields_collapse_only_after_barrier (migrations.test_optimizer.OptimizerTests.test_addfield_separated_by_barrier_then_alterfields_collapse_only_after_barrier)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/migrations/test_optimizer.py", line 822, in test_addfield_separated_by_barrier_then_alterfields_collapse_only_after_barrier
    self.assertOptimizesTo(
  File "/workspace/django/tests/migrations/test_optimizer.py", line 31, in assertOptimizesTo
    self.assertEqual(expected, result)
AssertionError: Lists differ: ["mig[268 chars]dels.DecimalField(decimal_places=2, max_digits=5),\n)"] != ["mig[268 chars]dels.FloatField(),\n)", "migrations.AlterField[105 chars]\n)"]

First differing element 2:
"migr[63 chars] field=models.DecimalField(decimal_places=2, max_digits=5),\n)"
"migr[63 chars] field=models.FloatField(),\n)"

Second list contains 1 additional elements.
First extra element 3:
"migrations.AlterField(\n    model_name='Foo',\n    name='age',\n    field=models.DecimalField(decimal_places=2, max_digits=5),\n)"

  ['migrations.AddField(\n'
   "    model_name='Foo',\n"
   "    name='age',\n"
   '    field=models.IntegerField(),\n'
   ')',
   'migrations.RunPython(\n'
   '    code=django.db.migrations.operations.special.RunPython.noop,\n'
   ')',
   'migrations.AlterField(\n'
   "    model_name='Foo',\n"
   "    name='age',\n"
   '    field=models.FloatField(),\n'
   ')',
   'migrations.AlterField(\n'
   "    model_name='Foo',\n"
   "    name='age',\n"
   '    field=models.DecimalField(decimal_places=2, max_digits=5),\n'
   ')']

======================================================================
FAIL: test_reduce_consecutive_alterfield_same_field_to_final (migrations.test_optimizer.OptimizerTests.test_reduce_consecutive_alterfield_same_field_to_final)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/migrations/test_optimizer.py", line 800, in test_reduce_consecutive_alterfield_same_field_to_final
    self.assertOptimizesTo(
  File "/workspace/django/tests/migrations/test_optimizer.py", line 31, in assertOptimizesTo
    self.assertEqual(expected, result)
AssertionError: Lists differ: ["mig[73 chars]dels.DecimalField(decimal_places=2, max_digits=5),\n)"] != ["mig[73 chars]dels.IntegerField(),\n)", "migrations.AlterFie[208 chars]\n)"]

First differing element 0:
"migr[63 chars] field=models.DecimalField(decimal_places=2, max_digits=5),\n)"
"migr[63 chars] field=models.IntegerField(),\n)"

Second list contains 2 additional elements.
First extra element 1:
"migrations.AlterField(\n    model_name='Foo',\n    name='age',\n    field=models.FloatField(),\n)"

  ['migrations.AlterField(\n'
   "    model_name='Foo',\n"
   "    name='age',\n"
   '    field=models.IntegerField(),\n'
   ')',
   'migrations.AlterField(\n'
   "    model_name='Foo',\n"
   "    name='age',\n"
   '    field=models.FloatField(),\n'
   ')',
   'migrations.AlterField(\n'
   "    model_name='Foo',\n"
   "    name='age',\n"
   '    field=models.DecimalField(decimal_places=2, max_digits=5),\n'
   ')']
```

## Fix & Tests
- treat consecutive AlterField operations on the same field as replaceable by the latest definition while keeping existing RemoveField/RenameField rules
- added regression coverage for consecutive AlterField sequences, barrier separation, and AddField + chained AlterField optimization
- tests run:
  - `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py migrations.test_optimizer.OptimizerTests --parallel=1`
  - `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py migrations --parallel=1`
  - `flake8 django/db/migrations/operations/fields.py tests/migrations/test_optimizer.py`

Resolves #409
