### PR TITLE
swev-id: django__django-14608 add nonform class to formset errors

### DIFF
--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -333,7 +333,7 @@ class BaseFormSet:
         self._non_form_errors.
         """
         self._errors = []
-        self._non_form_errors = self.error_class()
+        self._non_form_errors = self.error_class(error_class='nonform')
         empty_forms_count = 0
 
         if not self.is_bound:  # Stop further processing.
@@ -380,7 +380,7 @@ class BaseFormSet:
             # Give self.clean() a chance to do cross-form validation.
             self.clean()
         except ValidationError as e:
-            self._non_form_errors = self.error_class(e.error_list)
+            self._non_form_errors = self.error_class(e.error_list, error_class='nonform')
 
     def clean(self):
         """

--- a/django/forms/formsets.py
+++ b/django/forms/formsets.py
@@ -333,7 +333,8 @@ class BaseFormSet:
         self._non_form_errors.
         """
         self._errors = []
-        self._non_form_errors = self.error_class(error_class='nonform')
+        self._non_form_errors = self.error_class()
+        self._set_non_form_css_class(self._non_form_errors)
         empty_forms_count = 0
 
         if not self.is_bound:  # Stop further processing.
@@ -380,7 +381,8 @@ class BaseFormSet:
             # Give self.clean() a chance to do cross-form validation.
             self.clean()
         except ValidationError as e:
-            self._non_form_errors = self.error_class(e.error_list, error_class='nonform')
+            self._non_form_errors = self.error_class(e.error_list)
+            self._set_non_form_css_class(self._non_form_errors)
 
     def clean(self):
         """
@@ -390,6 +392,17 @@ class BaseFormSet:
         via formset.non_form_errors()
         """
         pass
+
+    def _set_non_form_css_class(self, error_list):
+        error_class_attr = getattr(error_list, 'error_class', None)
+        if error_class_attr is None:
+            return
+        if not error_class_attr:
+            error_list.error_class = 'errorlist nonform'
+            return
+        if 'nonform' in str(error_class_attr).split():
+            return
+        error_list.error_class = f"{error_class_attr} nonform"
 
     def has_changed(self):
         """Return True if data in any form differs from initial."""

--- a/docs/topics/forms/formsets.txt
+++ b/docs/topics/forms/formsets.txt
@@ -365,6 +365,11 @@ The formset ``clean`` method is called after all the ``Form.clean`` methods
 have been called. The errors will be found using the ``non_form_errors()``
 method on the formset.
 
+When rendered in a template, ``{{ formset.non_form_errors }}`` yields an
+:class:`~django.forms.utils.ErrorList` with the CSS classes ``errorlist`` and
+``nonform``, mirroring the ``errorlist nonfield`` classes used by
+``{{ form.non_field_errors }}`` on individual forms.
+
 Validating the number of forms in a formset
 ===========================================
 

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1145,6 +1145,32 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertIsInstance(formset.non_form_errors(), ErrorList)
         self.assertEqual(list(formset.non_form_errors()), ['This is a non-form error'])
 
+    def test_non_form_errors_include_nonform_class_from_clean(self):
+        class NonFormErrorFormSet(BaseFormSet):
+            def clean(self):
+                raise ValidationError("This is a non-form error")
+
+        FormSet = formset_factory(FavoriteDrinkForm, formset=NonFormErrorFormSet, extra=1)
+        data = {
+            'drinks-TOTAL_FORMS': '1',
+            'drinks-INITIAL_FORMS': '0',
+            'drinks-MIN_NUM_FORMS': '0',
+            'drinks-MAX_NUM_FORMS': '1000',
+            'drinks-0-name': 'Water',
+        }
+        formset = FormSet(data, prefix='drinks')
+        self.assertFalse(formset.is_valid())
+        errors_html = str(formset.non_form_errors())
+        self.assertIn('class="errorlist nonform"', errors_html)
+        self.assertIn('This is a non-form error', errors_html)
+
+    def test_management_form_errors_include_nonform_class(self):
+        ManagementErrorFormSet = formset_factory(FavoriteDrinkForm, extra=1)
+        formset = ManagementErrorFormSet(data={}, prefix='drinks')
+        errors_html = str(formset.non_form_errors())
+        self.assertIn('class="errorlist nonform"', errors_html)
+        self.assertIn('ManagementForm data is missing or has been tampered with.', errors_html)
+
     def test_validate_max_ignores_forms_marked_for_deletion(self):
         class CheckForm(Form):
             field = IntegerField()

--- a/tests/forms_tests/tests/test_formsets.py
+++ b/tests/forms_tests/tests/test_formsets.py
@@ -1171,6 +1171,32 @@ class FormsFormsetTestCase(SimpleTestCase):
         self.assertIn('class="errorlist nonform"', errors_html)
         self.assertIn('ManagementForm data is missing or has been tampered with.', errors_html)
 
+    def test_non_form_errors_custom_error_class_without_attribute(self):
+        class SimpleList(list):
+            pass
+
+        class NonFormErrorFormSet(BaseFormSet):
+            def clean(self):
+                raise ValidationError("This is a non-form error")
+
+        FormSet = formset_factory(
+            FavoriteDrinkForm,
+            formset=NonFormErrorFormSet,
+            extra=1,
+        )
+        data = {
+            'drinks-TOTAL_FORMS': '1',
+            'drinks-INITIAL_FORMS': '0',
+            'drinks-MIN_NUM_FORMS': '0',
+            'drinks-MAX_NUM_FORMS': '1000',
+            'drinks-0-name': 'Water',
+        }
+        formset = FormSet(data, prefix='drinks', error_class=SimpleList)
+        errors = formset.non_form_errors()
+        self.assertIsInstance(errors, SimpleList)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].messages, ['This is a non-form error'])
+
     def test_validate_max_ignores_forms_marked_for_deletion(self):
         class CheckForm(Form):
             field = IntegerField()


### PR DESCRIPTION
## Summary
- add the `nonform` CSS class to formset non-form error lists
- cover formset non-form error rendering with regression tests
- document the rendered classes for `{{ formset.non_form_errors }}`

## Issue
- Fixes #434

## Observed failure
```text
FAIL: test_non_form_errors_include_nonform_class_from_clean (forms_tests.tests.test_formsets.FormsFormsetTestCase.test_non_form_errors_include_nonform_class_from_clean)
AssertionError: 'class="errorlist nonform"' not found in '<ul class="errorlist"><li>This is a non-form error</li></ul>'

FAIL: test_management_form_errors_include_nonform_class (forms_tests.tests.test_formsets.FormsFormsetTestCase.test_management_form_errors_include_nonform_class)
AssertionError: 'class="errorlist nonform"' not found in '<ul class="errorlist"><li>ManagementForm data is missing or has been tampered with. Missing fields: drinks-TOTAL_FORMS, drinks-INITIAL_FORMS. You may need to file a bug report if the issue persists.</li></ul>'
```

## Stack trace
```text
$ PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py forms_tests.tests.test_formsets.FormsFormsetTestCase.test_non_form_errors_include_nonform_class_from_clean --parallel=1
Testing against Django installed in '/workspace/django/django'
Found 1 test(s).
System check identified no issues (0 silenced).
F
======================================================================
FAIL: test_non_form_errors_include_nonform_class_from_clean (forms_tests.tests.test_formsets.FormsFormsetTestCase.test_non_form_errors_include_nonform_class_from_clean)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/forms_tests/tests/test_formsets.py", line 1164, in test_non_form_errors_include_nonform_class_from_clean
    self.assertIn('class="errorlist nonform"', errors_html)
AssertionError: 'class="errorlist nonform"' not found in '<ul class="errorlist"><li>This is a non-form error</li></ul>'
```
```text
$ PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py forms_tests.tests.test_formsets.FormsFormsetTestCase.test_management_form_errors_include_nonform_class --parallel=1
Testing against Django installed in '/workspace/django/django'
Found 1 test(s).
System check identified no issues (0 silenced).
F
======================================================================
FAIL: test_management_form_errors_include_nonform_class (forms_tests.tests.test_formsets.FormsFormsetTestCase.test_management_form_errors_include_nonform_class)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/forms_tests/tests/test_formsets.py", line 1171, in test_management_form_errors_include_nonform_class
    self.assertIn('class="errorlist nonform"', errors_html)
AssertionError: 'class="errorlist nonform"' not found in '<ul class="errorlist"><li>ManagementForm data is missing or has been tampered with. Missing fields: drinks-TOTAL_FORMS, drinks-INITIAL_FORMS. You may need to file a bug report if the issue persists.</li></ul>'
```

## Reproduction steps
1. Create a virtual environment and install `asgiref`, `sqlparse`, and `pytz` so `tests/runtests.py` can execute.
2. Run the targeted regression tests:
   ```bash
   PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py forms_tests.tests.test_formsets.FormsFormsetTestCase.test_non_form_errors_include_nonform_class_from_clean --parallel=1
   PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py forms_tests.tests.test_formsets.FormsFormsetTestCase.test_management_form_errors_include_nonform_class --parallel=1
   ```
3. Alternatively, reproduce manually with a minimal formset:
   ```python
   from django.core.exceptions import ValidationError
   from django.forms import BaseFormSet, CharField, Form, formset_factory

   class SampleForm(Form):
       name = CharField()

   class SampleFormSet(BaseFormSet):
       def clean(self):
           raise ValidationError("This is a non-form error")

   FormSet = formset_factory(SampleForm, formset=SampleFormSet, extra=1)
   data = {
       'form-TOTAL_FORMS': '1',
       'form-INITIAL_FORMS': '0',
       'form-MIN_NUM_FORMS': '0',
       'form-MAX_NUM_FORMS': '1',
   }
   formset = FormSet(data=data)
   formset.is_valid()
   print(formset.non_form_errors())
   ```

## Backward compatibility
- Adds the ``nonform`` CSS class to the existing non-form ErrorList without changing the list contents.
