### PR TITLE
Fix: ensure single-column subquery for __in under OR (swev-id: django__django-14351)

### DIFF
--- a/django/db/models/fields/related_lookups.py
+++ b/django/db/models/fields/related_lookups.py
@@ -86,18 +86,28 @@ class RelatedIn(In):
                     AND)
             return root_constraint.as_sql(compiler, connection)
         else:
-            if (not getattr(self.rhs, 'has_select_fields', True) and
-                    not getattr(self.lhs.field.target_field, 'primary_key', False)):
-                self.rhs.clear_select_clause()
-                if (getattr(self.lhs.output_field, 'primary_key', False) and
-                        self.lhs.output_field.model == self.rhs.model):
+            from django.db.models.sql.query import Query
+
+            rhs = self.rhs
+            if isinstance(rhs, Query):
+                should_limit_rhs = rhs.default_cols or not rhs.has_select_fields
+            else:
+                should_limit_rhs = not getattr(rhs, 'has_select_fields', True)
+
+            if should_limit_rhs:
+                rhs.clear_select_clause()
+                if (
+                    getattr(self.lhs.output_field, 'primary_key', False) and
+                    getattr(self.lhs.output_field, 'model', None) == getattr(rhs, 'model', None)
+                ):
                     # A case like Restaurant.objects.filter(place__in=restaurant_qs),
                     # where place is a OneToOneField and the primary key of
                     # Restaurant.
-                    target_field = self.lhs.field.name
+                    target_field_name = self.lhs.field.name
                 else:
-                    target_field = self.lhs.field.target_field.name
-                self.rhs.add_fields([target_field], True)
+                    target = getattr(self.lhs.field, 'target_field', None)
+                    target_field_name = getattr(target, 'name', 'pk')
+                rhs.add_fields([target_field_name], allow_m2m=True)
             return super().as_sql(compiler, connection)
 
 

--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -401,7 +401,13 @@ class In(FieldGetDbPrepValueIterableMixin, BuiltinLookup):
             placeholder = '(' + ', '.join(sqls) + ')'
             return (placeholder, sqls_params)
         else:
-            if not getattr(self.rhs, 'has_select_fields', True):
+            from django.db.models.sql.query import Query
+
+            if isinstance(self.rhs, Query):
+                if self.rhs.default_cols or not self.rhs.has_select_fields:
+                    self.rhs.clear_select_clause()
+                    self.rhs.add_fields(['pk'])
+            elif not getattr(self.rhs, 'has_select_fields', True):
                 self.rhs.clear_select_clause()
                 self.rhs.add_fields(['pk'])
             return super().process_rhs(compiler, connection)

--- a/tests/or_lookups/models.py
+++ b/tests/or_lookups/models.py
@@ -20,3 +20,35 @@ class Article(models.Model):
 
     def __str__(self):
         return self.headline
+
+
+class Author(models.Model):
+    code = models.CharField(max_length=20, unique=True)
+    active = models.BooleanField(default=False)
+
+    class Meta:
+        ordering = ('id',)
+
+    def __str__(self):
+        return self.code
+
+
+class Book(models.Model):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='books')
+    pages = models.IntegerField()
+
+    class Meta:
+        ordering = ('id',)
+
+
+class CodeBook(models.Model):
+    author = models.ForeignKey(
+        Author,
+        on_delete=models.CASCADE,
+        related_name='code_books',
+        to_field='code',
+    )
+    pages = models.IntegerField()
+
+    class Meta:
+        ordering = ('id',)

--- a/tests/or_lookups/tests.py
+++ b/tests/or_lookups/tests.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 from operator import attrgetter
+import re
 
 from django.db.models import Q
 from django.test import TestCase
 
-from .models import Article
+from .models import Article, Author, Book, CodeBook
 
 
 class OrLookupsTests(TestCase):
@@ -238,3 +239,76 @@ class OrLookupsTests(TestCase):
             Article.objects.filter(Q(headline__startswith='Hello')).in_bulk([self.a1, self.a2]),
             {self.a1: Article.objects.get(pk=self.a1)}
         )
+
+
+class RelatedInOrLookupSingleColumnTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.active_author = Author.objects.create(code='ACTIVE', active=True)
+        cls.inactive_author = Author.objects.create(code='INACTIVE', active=False)
+        cls.other_inactive_author = Author.objects.create(code='OTHER', active=False)
+
+        cls.pk_books = {
+            'active': Book.objects.create(author=cls.active_author, pages=320),
+            'zero_pages': Book.objects.create(author=cls.inactive_author, pages=0),
+            'inactive': Book.objects.create(author=cls.other_inactive_author, pages=640),
+        }
+
+        cls.code_books = {
+            'active': CodeBook.objects.create(author=cls.active_author, pages=320),
+            'zero_pages': CodeBook.objects.create(author=cls.inactive_author, pages=0),
+            'inactive': CodeBook.objects.create(author=cls.other_inactive_author, pages=640),
+        }
+
+    def _assert_subquery_selects_single_column(self, queryset, expected_column):
+        compiler = queryset.query.get_compiler(using=queryset.db)
+        sql, params = compiler.as_sql()
+        match = re.search(r'IN\s*\(\s*SELECT\s+(.+?)\s+FROM', sql, flags=re.IGNORECASE | re.DOTALL)
+        self.assertIsNotNone(match, msg=sql)
+        select_expression = match.group(1)
+        self.assertNotIn(',', select_expression)
+        normalized = re.sub(r'["`\[\]]', '', select_expression).lower()
+        self.assertIn(expected_column.lower(), normalized)
+
+    def test_related_in_rhs_uses_single_pk_column(self):
+        active_authors = Author.objects.filter(active=True)
+        queryset = Book.objects.filter(
+            Q(author__in=active_authors) | Q(pages=0)
+        ).order_by('pk')
+
+        expected = Book.objects.filter(
+            Q(author__in=Author.objects.filter(active=True).values_list('pk', flat=True)) |
+            Q(pages=0)
+        ).order_by('pk')
+
+        self.assertEqual(list(queryset), list(expected))
+        self.assertEqual(
+            list(queryset.values_list('pk', flat=True)),
+            [
+                self.pk_books['active'].pk,
+                self.pk_books['zero_pages'].pk,
+            ],
+        )
+        self._assert_subquery_selects_single_column(queryset, Author._meta.pk.column)
+
+    def test_related_in_rhs_uses_single_to_field_column(self):
+        active_authors = Author.objects.filter(active=True)
+        queryset = CodeBook.objects.filter(
+            Q(author__in=active_authors) | Q(pages=0)
+        ).order_by('pk')
+
+        expected = CodeBook.objects.filter(
+            Q(author__in=Author.objects.filter(active=True).values_list('code', flat=True)) |
+            Q(pages=0)
+        ).order_by('pk')
+
+        self.assertEqual(list(queryset), list(expected))
+        self.assertEqual(
+            list(queryset.values_list('pk', flat=True)),
+            [
+                self.code_books['active'].pk,
+                self.code_books['zero_pages'].pk,
+            ],
+        )
+        self._assert_subquery_selects_single_column(queryset, Author._meta.get_field('code').column)


### PR DESCRIPTION
## Summary
- ensure RHS Query instances used in `__in` collapse to a single column even when ORed with other predicates.
- restore RelatedIn behavior for foreign keys targeting either the PK or a `to_field` by forcing the correct target column.
- add regression coverage for the OR-combined queryset case on both PK and to_field foreign keys.

## Observed Failure
Combining `Q(author__in=Author.objects.filter(active=True)) | Q(pages=0)` raises `ProgrammingError: subquery must return only one column` on PostgreSQL because the RHS subquery selects every default column when ORed with another predicate.

## Stack Trace & SQL
```
django.db.utils.ProgrammingError: subquery must return only one column
LINE 1: ..."id", T5."property_group_id", (SELECT U0...

Traceback (most recent call last):
  File "django/db/backends/utils.py", in execute
  File "django/db/backends/postgresql/base.py", in execute
psycopg2.errors.SyntaxError: subquery has more than one column
SQL: SELECT "book"."id" FROM "book" WHERE ("book"."author_code" IN (
  SELECT "author"."id", "author"."code", "author"."active"
  FROM "author" WHERE "author"."active" = TRUE
) OR "book"."pages" = 0)
```

## Reproduction Steps
1. Define `Author(code, active)` and `Book(author=ForeignKey(Author), pages)` with a second FK pointing to `Author(code)` via `to_field`.
2. Populate data with an active author and a different book that has `pages=0` to exercise the OR branch.
3. Execute `Book.objects.filter(Q(author__in=Author.objects.filter(active=True)) | Q(pages=0))` on PostgreSQL: the generated subquery selects three columns and raises the error above.

## Regression Reference
- 35431298226165986ad07e91f9d3aca721ff38ec

## Testing
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py or_lookups --parallel=1`
- `.venv/bin/flake8 django/db/models/lookups.py django/db/models/fields/related_lookups.py tests/or_lookups`

Fixes #419