### PR TITLE
fix: unwrap SimpleLazyObject inputs (swev-id: django__django-13297)

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -21,7 +21,7 @@ from django.utils.dateparse import (
     parse_date, parse_datetime, parse_duration, parse_time,
 )
 from django.utils.duration import duration_microseconds, duration_string
-from django.utils.functional import Promise, cached_property
+from django.utils.functional import LazyObject, Promise, cached_property, empty
 from django.utils.ipv6 import clean_ipv6_address
 from django.utils.itercompat import is_iterable
 from django.utils.text import capfirst
@@ -806,6 +806,10 @@ class Field(RegisterLookupMixin):
         """Perform preliminary non-db specific value checks and conversions."""
         if isinstance(value, Promise):
             value = value._proxy____cast()
+        if isinstance(value, LazyObject):
+            if value._wrapped is empty:
+                value._setup()
+            value = value._wrapped
         return value
 
     def get_db_prep_value(self, value, connection, prepared=False):

--- a/tests/generic_views/models.py
+++ b/tests/generic_views/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db import models
 from django.db.models import QuerySet
 from django.db.models.manager import BaseManager
@@ -28,6 +30,14 @@ class Author(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class UUIDAuthor(models.Model):
+    name = models.CharField(max_length=100)
+    uuid = models.UUIDField(default=uuid.uuid4, unique=True)
+
+    class Meta:
+        ordering = ['name']
 
 
 class DoesNotExistQuerySet(QuerySet):

--- a/tests/generic_views/test_base.py
+++ b/tests/generic_views/test_base.py
@@ -3,14 +3,18 @@ import time
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.test import (
-    RequestFactory, SimpleTestCase, ignore_warnings, override_settings,
+    RequestFactory, SimpleTestCase, TestCase, ignore_warnings, override_settings,
 )
 from django.test.utils import require_jinja2
+from django.shortcuts import get_object_or_404
 from django.urls import resolve
 from django.utils.deprecation import RemovedInDjango40Warning
+from django.utils.functional import SimpleLazyObject
 from django.views.generic import RedirectView, TemplateView, View
+from django.views.generic.base import _wrap_url_kwargs_with_deprecation_warning
 
 from . import views
+from .models import Artist, Author, UUIDAuthor
 
 
 class SimpleView(View):
@@ -388,6 +392,51 @@ class TemplateViewTest(SimpleTestCase):
     def test_extra_context(self):
         response = self.client.get('/template/extra_context/')
         self.assertEqual(response.context['title'], 'Title')
+
+
+class TemplateViewLazyKwargDatabaseTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = Author.objects.create(name='Lazy Author', slug='lazy-author')
+        cls.artist = Artist.objects.create(name='Lazy Artist')
+        cls.uuid_author = UUIDAuthor.objects.create(name='Lazy UUID Author')
+
+    def test_lazy_slug_kwarg_used_in_queryset(self):
+        lazy_kwargs = _wrap_url_kwargs_with_deprecation_warning({'slug': self.author.slug})
+        lazy_slug = lazy_kwargs['slug']
+        self.assertIsInstance(lazy_slug, SimpleLazyObject)
+        msg = (
+            'TemplateView passing URL kwargs to the context is deprecated. '
+            'Reference slug in your template through view.kwargs instead.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            found = get_object_or_404(Author, slug=lazy_slug)
+        self.assertEqual(found, self.author)
+
+    def test_lazy_pk_kwarg_used_in_queryset(self):
+        lazy_kwargs = _wrap_url_kwargs_with_deprecation_warning({'pk': self.artist.pk})
+        lazy_pk = lazy_kwargs['pk']
+        self.assertIsInstance(lazy_pk, SimpleLazyObject)
+        msg = (
+            'TemplateView passing URL kwargs to the context is deprecated. '
+            'Reference pk in your template through view.kwargs instead.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            found = get_object_or_404(Artist, pk=lazy_pk)
+        self.assertEqual(found, self.artist)
+
+    def test_lazy_uuid_kwarg_used_in_queryset(self):
+        lazy_kwargs = _wrap_url_kwargs_with_deprecation_warning({'uuid': self.uuid_author.uuid})
+        lazy_uuid = lazy_kwargs['uuid']
+        self.assertIsInstance(lazy_uuid, SimpleLazyObject)
+        msg = (
+            'TemplateView passing URL kwargs to the context is deprecated. '
+            'Reference uuid in your template through view.kwargs instead.'
+        )
+        with self.assertWarnsMessage(RemovedInDjango40Warning, msg):
+            found = get_object_or_404(UUIDAuthor, uuid=lazy_uuid)
+        self.assertEqual(found, self.uuid_author)
 
 
 @override_settings(ROOT_URLCONF='generic_views.urls')

--- a/tests/model_fields/test_lazyobjects.py
+++ b/tests/model_fields/test_lazyobjects.py
@@ -1,0 +1,28 @@
+import uuid
+
+from django.test import TestCase
+from django.utils.functional import SimpleLazyObject
+
+from .models import BigS, IntegerModel, UUIDModel
+
+
+class SimpleLazyObjectFilterTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.char_obj = BigS.objects.create(s='lazy-slug')
+        cls.int_obj = IntegerModel.objects.create(value=42)
+        cls.uuid_value = uuid.uuid4()
+        cls.uuid_obj = UUIDModel.objects.create(field=cls.uuid_value)
+
+    def test_char_field_filter_with_lazy_object(self):
+        lazy_value = SimpleLazyObject(lambda: self.char_obj.s)
+        self.assertEqual(list(BigS.objects.filter(s=lazy_value)), [self.char_obj])
+
+    def test_integer_field_filter_with_lazy_object(self):
+        lazy_value = SimpleLazyObject(lambda: self.int_obj.value)
+        self.assertEqual(list(IntegerModel.objects.filter(value=lazy_value)), [self.int_obj])
+
+    def test_uuid_field_filter_with_lazy_object(self):
+        lazy_value = SimpleLazyObject(lambda: self.uuid_value)
+        self.assertEqual(list(UUIDModel.objects.filter(field=lazy_value)), [self.uuid_obj])


### PR DESCRIPTION
## Summary
- unwrap LazyObject/SingleLazyObject values in `Field.get_prep_value()` so ORM filters receive native types
- add TemplateView regression tests covering SimpleLazyObject URL kwargs for slug, pk, and uuid lookups
- add ORM-level regression tests asserting SimpleLazyObject inputs work for CharField, IntegerField, and UUIDField

Fixes #413.

## Observed Failure
```
ERROR: test_lazy_slug_kwarg_used_in_queryset (generic_views.test_base.TemplateViewLazyKwargDatabaseTests)
...
  File "django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "django/db/backends/sqlite3/base.py", line 412, in execute
    return Database.Cursor.execute(self, query, params)
django.db.utils.ProgrammingError: Error binding parameter 1: type 'SimpleLazyObject' is not supported
```

## Reproduction Steps
1. `python3.11 -m venv .venv && .venv/bin/pip install asgiref sqlparse pytz`
2. `PYTHONPATH=$PWD:$PWD/tests:$PWD/.venv/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py generic_views.test_base.TemplateViewLazyKwargDatabaseTests`
3. `PYTHONPATH=$PWD:$PWD/tests:$PWD/.venv/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py model_fields.test_lazyobjects`