### PR TITLE
Fix _create_unique_sql Columns table arg; ensure references_column() is True (swev-id: django__django-14434)

### DIFF
--- a/django/db/backends/base/schema.py
+++ b/django/db/backends/base/schema.py
@@ -1251,7 +1251,9 @@ class BaseDatabaseSchemaEditor:
         else:
             sql = self.sql_create_unique
         if columns:
-            columns = self._index_columns(table, columns, col_suffixes=(), opclasses=opclasses)
+            columns = self._index_columns(
+                model._meta.db_table, columns, col_suffixes=(), opclasses=opclasses
+            )
         else:
             columns = Expressions(model._meta.db_table, expressions, compiler, self.quote_value)
         return Statement(

--- a/scripts/repro_output_after_fix.txt
+++ b/scripts/repro_output_after_fix.txt
@@ -1,0 +1,1 @@
+references_column() returned True for unique constraint on repro_author.email

--- a/scripts/repro_output_before_fix.txt
+++ b/scripts/repro_output_before_fix.txt
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "/workspace/django/scripts/repro_unique_references_column.py", line 72, in <module>
+    main()
+  File "/workspace/django/scripts/repro_unique_references_column.py", line 61, in main
+    assert statement.references_column(
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AssertionError: Expected references_column('repro_author', 'email') to be True

--- a/scripts/repro_unique_references_column.py
+++ b/scripts/repro_unique_references_column.py
@@ -1,0 +1,72 @@
+"""Reproduce Statement.references_column() failure for unique constraints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import django  # noqa: E402
+from django.conf import settings  # noqa: E402
+from django.db import connection, models  # noqa: E402
+
+
+def configure_settings() -> None:
+    if settings.configured:
+        return
+
+    settings.configure(
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": ":memory:",
+            }
+        },
+        INSTALLED_APPS=["django.contrib.contenttypes", "tests"],
+        SECRET_KEY="not-secret",
+        DEFAULT_AUTO_FIELD="django.db.models.AutoField",
+    )
+    django.setup()
+
+
+def get_author_model() -> type[models.Model]:
+    class Author(models.Model):
+        email = models.CharField(max_length=255)
+
+        class Meta:
+            app_label = "tests"
+            db_table = "repro_author"
+
+    return Author
+
+
+def main() -> None:
+    configure_settings()
+    Author = get_author_model()
+    field = Author._meta.get_field("email")
+
+    with connection.schema_editor() as editor:
+        statement = editor._create_unique_sql(
+            Author,
+            [field.column],
+            name="author_email_unique",
+        )
+
+    table = Author._meta.db_table
+    column = field.column
+
+    assert statement.references_column(
+        table, column
+    ), f"Expected references_column({table!r}, {column!r}) to be True"
+
+    print(
+        "references_column() returned True for unique constraint on %s.%s"
+        % (table, column)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/backends/test_ddl_references.py
+++ b/tests/backends/test_ddl_references.py
@@ -1,4 +1,5 @@
-from django.db import connection
+from django.apps.registry import Apps
+from django.db import connection, models
 from django.db.backends.ddl_references import (
     Columns, Expressions, ForeignKeyName, IndexName, Statement, Table,
 )
@@ -187,6 +188,33 @@ class StatementTests(SimpleTestCase):
         reference = MockReference('reference', {}, {})
         statement = Statement("%(reference)s - %(non_reference)s", reference=reference, non_reference='non_reference')
         self.assertEqual(str(statement), 'reference - non_reference')
+
+
+class SchemaEditorReferencesTests(SimpleTestCase):
+    databases = {"default"}
+
+    def test_create_unique_sql_references_column(self):
+        app_registry = Apps()
+
+        class Author(models.Model):
+            email = models.CharField(max_length=255)
+
+            class Meta:
+                app_label = "ddl_references"
+                apps = app_registry
+                db_table = "ddl_ref_author"
+
+        with connection.schema_editor() as editor:
+            statement = editor._create_unique_sql(
+                Author,
+                [Author._meta.get_field("email").column],
+                name="ddl_ref_author_email_unique",
+            )
+
+        self.assertIs(
+            statement.references_column(Author._meta.db_table, "email"),
+            True,
+        )
 
 
 class ExpressionsTests(TransactionTestCase):


### PR DESCRIPTION
## Issue
Fixes #424

## Root Cause
- `_create_unique_sql()` passed a `Table` wrapper into `_index_columns()`, so the resulting `Columns` reference stored the wrapper instead of the raw table name.
- `Columns.references_column()` compares table names as strings; the wrapper prevented unique-constraint statements from reporting column references when custom constraint names were supplied.

## Changes
- Pass the model's `db_table` string to `_index_columns()` when building unique constraint statements.
- Add a regression test that builds a unique constraint with an explicit name and asserts `Statement.references_column()` returns `True`.
- Add a standalone reproduction script with before/after outputs under `scripts/`.

## Reproduction
1. `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.12/site-packages python3.12 scripts/repro_unique_references_column.py`

### Observed failure (before fix)
```
$(cat scripts/repro_output_before_fix.txt)
```

### After fix
```
$(cat scripts/repro_output_after_fix.txt)
```

## Testing
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.12/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.12 tests/runtests.py backends.test_ddl_references --parallel=1`
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.12/site-packages python3.12 scripts/repro_unique_references_column.py`