### PR TITLE
swev-id: django__django-14672 fix m2m rel through_fields hashing

### DIFF
--- a/django/db/models/fields/reverse_related.py
+++ b/django/db/models/fields/reverse_related.py
@@ -310,7 +310,7 @@ class ManyToManyRel(ForeignObjectRel):
     def identity(self):
         return super().identity + (
             self.through,
-            self.through_fields,
+            make_hashable(self.through_fields),
             self.db_constraint,
         )
 

--- a/tests/model_fields/test_reverse_related_identity.py
+++ b/tests/model_fields/test_reverse_related_identity.py
@@ -1,0 +1,28 @@
+from django.db import models
+from django.test import SimpleTestCase
+from django.test.utils import isolate_apps
+
+
+class ManyToManyRelIdentityTests(SimpleTestCase):
+    @isolate_apps('model_fields')
+    def test_through_fields_list_is_hashable(self):
+        class Parent(models.Model):
+            pass
+
+        class ParentProxy(Parent):
+            class Meta:
+                proxy = True
+
+        class Container(models.Model):
+            m2m = models.ManyToManyField(
+                ParentProxy,
+                through='Through',
+                through_fields=['container', 'parent'],
+            )
+
+        class Through(models.Model):
+            container = models.ForeignKey(Container, on_delete=models.CASCADE)
+            parent = models.ForeignKey(Parent, on_delete=models.CASCADE)
+
+        rel = Container._meta.get_field('m2m').remote_field
+        self.assertIsInstance(hash(rel), int)


### PR DESCRIPTION
## Summary
- call make_hashable() when composing ManyToManyRel.identity
- add regression test covering proxy through_fields lists

## Testing
- PYTHONPATH=/workspace/django ../.venv/bin/python ./runtests.py model_fields.test_reverse_related_identity
- .venv/bin/flake8 django/db/models/fields/reverse_related.py tests/model_fields/test_reverse_related_identity.py

Fixes #439.