### PR TITLE
swev-id: django__django-14559 ORM: Return number of rows matched from bulk_update()

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -527,6 +527,7 @@ class QuerySet:
     def bulk_update(self, objs, fields, batch_size=None):
         """
         Update the given fields in each of the given objects in the database.
+        Return the number of rows matched (int).
         """
         if batch_size is not None and batch_size < 0:
             raise ValueError('Batch size must be a positive integer.')
@@ -541,7 +542,7 @@ class QuerySet:
         if any(f.primary_key for f in fields):
             raise ValueError('bulk_update() cannot be used with primary key fields.')
         if not objs:
-            return
+            return 0
         # PK is used twice in the resulting update query, once in the filter
         # and once in the WHEN. Each field will also have one CAST.
         max_batch_size = connections[self.db].ops.bulk_batch_size(['pk', 'pk'] + fields, objs)
@@ -563,9 +564,11 @@ class QuerySet:
                     case_statement = Cast(case_statement, output_field=field)
                 update_kwargs[field.attname] = case_statement
             updates.append(([obj.pk for obj in batch_objs], update_kwargs))
+        matched_rows = 0
         with transaction.atomic(using=self.db, savepoint=False):
             for pks, update_kwargs in updates:
-                self.filter(pk__in=pks).update(**update_kwargs)
+                matched_rows += self.filter(pk__in=pks).update(**update_kwargs)
+        return matched_rows
     bulk_update.alters_data = True
 
     def get_or_create(self, defaults=None, **kwargs):

--- a/docs/ref/models/querysets.txt
+++ b/docs/ref/models/querysets.txt
@@ -2231,6 +2231,8 @@ instances, generally with one query::
     >>> objs[1].headline = 'This is entry 2'
     >>> Entry.objects.bulk_update(objs, ['headline'])
 
+The method returns the number of rows matched as an :class:`int`.
+
 :meth:`.QuerySet.update` is used to save the changes, so this is more efficient
 than iterating through the list of models and calling ``save()`` on each of
 them, but it has a few caveats:
@@ -2245,7 +2247,8 @@ them, but it has a few caveats:
 * Updating fields defined on multi-table inheritance ancestors will incur an
   extra query per ancestor.
 * When an individual batch contains duplicates, only the first instance in that
-  batch will result in an update.
+  batch will result in an update. If the same primary key occurs in a later
+  batch, it will be updated again and counted each time it appears.
 
 The ``batch_size`` parameter controls how many objects are saved in a single
 query. The default is to update all objects in one batch, except for SQLite

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -240,3 +240,73 @@ class BulkUpdateTests(TestCase):
             obj.json_field = {'c': obj.json_field['a'] + 1}
         JSONFieldNullable.objects.bulk_update(objs, ['json_field'])
         self.assertCountEqual(JSONFieldNullable.objects.filter(json_field__has_key='c'), objs)
+
+
+class BulkUpdateReturnValueTests(TestCase):
+    def test_returns_int_single_object(self):
+        note = Note.objects.create(note='a', misc='a')
+        note.note = 'updated'
+
+        count = Note.objects.bulk_update([note], ['note'])
+
+        self.assertIsInstance(count, int)
+        self.assertEqual(count, 1)
+        note.refresh_from_db()
+        self.assertEqual(note.note, 'updated')
+
+    def test_returns_int_multiple_objects(self):
+        notes = [Note.objects.create(note=str(i), misc=str(i)) for i in range(3)]
+        for index, note in enumerate(notes):
+            note.note = f'updated-{index}'
+
+        count = Note.objects.bulk_update(notes, ['note'])
+
+        self.assertIsInstance(count, int)
+        self.assertEqual(count, len(notes))
+        self.assertCountEqual(
+            Note.objects.values_list('note', flat=True),
+            [note.note for note in notes],
+        )
+
+    def test_returns_int_with_batching(self):
+        notes = [Note.objects.create(note=str(i), misc=str(i)) for i in range(3)]
+        for index, note in enumerate(notes):
+            note.note = f'batched-{index}'
+
+        count = Note.objects.bulk_update(notes, ['note'], batch_size=1)
+
+        self.assertEqual(count, len(notes))
+        self.assertCountEqual(
+            Note.objects.values_list('note', flat=True),
+            [note.note for note in notes],
+        )
+
+    def test_returns_zero_for_no_matches(self):
+        note = Note(pk=999999, note='missing', misc='missing')
+
+        count = Note.objects.bulk_update([note], ['note'])
+
+        self.assertEqual(count, 0)
+        self.assertFalse(Note.objects.filter(pk=note.pk).exists())
+
+    def test_duplicates_within_same_batch_first_wins(self):
+        saved = Note.objects.create(note='original', misc='m')
+        first = Note(pk=saved.pk, note='first', misc='m')
+        second = Note(pk=saved.pk, note='second', misc='m')
+
+        count = Note.objects.bulk_update([first, second], ['note'])
+
+        self.assertEqual(count, 1)
+        saved.refresh_from_db()
+        self.assertEqual(saved.note, 'first')
+
+    def test_duplicates_across_batches_double_counts(self):
+        saved = Note.objects.create(note='original', misc='m')
+        first = Note(pk=saved.pk, note='first', misc='m')
+        second = Note(pk=saved.pk, note='second', misc='m')
+
+        count = Note.objects.bulk_update([first, second], ['note'], batch_size=1)
+
+        self.assertEqual(count, 2)
+        saved.refresh_from_db()
+        self.assertEqual(saved.note, 'second')

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -289,6 +289,11 @@ class BulkUpdateReturnValueTests(TestCase):
         self.assertEqual(count, 0)
         self.assertFalse(Note.objects.filter(pk=note.pk).exists())
 
+    def test_returns_zero_for_empty_input(self):
+        count = Note.objects.bulk_update([], ['note'])
+
+        self.assertEqual(count, 0)
+
     def test_duplicates_within_same_batch_first_wins(self):
         saved = Note.objects.create(note='original', misc='m')
         first = Note(pk=saved.pk, note='first', misc='m')


### PR DESCRIPTION
## Summary
- aggregate the per-batch counts returned by QuerySet.bulk_update() and return the total rows matched
- document the new return value and add regression coverage for note bulk updates, including duplicate objects
- capture the duplicate caveat: first occurrence wins inside a batch, but duplicates rerun in later batches are double-counted

## Testing
- PYTHONPATH=/workspace/django:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py queries.test_bulk_update --parallel=1
- flake8 django/db/models/query.py tests/queries/test_bulk_update.py

Resolves #432