### PR TITLE
swev-id: django__django-14539 fix urlize entity trailing punctuation

### DIFF
--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -283,8 +283,9 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
             middle_unescaped = html.unescape(middle)
             stripped = middle_unescaped.rstrip(TRAILING_PUNCTUATION_CHARS)
             if middle_unescaped != stripped:
-                trail = middle[len(stripped):] + trail
-                middle = middle[:len(stripped) - len(middle_unescaped)]
+                trailing_count = len(middle_unescaped) - len(stripped)
+                trail = middle[-trailing_count:] + trail
+                middle = middle[:-trailing_count]
                 trimmed_something = True
         return lead, middle, trail
 

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -18,6 +18,7 @@ from django.utils.text import normalize_newlines
 # Configuration for urlize() function.
 TRAILING_PUNCTUATION_CHARS = '.,:;!'
 WRAPPING_PUNCTUATION = [('(', ')'), ('[', ']')]
+HTML_ENTITY_RE = re.compile(r'&(?:#\d+|#x[0-9A-Fa-f]+|\w+);')
 
 # List of possible strings used for bullets in bulleted lists.
 DOTS = ['&middot;', '*', '\u2022', '&#149;', '&bull;', '&#8226;']
@@ -284,8 +285,24 @@ def urlize(text, trim_url_limit=None, nofollow=False, autoescape=False):
             stripped = middle_unescaped.rstrip(TRAILING_PUNCTUATION_CHARS)
             if middle_unescaped != stripped:
                 trailing_count = len(middle_unescaped) - len(stripped)
-                trail = middle[-trailing_count:] + trail
-                middle = middle[:-trailing_count]
+                idx = len(middle)
+                units_remaining = trailing_count
+                while units_remaining > 0 and idx > 0:
+                    if middle[idx - 1] == ';':
+                        amp_idx = middle.rfind('&', 0, idx)
+                        if amp_idx != -1:
+                            entity = middle[amp_idx:idx]
+                            if HTML_ENTITY_RE.fullmatch(entity):
+                                decoded = html.unescape(entity)
+                                if (len(decoded) == 1 and
+                                        decoded in TRAILING_PUNCTUATION_CHARS):
+                                    idx = amp_idx
+                                    units_remaining -= 1
+                                    continue
+                    idx -= 1
+                    units_remaining -= 1
+                trail = middle[idx:] + trail
+                middle = middle[:idx]
                 trimmed_something = True
         return lead, middle, trail
 

--- a/tests/template_tests/filter_tests/test_urlize.py
+++ b/tests/template_tests/filter_tests/test_urlize.py
@@ -79,6 +79,26 @@ class UrlizeTests(SimpleTestCase):
             '<a href="http://example.com/?x=&amp;y=%3C2%3E" rel="nofollow">http://example.com/?x=&amp;y=&lt;2&gt;</a>',
         )
 
+    @setup({'urlize10': '{{ text|urlize }}'})
+    def test_urlize_entity_trailing_punctuation(self):
+        output = self.engine.render_to_string('urlize10', {
+            'text': 'Search for google.com/?q=1&lt! and see.',
+        })
+        self.assertEqual(
+            output,
+            'Search for <a href="http://google.com/?q=1%3C" rel="nofollow">google.com/?q=1&amp;lt</a>! and see.',
+        )
+
+    @setup({'urlize11': '{{ text|urlize }}'})
+    def test_urlize_entity_trailing_parentheses(self):
+        output = self.engine.render_to_string('urlize11', {
+            'text': '(see google.com/?q=1&lt!)',
+        })
+        self.assertEqual(
+            output,
+            '(see <a href="http://google.com/?q=1%3C" rel="nofollow">google.com/?q=1&amp;lt</a>!)',
+        )
+
 
 class FunctionTests(SimpleTestCase):
 

--- a/tests/template_tests/filter_tests/test_urlize.py
+++ b/tests/template_tests/filter_tests/test_urlize.py
@@ -99,6 +99,26 @@ class UrlizeTests(SimpleTestCase):
             '(see <a href="http://google.com/?q=1%3C" rel="nofollow">google.com/?q=1&amp;lt</a>!)',
         )
 
+    @setup({'urlize12': '{{ text|urlize }}'})
+    def test_urlize_entity_trailing_numeric_reference(self):
+        output = self.engine.render_to_string('urlize12', {
+            'text': 'Search for google.com/?q=1&#33; and see.',
+        })
+        self.assertEqual(
+            output,
+            'Search for <a href="http://google.com/?q=1" rel="nofollow">google.com/?q=1</a>&amp;#33; and see.',
+        )
+
+    @setup({'urlize13': '{{ text|urlize }}'})
+    def test_urlize_entity_trailing_hex_reference(self):
+        output = self.engine.render_to_string('urlize13', {
+            'text': 'Search for google.com/?q=1&#x21;! and see.',
+        })
+        self.assertEqual(
+            output,
+            'Search for <a href="http://google.com/?q=1" rel="nofollow">google.com/?q=1</a>&amp;#x21;! and see.',
+        )
+
 
 class FunctionTests(SimpleTestCase):
 

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -255,6 +255,34 @@ class TestUtilsHtml(SimpleTestCase):
                 'Search for <a href="http://google.com/?q=">google.com/?q=</a>!'
             ),
             ('foo@example.com', '<a href="mailto:foo@example.com">foo@example.com</a>'),
+            (
+                'Search for google.com/?q=1&lt! and see.',
+                'Search for <a href="http://google.com/?q=1%3C">google.com/?q=1&lt</a>! and see.'
+            ),
+            (
+                'Search for google.com/?q=1&lt;! and see.',
+                'Search for <a href="http://google.com/?q=1%3C">google.com/?q=1&lt;</a>! and see.'
+            ),
+            (
+                'Search for google.com/?q=&#60! and see.',
+                'Search for <a href="http://google.com/?q=%3C">google.com/?q=&#60</a>! and see.'
+            ),
+            (
+                'Search for google.com/?q=&#60;! and see.',
+                'Search for <a href="http://google.com/?q=%3C">google.com/?q=&#60;</a>! and see.'
+            ),
+            (
+                'Search for google.com/?q=1&lt!!! and see.',
+                'Search for <a href="http://google.com/?q=1%3C">google.com/?q=1&lt</a>!!! and see.'
+            ),
+            (
+                'Check example.com/a&lt! now.',
+                'Check <a href="http://example.com/a%3C">example.com/a&lt</a>! now.'
+            ),
+            (
+                '(see google.com/?q=1&lt!)',
+                '(see <a href="http://google.com/?q=1%3C">google.com/?q=1&lt</a>!)'
+            ),
         )
         for value, output in tests:
             with self.subTest(value=value):

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -283,6 +283,18 @@ class TestUtilsHtml(SimpleTestCase):
                 '(see google.com/?q=1&lt!)',
                 '(see <a href="http://google.com/?q=1%3C">google.com/?q=1&lt</a>!)'
             ),
+            (
+                'Search for google.com/?q=1&#33; and see.',
+                'Search for <a href="http://google.com/?q=1">google.com/?q=1</a>&#33; and see.'
+            ),
+            (
+                'Search for google.com/?q=1&#x21;! and see.',
+                'Search for <a href="http://google.com/?q=1">google.com/?q=1</a>&#x21;! and see.'
+            ),
+            (
+                'See google.com/?q=1&#33;&#33;',
+                'See <a href="http://google.com/?q=1">google.com/?q=1</a>&#33;&#33;'
+            ),
         )
         for value, output in tests:
             with self.subTest(value=value):


### PR DESCRIPTION
## Summary
- fix #426 by trimming trailing punctuation based on the unescaped token so entities don't duplicate their suffix
- add regression coverage for escaped/numeric entities and template filter nofollow rendering

## Reproduction & failure
1. utils urlize path:
   ```
   PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py utils_tests.test_html.TestUtilsHtml.test_urlize --parallel=1
   ```
   ```
   AssertionError: 'Search for <a href=\"http://google.com/?q=1%3C\">google.com/?q=1&lt</a>lt! and see.' != 'Search for <a href=\"http://google.com/?q=1%3C\">google.com/?q=1&lt</a>! and see.'
   ```
2. template filter path:
   ```
   PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py template_tests.filter_tests.test_urlize.UrlizeTests.test_urlize_entity_trailing_punctuation --parallel=1
   ```
   ```
   AssertionError: 'Search for <a href=\"http://google.com/?q=1%3C\" rel=\"nofollow\">google.com/?q=1&amp;lt</a>lt! and see.' != 'Search for <a href=\"http://google.com/?q=1%3C\" rel=\"nofollow\">google.com/?q=1&lt</a>! and see.'
   ```

## Fix
- compute the trailing punctuation length from the unescaped string and move exactly that many characters from the escaped token into the trail

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py utils_tests.test_html.TestUtilsHtml.test_urlize --parallel=1
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py template_tests.filter_tests.test_urlize.UrlizeTests.test_urlize_entity_trailing_punctuation template_tests.filter_tests.test_urlize.UrlizeTests.test_urlize_entity_trailing_parentheses --parallel=1
- flake8 django/utils/html.py tests/utils_tests/test_html.py tests/template_tests/filter_tests/test_urlize.py

## Links
- #426
- django/django#14539

Python 3.12.12 via nix profile; dependencies installed into a venv.