### PR TITLE
swev-id: django__django-14500 synchronize squashed migration unapply state

### DIFF
--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -277,6 +277,8 @@ class MigrationExecutor:
             all_applied = all(m in applied for m in migration.replaces)
             if all_applied and key not in applied:
                 self.recorder.record_applied(*key)
+            elif not all_applied and key in applied:
+                self.recorder.record_unapplied(*key)
 
     def detect_soft_applied(self, project_state, migration):
         """

--- a/tests/migrations/test_executor.py
+++ b/tests/migrations/test_executor.py
@@ -4,6 +4,7 @@ from django.apps.registry import apps as global_apps
 from django.db import DatabaseError, connection, migrations, models
 from django.db.migrations.exceptions import InvalidMigrationPlan
 from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.graph import MigrationGraph
 from django.db.migrations.recorder import MigrationRecorder
 from django.db.migrations.state import ProjectState
@@ -652,6 +653,45 @@ class ExecutorTests(MigrationTestBase):
             ("migrations", "0001_squashed_0002"),
             recorder.applied_migrations(),
         )
+
+    @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"})
+    def test_unapply_replacement_removes_replacement_record(self):
+        """Unapplying a replacement migration removes its record."""
+        recorder = MigrationRecorder(connection)
+        executor = MigrationExecutor(connection)
+        executor.migrate([("migrations", "0001_squashed_0002")])
+        self.assertIn(
+            ("migrations", "0001_squashed_0002"),
+            recorder.applied_migrations(),
+        )
+
+        executor.loader.build_graph()
+        executor.migrate([("migrations", None)])
+
+        self.assertNotIn(
+            ("migrations", "0001_squashed_0002"),
+            recorder.applied_migrations(),
+        )
+
+    @override_settings(MIGRATION_MODULES={"migrations": "migrations.test_migrations_squashed"})
+    def test_unapply_replaced_migration_removes_replacement_record(self):
+        """Unapplying a replaced migration removes the replacement record."""
+        recorder = MigrationRecorder(connection)
+        recorder.record_applied("migrations", "0001_initial")
+        executor = MigrationExecutor(connection)
+        executor.migrate([("migrations", "0002_second")], fake=True)
+        self.assertIn(
+            ("migrations", "0001_squashed_0002"),
+            recorder.applied_migrations(),
+        )
+
+        executor.loader.build_graph()
+        executor.loader = MigrationLoader(connection, replace_migrations=False)
+        executor.migrate([("migrations", "0001_initial")], fake=True)
+
+        applied = recorder.applied_migrations()
+        self.assertNotIn(("migrations", "0001_squashed_0002"), applied)
+        self.assertIn(("migrations", "0001_initial"), applied)
 
     # When the feature is False, the operation and the record won't be
     # performed in a transaction and the test will systematically pass.


### PR DESCRIPTION
## Summary
- ensure replacement migrations are marked unapplied when any replaced migration is unapplied
- add regression tests covering unapplying the replacement itself and individual replaced migrations

## Testing
- PYTHONPATH=$PWD:$PWD/tests DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py migrations.test_executor --parallel=1

## Pre-fix failure reproduction
Command:
```
PYTHONPATH=$PWD:$PWD/tests DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py migrations.test_executor.ExecutorTests.test_unapply_replacement_removes_replacement_record --parallel=1
```
Output:
```
FAIL: test_unapply_replacement_removes_replacement_record (migrations.test_executor.ExecutorTests.test_unapply_replacement_removes_replacement_record)
Unapplying a replacement migration removes its record.
...
AssertionError: ('migrations', '0001_squashed_0002') unexpectedly found in {('admin', '0001_initial'): <Migration: Migration 0001_initial for admin>, ('admin', '0002_logentry_remove_auto_add'): <Migration: Migration 0002_logentry_remove_auto_add for admin>, ('admin', '0003_logentry_add_action_flag_choices'): <Migration: Migration 0003_logentry_add_action_flag_choices for admin>, ('sites', '0001_initial'): <Migration: Migration 0001_initial for sites>, ('sites', '0002_alter_domain_unique'): <Migration: Migration 0002_alter_domain_unique for sites>, ('migrations', '0001_squashed_0002'): <Migration: Migration 0001_squashed_0002 for migrations>}
```

Command:
```
PYTHONPATH=$PWD:$PWD/tests DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py migrations.test_executor.ExecutorTests.test_unapply_replaced_migration_removes_replacement_record --parallel=1
```
Output:
```
FAIL: test_unapply_replaced_migration_removes_replacement_record (migrations.test_executor.ExecutorTests.test_unapply_replaced_migration_removes_replacement_record)
Unapplying a replaced migration removes the replacement record.
...
AssertionError: ('migrations', '0001_squashed_0002') unexpectedly found in {('admin', '0001_initial'): <Migration: Migration 0001_initial for admin>, ('admin', '0002_logentry_remove_auto_add'): <Migration: Migration 0002_logentry_remove_auto_add for admin>, ('admin', '0003_logentry_add_action_flag_choices'): <Migration: Migration 0003_logentry_add_action_flag_choices for admin>, ('sites', '0001_initial'): <Migration: Migration 0001_initial for sites>, ('sites', '0002_alter_domain_unique'): <Migration: Migration 0002_alter_domain_unique for sites>, ('migrations', '0001_initial'): <Migration: Migration 0001_initial for migrations>, ('migrations', '0001_squashed_0002'): <Migration: Migration 0001_squashed_0002 for migrations>}
```

Resolves #425.