### PR TITLE
swev-id: django__django-14376: Replace deprecated MySQLdb kwargs 'db'/'passwd' with 'database'/'password'

### DIFF
--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -200,9 +200,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         if settings_dict['USER']:
             kwargs['user'] = settings_dict['USER']
         if settings_dict['NAME']:
-            kwargs['db'] = settings_dict['NAME']
+            kwargs['database'] = settings_dict['NAME']
         if settings_dict['PASSWORD']:
-            kwargs['passwd'] = settings_dict['PASSWORD']
+            kwargs['password'] = settings_dict['PASSWORD']
         if settings_dict['HOST'].startswith('/'):
             kwargs['unix_socket'] = settings_dict['HOST']
         elif settings_dict['HOST']:

--- a/scripts/repro_mysql_kwargs.py
+++ b/scripts/repro_mysql_kwargs.py
@@ -1,0 +1,29 @@
+import traceback
+from django.db.backends.mysql.base import DatabaseWrapper
+
+
+settings_dict = {
+    'NAME': 'testdb',
+    'USER': 'testuser',
+    'PASSWORD': 'testpass',
+    'HOST': '127.0.0.1',
+    'PORT': '3306',
+    'OPTIONS': {},
+    'AUTOCOMMIT': True,
+    'ATOMIC_REQUESTS': False,
+    'CONN_MAX_AGE': 0,
+    'ENGINE': 'django.db.backends.mysql',
+    'TIME_ZONE': 'UTC',
+    'DISABLE_SERVER_SIDE_CURSORS': False,
+}
+
+
+wrapper = DatabaseWrapper(settings_dict)
+params = wrapper.get_connection_params()
+print("Connection params:", params)
+assert 'database' in params, "Expected 'database' key (canonical), but got legacy keys: %r" % params
+assert 'password' in params, "Expected 'password' key (canonical), but got legacy keys: %r" % params
+try:
+    wrapper.get_new_connection(params)
+except Exception:
+    traceback.print_exc()


### PR DESCRIPTION
## Summary
- switch MySQL connection params to mysqlclient's canonical 'database' and 'password' kwargs
- add a reproducible script under scripts/ to demonstrate the behavior change

## Testing
- source /workspace/.venv/bin/activate && flake8 django/db/backends/mysql/base.py scripts/repro_mysql_kwargs.py
- source /workspace/.venv/bin/activate && python3 -m compileall django/db/backends/mysql/base.py
- source /workspace/.venv/bin/activate && PYTHONPATH=/workspace/django python3 scripts/repro_mysql_kwargs.py

## Evidence

**Pre-change (assertions show legacy keys)**

```bash
$ source /workspace/.venv/bin/activate && PYTHONPATH=/workspace/django python3 scripts/repro_mysql_kwargs.py
Traceback (most recent call last):
  File "/workspace/django/scripts/repro_mysql_kwargs.py", line 24, in <module>
    assert 'database' in params, "Expected 'database' key (canonical), but got legacy keys: %r" % params
           ^^^^^^^^^^^^^^^^^^^^
AssertionError: Expected 'database' key (canonical), but got legacy keys: {'conv': {<class 'int'>: <function Thing2Str at 0xffffbbb3e660>, <class 'float'>: <function Float2Str at 0xffffbbb3e700>, <class 'NoneType'>: <function None2NULL at 0xffffbbb3e7a0>, <class 'array.array'>: <function array2Str at 0xffffbbb3e980>, <class 'bool'>: <function Bool2Str at 0xffffbbb3e3e0>, <class 'datetime.date'>: <function Thing2Literal at 0xffffbbb3e840>, <class 'datetime.datetime'>: <function DateTime2literal at 0xffffbbb3dee0>, <class 'datetime.timedelta'>: <function DateTimeDelta2literal at 0xffffbbb3df80>, <class 'set'>: <function Set2Str at 0xffffbbb3e5c0>, <class 'decimal.Decimal'>: <function Decimal2Literal at 0xffffbbb3e8e0>, 1: <class 'int'>, 2: <class 'int'>, 3: <class 'int'>, 4: <class 'float'>, 5: <class 'float'>, 0: <class 'decimal.Decimal'>, 246: <class 'decimal.Decimal'>, 8: <class 'int'>, 9: <class 'int'>, 13: <class 'int'>, 7: <function DateTime_or_None at 0xffffbbb3dc60>, 12: <function DateTime_or_None at 0xffffbbb3dc60>, 11: <function typecast_time at 0xffffbbae2f20>, 10: <function Date_or_None at 0xffffbbb3de40>, 249: <class 'bytes'>, 250: <class 'bytes'>, 251: <class 'bytes'>, 252: <class 'bytes'>, 254: <class 'bytes'>, 253: <class 'bytes'>, 15: <class 'bytes'>, 245: <class 'bytes'>}, 'charset': 'utf8', 'user': 'testuser', 'db': 'testdb', 'passwd': 'testpass', 'host': '127.0.0.1', 'port': 3306, 'client_flag': 2}
Pre-change conn params: {'conv': {<class 'int'>: <function Thing2Str at 0xffffbbb3e660>, <class 'float'>: <function Float2Str at 0xffffbbb3e700>, <class 'NoneType'>: <function None2NULL at 0xffffbbb3e7a0>, <class 'array.array'>: <function array2Str at 0xffffbbb3e980>, <class 'bool'>: <function Bool2Str at 0xffffbbb3e3e0>, <class 'datetime.date'>: <function Thing2Literal at 0xffffbbb3e840>, <class 'datetime.datetime'>: <function DateTime2literal at 0xffffbbb3dee0>, <class 'datetime.timedelta'>: <function DateTimeDelta2literal at 0xffffbbb3df80>, <class 'set'>: <function Set2Str at 0xffffbbb3e5c0>, <class 'decimal.Decimal'>: <function Decimal2Literal at 0xffffbbb3e8e0>, 1: <class 'int'>, 2: <class 'int'>, 3: <class 'int'>, 4: <class 'float'>, 5: <class 'float'>, 0: <class 'decimal.Decimal'>, 246: <class 'decimal.Decimal'>, 8: <class 'int'>, 9: <class 'int'>, 13: <class 'int'>, 7: <function DateTime_or_None at 0xffffbbb3dc60>, 12: <function DateTime_or_None at 0xffffbbb3dc60>, 11: <function typecast_time at 0xffffbbae2f20>, 10: <function Date_or_None at 0xffffbbb3de40>, 249: <class 'bytes'>, 250: <class 'bytes'>, 251: <class 'bytes'>, 252: <class 'bytes'>, 254: <class 'bytes'>, 253: <class 'bytes'>, 15: <class 'bytes'>, 245: <class 'bytes'>}, 'charset': 'utf8', 'user': 'testuser', 'db': 'testdb', 'passwd': 'testpass', 'host': '127.0.0.1', 'port': 3306, 'client_flag': 2}
```

**Post-change (assertions pass, connection fails without server)**

```bash
$ source /workspace/.venv/bin/activate && PYTHONPATH=/workspace/django python3 scripts/repro_mysql_kwargs.py
Traceback (most recent call last):
  File "/workspace/django/scripts/repro_mysql_kwargs.py", line 27, in <module>
    wrapper.get_new_connection(params)
  File "/workspace/django/django/utils/asyncio.py", line 25, in inner
    return func(*args, **kwargs)
  File "/workspace/django/django/db/backends/mysql/base.py", line 233, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/workspace/.venv/lib/python3.11/site-packages/MySQLdb/__init__.py", line 121, in Connect
    return Connection(*args, **kwargs)
  File "/workspace/.venv/lib/python3.11/site-packages/MySQLdb/connections.py", line 200, in __init__
    super().__init__(*args, **kwargs2)
MySQLdb.OperationalError: (2002, "Can't connect to server on '127.0.0.1' (115)")
Connection params: {'conv': {<class 'int'>: <function Thing2Str at 0xffffa8aa2700>, <class 'float'>: <function Float2Str at 0xffffa8aa27a0>, <class 'NoneType'>: <function None2NULL at 0xffffa8aa2840>, <class 'array.array'>: <function array2Str at 0xffffa8aa2a20>, <class 'bool'>: <function Bool2Str at 0xffffa8aa2480>, <class 'datetime.date'>: <function Thing2Literal at 0xffffa8aa28e0>, <class 'datetime.datetime'>: <function DateTime2literal at 0xffffa8aa1f80>, <class 'datetime.timedelta'>: <function DateTimeDelta2literal at 0xffffa8aa2020>, <class 'set'>: <function Set2Str at 0xffffa8aa2660>, <class 'decimal.Decimal'>: <function Decimal2Literal at 0xffffa8aa2980>, 1: <class 'int'>, 2: <class 'int'>, 3: <class 'int'>, 4: <class 'float'>, 5: <class 'float'>, 0: <class 'decimal.Decimal'>, 246: <class 'decimal.Decimal'>, 8: <class 'int'>, 9: <class 'int'>, 13: <class 'int'>, 7: <function DateTime_or_None at 0xffffa8aa1d00>, 12: <function DateTime_or_None at 0xffffa8aa1d00>, 11: <function typecast_time at 0xffffa8a2efc0>, 10: <function Date_or_None at 0xffffa8aa1ee0>, 249: <class 'bytes'>, 250: <class 'bytes'>, 251: <class 'bytes'>, 252: <class 'bytes'>, 254: <class 'bytes'>, 253: <class 'bytes'>, 15: <class 'bytes'>, 245: <class 'bytes'>}, 'charset': 'utf8', 'user': 'testuser', 'database': 'testdb', 'password': 'testpass', 'host': '127.0.0.1', 'port': 3306, 'client_flag': 2}
```
