### PR TITLE
fix(dateformat): swev-id: django__django-13670 align y token

### DIFF
--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -326,7 +326,7 @@ class DateFormat(TimeFormat):
 
     def y(self):
         "Year, 2 digits; e.g. '99'"
-        return str(self.data.year)[2:]
+        return "%02d" % (self.data.year % 100)
 
     def Y(self):
         "Year, 4 digits; e.g. '1999'"

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -105,6 +105,20 @@ class DateFormatTests(SimpleTestCase):
         self.assertEqual(dateformat.format(my_birthday, 'Y'), '1979')
         self.assertEqual(dateformat.format(my_birthday, 'z'), '189')
 
+    def test_year_two_digits(self):
+        cases = (
+            (date(1, 1, 1), '01'),
+            (date(9, 1, 1), '09'),
+            (date(99, 1, 1), '99'),
+            (date(123, 1, 1), '23'),
+            (date(1000, 1, 1), '00'),
+            (date(2001, 1, 1), '01'),
+        )
+
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(dateformat.format(value, 'y'), expected)
+
     def test_dateformat(self):
         my_birthday = datetime(1979, 7, 8, 22, 00)
 


### PR DESCRIPTION
## Summary
- adjust `DateFormat.y` to use modulo arithmetic so values below 1000 match `strftime('%y')`
- add regression coverage for 2-digit year formatting spanning sub-100 and millennium boundaries

## Observed Failure (pre-fix)
```
FAIL: test_year_two_digits (utils_tests.test_dateformat.DateFormatTests.test_year_two_digits) (value=datetime.date(123, 1, 1))
  AssertionError: '3' != '23'
  - 3
  + 23
```

## Reproduction Steps
1. `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py utils_tests.test_dateformat.DateFormatTests.test_year_two_digits --parallel=1`
2. Or from a REPL:
   ```python
   from django.conf import settings
   settings.configure(USE_TZ=True, TIME_ZONE='UTC', SECRET_KEY='x')
   import django; django.setup()
   import datetime
   from django.utils import dateformat
   dateformat.format(datetime.datetime(123, 4, 5, 6, 7), "y")  # returns '3' before this patch
   ```

## Testing
- `PYTHONPATH=$PWD:$PWD/tests DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py utils_tests.test_dateformat --parallel=1` *(fails with pre-existing timezone offset assertions)*
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py utils_tests.test_dateformat.DateFormatTests.test_year_two_digits --parallel=1`

Fixes #415