### PR TITLE
fix: swev-id: django__django-14373 zero-pad DateFormat.Y output

### DIFF
--- a/django/utils/dateformat.py
+++ b/django/utils/dateformat.py
@@ -314,7 +314,7 @@ class DateFormat(TimeFormat):
 
     def Y(self):
         "Year, 4 digits; e.g. '1999'"
-        return self.data.year
+        return f"{self.data.year:04d}"
 
     def z(self):
         """Day of the year, i.e. 1 to 366."""

--- a/tests/utils_tests/test_dateformat.py
+++ b/tests/utils_tests/test_dateformat.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from django.test import SimpleTestCase, override_settings
 from django.test.utils import TZ_SUPPORT, requires_tz_support
 from django.utils import dateformat, translation
-from django.utils.dateformat import format
+from django.utils.dateformat import DateFormat, format
 from django.utils.timezone import (
     get_default_timezone, get_fixed_timezone, make_aware, utc,
 )
@@ -194,3 +194,22 @@ class DateFormatTests(SimpleTestCase):
                     dateformat.format(datetime(2000, 1, 1, hour), 'g'),
                     expected,
                 )
+
+    def test_year_format_zero_padding(self):
+        tests = [
+            (1, '0001'),
+            (10, '0010'),
+            (100, '0100'),
+            (999, '0999'),
+            (1000, '1000'),
+            (2025, '2025'),
+        ]
+        for year, expected in tests:
+            with self.subTest(year=year):
+                self.assertEqual(
+                    dateformat.format(datetime(year, 1, 1), 'Y'),
+                    expected,
+                )
+
+    def test_year_format_returns_string(self):
+        self.assertIsInstance(DateFormat(date(1, 1, 1)).Y(), str)


### PR DESCRIPTION
## Summary
- return a zero-padded four-character string from DateFormat.Y()
- add regression coverage for years < 1000 and type expectations

## Issue
- Closes #418

## Reproduction
1. Clone the repository and check out the branch:
   ```bash
   gh repo clone agyn-sandbox/django /workspace/django
   git -C /workspace/django checkout django__django-14373
   ```
2. Create and activate a virtual environment, then install minimal dependencies:
   ```bash
   python3 -m venv /workspace/venv
   source /workspace/venv/bin/activate
   pip install asgiref pytz
   ```
3. Run a minimal script:
   ```python
   import sys, datetime
   sys.path.insert(0, '/workspace/django')
   from django.utils.dateformat import DateFormat
   val = DateFormat(datetime.date(1, 1, 1)).Y()
   print(val, type(val).__name__)
   assert val == '0001', f"Expected '0001', got {val!r} (type={type(val).__name__})"
   ```

Observed failure and stack trace:
```text
1 int
Traceback (most recent call last):
  File "repro.py", line 6, in <module>
    assert val == '0001', f"Expected '0001', got {val!r} (type={type(val).__name__})"
AssertionError: Expected '0001', got 1 (type=int)
```

## Documentation
- Behavior matches existing docs; no documentation changes required.