### PR TITLE
swev-id: django__django-14725 — Edit-only ModelFormSet mode (allow_create=False): spec, tests, docs plan

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -568,21 +568,54 @@ class BaseModelFormSet(BaseFormSet):
     A ``FormSet`` for editing a queryset and/or adding new objects to it.
     """
     model = None
+    allow_create = True
+    edit_only = False
+    default_error_messages = {
+        'add_not_allowed': _('Adding new objects is not allowed in this formset.'),
+    }
 
     # Set of fields that must be unique among forms of this set.
     unique_fields = set()
 
     def __init__(self, data=None, files=None, auto_id='id_%s', prefix=None,
                  queryset=None, *, initial=None, **kwargs):
+        allow_create_value = kwargs.pop('allow_create', None)
+        edit_only = kwargs.pop('edit_only', None)
+        if allow_create_value is not None and edit_only is not None:
+            raise TypeError("'allow_create' and 'edit_only' arguments are mutually exclusive.")
+        if edit_only is not None:
+            allow_create_value = not edit_only
+        if allow_create_value is None:
+            allow_create_value = getattr(type(self), 'allow_create', True)
+        self.allow_create = bool(allow_create_value)
+        self.edit_only = not self.allow_create
+        if not self.allow_create:
+            self.extra = 0
         self.queryset = queryset
         self.initial_extra = initial
+        self._initial_queryset_count_cache = None
+        self._existing_object_pks_cache = None
         super().__init__(**{'data': data, 'files': files, 'auto_id': auto_id, 'prefix': prefix, **kwargs})
 
     def initial_form_count(self):
         """Return the number of forms that are required in this FormSet."""
         if not self.is_bound:
-            return len(self.get_queryset())
+            return self._initial_queryset_count()
+        if not self.allow_create:
+            return self._initial_queryset_count()
         return super().initial_form_count()
+
+    def _initial_queryset_count(self):
+        if self._initial_queryset_count_cache is None:
+            self._initial_queryset_count_cache = len(self.get_queryset())
+        return self._initial_queryset_count_cache
+
+    def _existing_object_pks(self):
+        if self._existing_object_pks_cache is None:
+            self._existing_object_pks_cache = {
+                obj.pk for obj in self.get_queryset() if obj.pk is not None
+            }
+        return self._existing_object_pks_cache
 
     def _existing_object(self, pk):
         if not hasattr(self, '_object_dict'):
@@ -653,6 +686,8 @@ class BaseModelFormSet(BaseFormSet):
 
     def save_new(self, form, commit=True):
         """Save and return a new model instance for the given form."""
+        if not self.allow_create:
+            self._raise_add_not_allowed()
         return form.save(commit=commit)
 
     def save_existing(self, form, instance, commit=True):
@@ -682,6 +717,26 @@ class BaseModelFormSet(BaseFormSet):
 
     def clean(self):
         self.validate_unique()
+        if self.allow_create:
+            return
+        initial_count = self._initial_queryset_count()
+        existing_pks = self._existing_object_pks()
+        for index, form in enumerate(self.forms):
+            if self.can_delete and self._should_delete_form(form):
+                continue
+            if index >= initial_count:
+                if form.has_changed():
+                    self._raise_add_not_allowed()
+                continue
+            instance_pk = getattr(form.instance, 'pk', None)
+            if instance_pk not in existing_pks and form.has_changed():
+                self._raise_add_not_allowed()
+
+    def _raise_add_not_allowed(self):
+        raise ValidationError(
+            self.error_messages['add_not_allowed'],
+            code='add_not_allowed',
+        )
 
     def validate_unique(self):
         # Collect unique_checks and date_checks to run from all the forms.
@@ -793,18 +848,28 @@ class BaseModelFormSet(BaseFormSet):
 
         saved_instances = []
         forms_to_delete = self.deleted_forms
+        existing_pks = self._existing_object_pks() if not self.allow_create else None
         for form in self.initial_forms:
             obj = form.instance
+            if form in forms_to_delete:
+                if obj.pk is None:
+                    continue
+                self.deleted_objects.append(obj)
+                self.delete_existing(obj, commit=commit)
+                continue
+            if not self.allow_create:
+                instance_pk = getattr(obj, 'pk', None)
+                if instance_pk not in existing_pks:
+                    if form.has_changed():
+                        self._raise_add_not_allowed()
+                    continue
             # If the pk is None, it means either:
             # 1. The object is an unexpected empty model, created by invalid
             #    POST data such as an object outside the formset's queryset.
             # 2. The object was already deleted from the database.
             if obj.pk is None:
                 continue
-            if form in forms_to_delete:
-                self.deleted_objects.append(obj)
-                self.delete_existing(obj, commit=commit)
-            elif form.has_changed():
+            if form.has_changed():
                 self.changed_objects.append((obj, form.changed_data))
                 saved_instances.append(self.save_existing(form, obj, commit=commit))
                 if not commit:
@@ -813,6 +878,14 @@ class BaseModelFormSet(BaseFormSet):
 
     def save_new_objects(self, commit=True):
         self.new_objects = []
+        if not self.allow_create:
+            for form in self.extra_forms:
+                if not form.has_changed():
+                    continue
+                if self.can_delete and self._should_delete_form(form):
+                    continue
+                self._raise_add_not_allowed()
+            return self.new_objects
         for form in self.extra_forms:
             if not form.has_changed():
                 continue
@@ -875,7 +948,8 @@ def modelformset_factory(model, form=ModelForm, formfield_callback=None,
                          widgets=None, validate_max=False, localized_fields=None,
                          labels=None, help_texts=None, error_messages=None,
                          min_num=None, validate_min=False, field_classes=None,
-                         absolute_max=None, can_delete_extra=True, renderer=None):
+                         absolute_max=None, can_delete_extra=True, renderer=None,
+                         allow_create=None, edit_only=None):
     """Return a FormSet class for the given Django model class."""
     meta = getattr(form, 'Meta', None)
     if (getattr(meta, 'fields', fields) is None and
@@ -890,12 +964,21 @@ def modelformset_factory(model, form=ModelForm, formfield_callback=None,
                              widgets=widgets, localized_fields=localized_fields,
                              labels=labels, help_texts=help_texts,
                              error_messages=error_messages, field_classes=field_classes)
+    if allow_create is not None and edit_only is not None:
+        raise TypeError("'allow_create' and 'edit_only' arguments are mutually exclusive.")
+    if edit_only is not None:
+        allow_create = not edit_only
+    if allow_create is False:
+        extra = 0
     FormSet = formset_factory(form, formset, extra=extra, min_num=min_num, max_num=max_num,
                               can_order=can_order, can_delete=can_delete,
                               validate_min=validate_min, validate_max=validate_max,
                               absolute_max=absolute_max, can_delete_extra=can_delete_extra,
                               renderer=renderer)
     FormSet.model = model
+    if allow_create is not None:
+        FormSet.allow_create = allow_create
+        FormSet.edit_only = not allow_create
     return FormSet
 
 
@@ -1076,7 +1159,8 @@ def inlineformset_factory(parent_model, model, form=ModelForm,
                           widgets=None, validate_max=False, localized_fields=None,
                           labels=None, help_texts=None, error_messages=None,
                           min_num=None, validate_min=False, field_classes=None,
-                          absolute_max=None, can_delete_extra=True, renderer=None):
+                          absolute_max=None, can_delete_extra=True, renderer=None,
+                          allow_create=None, edit_only=None):
     """
     Return an ``InlineFormSet`` for the given kwargs.
 
@@ -1087,6 +1171,12 @@ def inlineformset_factory(parent_model, model, form=ModelForm,
     # enforce a max_num=1 when the foreign key to the parent model is unique.
     if fk.unique:
         max_num = 1
+    if allow_create is not None and edit_only is not None:
+        raise TypeError("'allow_create' and 'edit_only' arguments are mutually exclusive.")
+    if edit_only is not None:
+        allow_create = not edit_only
+    if allow_create is False:
+        extra = 0
     kwargs = {
         'form': form,
         'formfield_callback': formfield_callback,
@@ -1110,6 +1200,8 @@ def inlineformset_factory(parent_model, model, form=ModelForm,
         'can_delete_extra': can_delete_extra,
         'renderer': renderer,
     }
+    if allow_create is not None:
+        kwargs['allow_create'] = allow_create
     FormSet = modelformset_factory(model, **kwargs)
     FormSet.fk = fk
     return FormSet

--- a/docs/adr/ADR-edit-only-model-formset.md
+++ b/docs/adr/ADR-edit-only-model-formset.md
@@ -1,1 +1,141 @@
 # ADR: Edit-only ModelFormSet mode
+
+Context: Users need a robust way to present an edit-only ModelFormSet that allows editing and optional deletion of existing objects but strictly disallows creation of new objects. Current patterns (e.g., using extra=0, max_num=0, validate_max=True) are insufficient because client-side JavaScript can add forms and POST payloads can tamper with ManagementForm fields (TOTAL_FORMS, INITIAL_FORMS). This ADR specifies an explicit API and server-side validation to enforce edit-only behavior.
+
+Decision: Introduce a first-class flag on BaseModelFormSet and the model formset factories to disable creation of new objects, independent of client-submitted ManagementForm values.
+
+Summary
+- New flag: allow_create (bool), default True. When False, the formset operates in edit-only mode.
+- Optional alias: edit_only (bool), default False, sugar for allow_create=False. Only one source of truth is persisted (allow_create).
+- Enforce server-side invariants that do not trust ManagementForm INITIAL_FORMS for edit-only classification.
+- Save behavior never calls save_new() when allow_create=False; instead, raise a ValidationError on attempts to submit extra/new forms.
+
+API Proposal
+- Add parameter allow_create to:
+  - django.forms.models.modelformset_factory(..., allow_create: bool = True, ...)
+  - django.forms.models.inlineformset_factory(..., allow_create: bool = True, ...)
+  - django.forms.models.BaseModelFormSet.__init__(..., allow_create: bool = True, ...)
+- Optional alias edit_only (default False) accepted by the same entry points; internally translated to allow_create = not edit_only.
+- Backwards-compatible default: omit the flag to preserve current behavior.
+
+Validation and Save Behavior
+1) Classification independent of client INITIAL_FORMS
+   - In BaseModelFormSet.initial_form_count():
+     - If allow_create is False, return len(self.get_queryset()) even when bound.
+     - Otherwise, keep existing behavior (use ManagementForm.cleaned_data[INITIAL_FORMS] when bound).
+   - Rationale: Prevent tampering with INITIAL_FORMS from reclassifying posted forms.
+
+2) Extra form submission is rejected in edit-only mode
+   - In BaseModelFormSet.clean():
+     - Call super().clean() (to retain validate_unique and other inherited behaviors).
+     - If allow_create is False:
+       - Compute changed_extra = [f for f in self.extra_forms if f.has_changed() and not (self.can_delete and self._should_delete_form(f))].
+       - If changed_extra is non-empty, raise ValidationError with code='add_not_allowed' and message: "Adding new objects is not allowed in this formset.".
+       - Note: This tolerates empty extra forms posted by clients (e.g., TOTAL_FORMS greater than expected) but enforces that they’re empty or marked for deletion.
+
+3) save() never creates new objects in edit-only mode
+   - In BaseModelFormSet.save_new_objects():
+     - If allow_create is False:
+       - If any extra form has changed and is not marked for deletion, raise ValidationError(code='add_not_allowed').
+       - Return [] (no new objects).
+   - In BaseModelFormSet.save():
+     - Keep existing orchestration, but the save_new_objects() guard ensures no new objects are created even if save() is called without prior is_valid().
+
+4) Prevent editing objects outside the provided queryset
+   - Preserve current behavior:
+     - BaseModelFormSet._construct_form() binds instances by PK only if pk belongs to self.get_queryset(); otherwise, the form’s instance remains new (instance.pk is None).
+     - BaseModelFormSet.save_existing_objects() skips forms whose instance.pk is None. No new objects are created or edited in this path.
+   - Tests will assert that posting PKs not in the queryset does not lead to creation or modification of out-of-scope objects.
+
+5) Deletions
+   - Deletions remain controlled by can_delete / can_delete_extra.
+   - Recommended default: allow deletions (can_delete=True) is orthogonal to allow_create. Edit-only means "no creation"; editing and deletion behavior follow existing configuration.
+   - Behavior: In edit-only mode, extra forms marked for deletion are ignored (no-op).
+
+6) Interaction with extra, max_num, validate_max, min_num, absolute_max
+   - When allow_create is False:
+     - Rendering (unbound): Force extra=0 to avoid presenting add forms. Precedence: edit-only overrides any explicit extra > 0.
+     - Bound post: total_form_count still uses ManagementForm’s TOTAL_FORMS (with absolute_max cap). Edit-only validation tolerates empty extra forms but rejects changed ones.
+     - validate_max / max_num: Unchanged behavior; if validate_max is True and clients post more than max_num forms, the existing 'too_many_forms' error may be raised in addition to 'add_not_allowed'. If max_num is set lower than len(queryset), existing behavior applies (initial forms are still displayed).
+     - min_num / validate_min: Unchanged and orthogonal. Edit-only does not force a minimum number of changed forms.
+     - absolute_max: Unchanged; continues to protect against memory exhaustion. Edit-only logic runs after ManagementForm is cleaned.
+
+7) Error messages and codes
+   - BaseModelFormSet.default_error_messages augmented with:
+     - 'add_not_allowed': _('Adding new objects is not allowed in this formset.')
+   - ValidationError raised at formset.clean() and/or save_new_objects() uses this code/message.
+
+Concrete Implementation Outline (code paths)
+- django/forms/models.py:
+  - class BaseModelFormSet:
+    - __init__: accept allow_create and optional edit_only; set self.allow_create accordingly and store self.initial_extra.
+    - initial_form_count(): if self.allow_create is False, return len(self.get_queryset()) regardless of is_bound.
+    - clean(): call super().clean(); enforce changed_extra validation (add_not_allowed) when allow_create is False.
+    - save_new_objects(): enforce add_not_allowed and return [] when allow_create is False.
+  - modelformset_factory(...): accept allow_create (and edit_only alias); if allow_create is False, set extra=0 for the returned FormSet type; propagate allow_create into the constructed FormSet via formset attrs or __init__ kwargs.
+  - inlineformset_factory(...): same as above.
+- django/forms/formsets.py:
+  - No changes required for core mechanisms; behavior remains compatible. Optionally add 'add_not_allowed' in BaseFormSet.default_error_messages if shared by subclasses.
+- docs/topics/forms/modelforms.txt:
+  - Replace the note that "formsets don’t yet provide functionality for an edit-only view" (ticket 26142) with guidance on the new flag. Include rationale why extra=0 is insufficient.
+
+Server-side Invariants (edit-only)
+- initial_form_count = len(queryset), independent of client INITIAL_FORMS.
+- For i >= initial_form_count, any form with has_changed() and not marked for deletion causes a ValidationError at clean() and save().
+- save() must not call save_new(); save_new_objects() raises if any attempt is made.
+- Objects outside queryset are not edited, and no new object is created from such data.
+
+Test Plan (unit tests)
+1) Reproduce vulnerabilities with current behavior (flag absent)
+   - Case A: extra=0, client posts a payload with TOTAL_FORMS = initial_count + 1 and provides data for the extra form; assert new object is created (pre-flag behavior).
+   - Case B: max_num=0, validate_max=True, client tampers with INITIAL_FORMS to reclassify forms; assert new object can be created (pre-flag behavior).
+
+2) Edit-only prevents creation
+   - With allow_create=False (or edit_only=True), repeat Case A and Case B:
+     - is_valid() returns False with non-form error code='add_not_allowed' when extra forms contain changes.
+     - save() raises ValidationError(code='add_not_allowed') if called directly without validation, and no objects are created.
+
+3) Successful editing of existing queryset objects
+   - Provide changes to one or more initial forms; assert is_valid() is True and save() updates those instances; no additions.
+
+4) Bogus PKs, blank PKs, PKs outside queryset
+   - Submit initial-index forms whose posted PKs are invalid, blank, or outside the queryset:
+     - Assert that those forms either error due to required PK (invalid/blank) or are treated as non-existent instances with instance.pk=None and thus skipped by save_existing_objects.
+     - Assert that no new objects are created and appropriate errors surface for required PKs.
+
+5) Deletion behavior
+   - With can_delete=True and allow_create=False, mark initial forms for deletion:
+     - Assert is_valid() is True and save() deletes those objects.
+   - Mark extra forms for deletion and submit changes:
+     - Assert is_valid() is True and those extra forms are ignored (no object creation and no deletion of non-existent objects).
+
+6) Interaction with max_num/validate_max/extra
+   - With allow_create=False and explicit extra>0 passed to factory:
+     - Assert rendered unbound formset has no add forms (extra=0 enforced).
+   - With allow_create=False and validate_max=True, max_num<N forms posted:
+     - Assert too_many_forms error appears alongside add_not_allowed when applicable; no object creation.
+
+Documentation Updates Outline
+- Update docs/topics/forms/modelforms.txt:
+  - New section: "Edit-only model formsets" describing allow_create=False (and edit_only=True alias).
+  - Explain why extra=0 and max_num=0 are insufficient; show POST manipulation examples.
+  - Provide usage examples:
+    - AuthorFormSet = modelformset_factory(Author, fields=(...), allow_create=False, can_delete=True)
+    - Inline formset equivalent.
+  - Describe error messaging and interaction with deletion.
+
+Backwards Compatibility
+- Defaults preserve existing behavior: allow_create defaults to True.
+- No changes to ManagementForm or BaseFormSet semantics for non-edit-only formsets.
+- Existing code continues to work without modification; edit-only must be explicitly opted in.
+
+References
+- Django docs (current): docs/topics/forms/modelforms.txt states lack of edit-only functionality and references ticket #26142.
+- Relevant code paths and behaviors analyzed:
+  - django/forms/formsets.py: ManagementForm, BaseFormSet.initial_form_count(), total_form_count(), extra_forms, full_clean(), validate_max.
+  - django/forms/models.py: BaseModelFormSet.initial_form_count(), _construct_form(), save_existing_objects(), save_new_objects(), add_fields(), modelformset_factory(), inlineformset_factory().
+
+Consequences
+- Provides a secure, explicit server-side control to prevent new object creation via formsets.
+- Minimal, localized changes to BaseModelFormSet and factories; no changes to core formset mechanics.
+- Clear tests and documentation to support and enforce expected behavior.

--- a/docs/adr/ADR-edit-only-model-formset.md
+++ b/docs/adr/ADR-edit-only-model-formset.md
@@ -1,0 +1,1 @@
+# ADR: Edit-only ModelFormSet mode

--- a/docs/topics/forms/modelforms.txt
+++ b/docs/topics/forms/modelforms.txt
@@ -953,8 +953,37 @@ extra forms displayed.
 
 Also, ``extra=0`` doesn't prevent creation of new model instances as you can
 :ref:`add additional forms with JavaScript <understanding-the-managementform>`
-or send additional POST data. Formsets :ticket:`don't yet provide functionality
-<26142>` for an "edit only" view that prevents creation of new instances.
+or send additional POST data. To make a formset edit-only, pass
+``allow_create=False`` (or ``edit_only=True``) to
+:func:`~django.forms.models.modelformset_factory` or
+:func:`~django.forms.models.inlineformset_factory`. Edit-only formsets render
+without extra forms (``extra`` is forced to ``0`` when unbound) and reject any
+tampered POST submissions—including altered management form counts or missing
+and out-of-queryset primary keys—that would otherwise create new objects.
+Existing objects continue to be editable, and deletions still work when
+``can_delete=True``. Existing ``max_num``/``validate_max`` limits remain in
+effect; they don't re-enable creation.
+
+For example::
+
+    >>> AuthorFormSet = modelformset_factory(
+    ...     Author,
+    ...     fields=('name',),
+    ...     allow_create=False,
+    ...     can_delete=True,
+    ... )
+    >>> formset = AuthorFormSet(queryset=Author.objects.order_by('name'))
+
+Inline formsets support the same flag::
+
+    >>> AuthorBooksFormSet = inlineformset_factory(
+    ...     Author,
+    ...     Book,
+    ...     fields=('title',),
+    ...     allow_create=False,
+    ...     can_delete=True,
+    ... )
+    >>> formset = AuthorBooksFormSet(instance=author)
 
 If the value of ``max_num`` is greater than the number of existing related
 objects, up to ``extra`` additional blank forms will be added to the formset,

--- a/tests/model_formsets/tests.py
+++ b/tests/model_formsets/tests.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 
 from django import forms
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.forms.models import (
     BaseModelFormSet, _get_foreign_key, inlineformset_factory,
@@ -2021,3 +2021,157 @@ class TestModelFormsetOverridesTroughFormMeta(TestCase):
         BookFormSet = modelformset_factory(Author, fields='__all__', renderer=renderer)
         formset = BookFormSet()
         self.assertEqual(formset.renderer, renderer)
+
+
+class EditOnlyModelFormSetTests(TestCase):
+    def test_allow_create_true_accepts_tampered_total_forms(self):
+        author = Author.objects.create(name='Existing Author')
+        AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=0)
+        data = {
+            'form-TOTAL_FORMS': '2',
+            'form-INITIAL_FORMS': '1',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-id': str(author.pk),
+            'form-0-name': 'Existing Author',
+            'form-1-id': '',
+            'form-1-name': 'Unauthorized Author',
+        }
+        formset = AuthorFormSet(data=data, queryset=Author.objects.order_by('pk'))
+        self.assertTrue(formset.is_valid())
+        self.assertEqual(Author.objects.count(), 1)
+
+        saved = formset.save()
+        self.assertEqual(len(saved), 1)
+        self.assertEqual(Author.objects.count(), 2)
+        self.assertTrue(Author.objects.filter(name='Unauthorized Author').exists())
+
+    def test_disallow_create_rejects_added_form(self):
+        author = Author.objects.create(name='Existing Author')
+        AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=0, allow_create=False)
+        data = {
+            'form-TOTAL_FORMS': '2',
+            'form-INITIAL_FORMS': '1',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-id': str(author.pk),
+            'form-0-name': 'Existing Author',
+            'form-1-id': '',
+            'form-1-name': 'Unauthorized Author',
+        }
+        formset = AuthorFormSet(data=data, queryset=Author.objects.order_by('pk'))
+        self.assertIs(formset.is_valid(), False)
+        errors = formset.non_form_errors().as_data()
+        self.assertTrue(errors)
+        self.assertEqual(errors[0].code, 'add_not_allowed')
+        with self.assertRaises(ValidationError):
+            formset.save()
+        self.assertEqual(Author.objects.count(), 1)
+
+    def test_disallow_create_rejects_initial_forms_tampering(self):
+        author = Author.objects.create(name='Existing Author')
+        AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=0, allow_create=False)
+        data = {
+            'form-TOTAL_FORMS': '2',
+            'form-INITIAL_FORMS': '2',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-id': str(author.pk),
+            'form-0-name': 'Existing Author',
+            'form-1-id': '',
+            'form-1-name': 'Unauthorized Author',
+        }
+        formset = AuthorFormSet(data=data, queryset=Author.objects.order_by('pk'))
+        self.assertIs(formset.is_valid(), False)
+        errors = formset.non_form_errors().as_data()
+        self.assertEqual(errors[0].code, 'add_not_allowed')
+        self.assertEqual(Author.objects.count(), 1)
+
+    def test_disallow_create_rejects_bogus_primary_key(self):
+        Author.objects.create(name='Existing Author')
+        AuthorFormSet = modelformset_factory(Author, fields="__all__", extra=0, allow_create=False)
+        data = {
+            'form-TOTAL_FORMS': '1',
+            'form-INITIAL_FORMS': '1',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-id': '',
+            'form-0-name': 'Unauthorized Author',
+        }
+        formset = AuthorFormSet(data=data, queryset=Author.objects.order_by('pk'))
+        self.assertIs(formset.is_valid(), False)
+        errors = formset.non_form_errors().as_data()
+        self.assertEqual(errors[0].code, 'add_not_allowed')
+        self.assertEqual(Author.objects.count(), 1)
+
+    def test_disallow_create_allows_updates_and_deletions(self):
+        author = Author.objects.create(name='Existing Author')
+        former_author = Author.objects.create(name='To Remove')
+        AuthorFormSet = modelformset_factory(
+            Author,
+            fields="__all__",
+            extra=0,
+            can_delete=True,
+            allow_create=False,
+        )
+        data = {
+            'form-TOTAL_FORMS': '2',
+            'form-INITIAL_FORMS': '2',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-id': str(author.pk),
+            'form-0-name': 'Updated Author',
+            'form-1-id': str(former_author.pk),
+            'form-1-name': 'To Remove',
+            'form-1-DELETE': 'on',
+        }
+        formset = AuthorFormSet(data=data, queryset=Author.objects.order_by('pk'))
+        self.assertTrue(formset.is_valid())
+        formset.save()
+        self.assertTrue(Author.objects.filter(name='Updated Author').exists())
+        self.assertFalse(Author.objects.filter(pk=former_author.pk).exists())
+
+    def test_disallow_create_respects_max_num_without_validate_max(self):
+        author = Author.objects.create(name='Existing Author')
+        AuthorFormSet = modelformset_factory(
+            Author,
+            fields="__all__",
+            extra=0,
+            allow_create=False,
+            max_num=1,
+            validate_max=False,
+        )
+        data = {
+            'form-TOTAL_FORMS': '2',
+            'form-INITIAL_FORMS': '1',
+            'form-MAX_NUM_FORMS': '',
+            'form-0-id': str(author.pk),
+            'form-0-name': 'Existing Author',
+            'form-1-id': '',
+            'form-1-name': 'Unauthorized Author',
+        }
+        formset = AuthorFormSet(data=data, queryset=Author.objects.order_by('pk'))
+        self.assertIs(formset.is_valid(), False)
+        errors = formset.non_form_errors().as_data()
+        self.assertEqual(errors[0].code, 'add_not_allowed')
+        self.assertEqual(Author.objects.count(), 1)
+
+    def test_inline_formset_disallow_create_blocks_add(self):
+        author = Author.objects.create(name='Existing Author')
+        book = Book.objects.create(author=author, title='Existing Book')
+        AuthorBooksFormSet = inlineformset_factory(
+            Author,
+            Book,
+            fields="__all__",
+            extra=0,
+            allow_create=False,
+        )
+        data = {
+            'book_set-TOTAL_FORMS': '2',
+            'book_set-INITIAL_FORMS': '1',
+            'book_set-MAX_NUM_FORMS': '',
+            'book_set-0-id': str(book.pk),
+            'book_set-0-title': 'Existing Book',
+            'book_set-1-id': '',
+            'book_set-1-title': 'Unauthorized Book',
+        }
+        formset = AuthorBooksFormSet(data=data, instance=author, prefix='book_set')
+        self.assertIs(formset.is_valid(), False)
+        errors = formset.non_form_errors().as_data()
+        self.assertEqual(errors[0].code, 'add_not_allowed')
+        self.assertEqual(author.book_set.count(), 1)


### PR DESCRIPTION
## Summary
- implement `allow_create`/`edit_only` on `BaseModelFormSet`, `modelformset_factory`, and `inlineformset_factory`
- derive bound initial counts from the queryset, raise `add_not_allowed` on changed extra forms or tampered primary keys, and block `save_new`/`save_new_objects` when creation is disabled
- add regression coverage for POST tampering (extra forms, management form spoofing, bogus PKs, max_num interactions) and confirm inline support
- update `docs/topics/forms/modelforms.txt` to describe edit-only usage and why `extra=0` is insufficient

## Reproduction
1. Run
   ```bash
   PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages \
   DJANGO_SETTINGS_MODULE=tests.test_sqlite \
   python3 tests/runtests.py model_formsets.tests.EditOnlyModelFormSetTests --parallel=1
   ```
2. Before this fix the suite fails, e.g.
   ```text
   ..FEEFF
   ERROR: test_disallow_create_rejects_bogus_primary_key ...
   IndexError: list index out of range
   FAIL: test_disallow_create_rejects_added_form ...
   AssertionError: True is not False
   FAIL: test_disallow_create_respects_max_num_without_validate_max ...
   AssertionError: True is not False
   ```
3. After the changes the same command reports `Ran 7 tests in ... OK`.

## Testing
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py model_formsets.tests.EditOnlyModelFormSetTests --parallel=1`
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py model_formsets --parallel=1`
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages flake8 django/forms/models.py tests/model_formsets/tests.py`