### PR TITLE
swev-id: django__django-13568 - Accept UniqueConstraint for USERNAME_FIELD

### DIFF
--- a/django/contrib/auth/checks.py
+++ b/django/contrib/auth/checks.py
@@ -4,6 +4,7 @@ from types import MethodType
 from django.apps import apps
 from django.conf import settings
 from django.core import checks
+from django.db.models import UniqueConstraint
 
 from .management import _get_builtin_permissions
 
@@ -51,8 +52,21 @@ def check_user_model(app_configs=None, **kwargs):
             )
         )
 
+    username_field = cls._meta.get_field(cls.USERNAME_FIELD)
+
     # Check that the username field is unique
-    if not cls._meta.get_field(cls.USERNAME_FIELD).unique:
+    if not username_field.unique:
+        has_unconditional_unique_constraint = any(
+            isinstance(constraint, UniqueConstraint) and
+            constraint.condition is None and
+            not getattr(constraint, 'expressions', ()) and
+            constraint.fields == (cls.USERNAME_FIELD,)
+            for constraint in cls._meta.constraints
+        )
+    else:
+        has_unconditional_unique_constraint = True
+
+    if not has_unconditional_unique_constraint:
         if (settings.AUTHENTICATION_BACKENDS ==
                 ['django.contrib.auth.backends.ModelBackend']):
             errors.append(

--- a/tests/auth_tests/test_checks.py
+++ b/tests/auth_tests/test_checks.py
@@ -4,6 +4,7 @@ from django.contrib.auth.checks import (
 from django.contrib.auth.models import AbstractBaseUser
 from django.core import checks
 from django.db import models
+from django.db.models import Q
 from django.test import (
     SimpleTestCase, override_settings, override_system_checks,
 )
@@ -84,6 +85,58 @@ class UserModelChecksTests(SimpleTestCase):
                     id='auth.W004',
                 ),
             ])
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserUsernameConstraint')
+    def test_username_unique_constraint(self):
+        class CustomUserUsernameConstraint(AbstractBaseUser):
+            username = models.CharField(max_length=30)
+
+            USERNAME_FIELD = 'username'
+
+            class Meta:
+                constraints = [
+                    models.UniqueConstraint(fields=['username'], name='unique_username'),
+                ]
+
+        errors = checks.run_checks(app_configs=self.apps.get_app_configs())
+        self.assertEqual(errors, [])
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserPartialUniqueConstraint')
+    def test_username_partial_unique_constraint(self):
+        class CustomUserPartialUniqueConstraint(AbstractBaseUser):
+            username = models.CharField(max_length=30)
+            is_active = models.BooleanField(default=True)
+
+            USERNAME_FIELD = 'username'
+
+            class Meta:
+                constraints = [
+                    models.UniqueConstraint(
+                        fields=['username'],
+                        condition=Q(is_active=True),
+                        name='unique_active_username',
+                    ),
+                ]
+
+        errors = checks.run_checks(app_configs=self.apps.get_app_configs())
+        self.assertEqual(errors, [
+            checks.Error(
+                "'CustomUserPartialUniqueConstraint.username' must be "
+                "unique because it is named as the 'USERNAME_FIELD'.",
+                obj=CustomUserPartialUniqueConstraint,
+                id='auth.E003',
+            ),
+        ])
+
+    @override_settings(AUTH_USER_MODEL='auth_tests.CustomUserUniqueUsername')
+    def test_username_unique_flag(self):
+        class CustomUserUniqueUsername(AbstractBaseUser):
+            username = models.CharField(max_length=30, unique=True)
+
+            USERNAME_FIELD = 'username'
+
+        errors = checks.run_checks(app_configs=self.apps.get_app_configs())
+        self.assertEqual(errors, [])
 
     @override_settings(AUTH_USER_MODEL='auth_tests.BadUser')
     def test_is_anonymous_authenticated_methods(self):


### PR DESCRIPTION
## Summary
- allow an unconditional UniqueConstraint on the configured USERNAME_FIELD to satisfy the auth uniqueness check
- keep rejecting partial, multi-column, or expression-based constraints when validating custom user models
- add system check coverage for unconditional, partial, non-unique, and unique=True USERNAME_FIELD definitions

## Testing
- PYTHONPATH=/workspace/django .venv/bin/flake8 django/contrib/auth/checks.py tests/auth_tests/test_checks.py
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py auth_tests.test_checks --parallel=1

## Reproduction Steps (pre-fix)
1. Define a custom user model:
   ```python
   class CustomUserUsernameConstraint(AbstractBaseUser):
       username = models.CharField(max_length=150)
       USERNAME_FIELD = "username"

       class Meta:
           constraints = [models.UniqueConstraint(fields=["username"], name="unique_username")]
   ```
2. Set `AUTH_USER_MODEL = "yourapp.CustomUserUsernameConstraint"` and run `python manage.py check`.

### Observed failure output
```
auth.CustomUserUsernameConstraint: (auth.E003) 'CustomUserUsernameConstraint.username' must be unique because it is named as the 'USERNAME_FIELD'.
```