### PR TITLE
swev-id: django__django-14349

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -101,12 +101,15 @@ class URLValidator(RegexValidator):
     def __call__(self, value):
         if not isinstance(value, str):
             raise ValidationError(self.message, code=self.code, params={'value': value})
+        if any(char in value for char in ('\r', '\n', '\t')):
+            raise ValidationError(self.message, code=self.code, params={'value': value})
         # Check if the scheme is valid.
         scheme = value.split('://')[0].lower()
         if scheme not in self.schemes:
             raise ValidationError(self.message, code=self.code, params={'value': value})
 
         # Then check full URL
+        split_result = None
         try:
             super().__call__(value)
         except ValidationError as e:
@@ -126,7 +129,11 @@ class URLValidator(RegexValidator):
                 raise
         else:
             # Now verify IPv6 in the netloc part
-            host_match = re.search(r'^\[(.+)\](?::\d{2,5})?$', urlsplit(value).netloc)
+            try:
+                split_result = urlsplit(value)
+            except ValueError:
+                raise ValidationError(self.message, code=self.code, params={'value': value})
+            host_match = re.search(r'^\[(.+)\](?::\d{2,5})?$', split_result.netloc)
             if host_match:
                 potential_ip = host_match[1]
                 try:
@@ -138,7 +145,15 @@ class URLValidator(RegexValidator):
         # section 3.1. It's defined to be 255 bytes or less, but this includes
         # one byte for the length of the name and one byte for the trailing dot
         # that's used to indicate absolute names in DNS.
-        if len(urlsplit(value).hostname) > 253:
+        if split_result is None:
+            try:
+                split_result = urlsplit(value)
+            except ValueError:
+                raise ValidationError(self.message, code=self.code, params={'value': value})
+        hostname = split_result.hostname
+        if hostname is None:
+            raise ValidationError(self.message, code=self.code, params={'value': value})
+        if len(hostname) > 253:
             raise ValidationError(self.message, code=self.code, params={'value': value})
 
 

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -229,6 +229,11 @@ TEST_DATA = [
     # Trailing newlines not accepted
     (URLValidator(), 'http://www.djangoproject.com/\n', ValidationError),
     (URLValidator(), 'http://[::ffff:192.9.5.5]\n', ValidationError),
+    # Trailing carriage returns and tabs not accepted
+    (URLValidator(), 'http://www.djangoproject.com/\r', ValidationError),
+    (URLValidator(), 'http://[::ffff:192.9.5.5]\r', ValidationError),
+    (URLValidator(), 'http://www.djangoproject.com/\t', ValidationError),
+    (URLValidator(), 'http://[::ffff:192.9.5.5]\t', ValidationError),
     # Trailing junk does not take forever to reject
     (URLValidator(), 'http://www.asdasdasdasdsadfm.com.br ', ValidationError),
     (URLValidator(), 'http://www.asdasdasdasdsadfm.com.br z', ValidationError),


### PR DESCRIPTION
## Summary
- add an early CR/LF/TAB guard in URLValidator boundary logic
- surface urlsplit ValueError cases as ValidationError before IPv6 and hostname checks
- extend validators coverage with carriage-return and tab URL fixtures

## Failing behavior (before fix)
```bash
PYTHONPATH=/workspace/django:$HOME/.nix-profile/lib/python3.10/site-packages python3 tests/runtests.py validators -k TestValidators.test_validators
```
Resulted in:
- ValueError: '::1:2::3' does not appear to be an IPv4 or IPv6 address
- ValidationError not raised for URLs ending with ``\n``

## Testing
```bash
PYTHONPATH=/workspace/django:$HOME/.nix-profile/lib/python3.10/site-packages python3 tests/runtests.py validators
micromamba run -n py39 env PYTHONPATH=/workspace/django python tests/runtests.py validators
```

Refs #416
