### PR TITLE
swev-id: django__django-14765 - Assert real_apps is a set in ProjectState.__init__ when provided

### DIFF
--- a/django/db/migrations/state.py
+++ b/django/db/migrations/state.py
@@ -91,10 +91,11 @@ class ProjectState:
     def __init__(self, models=None, real_apps=None):
         self.models = models or {}
         # Apps to include from main registry, usually unmigrated ones
-        if real_apps:
-            self.real_apps = real_apps if isinstance(real_apps, set) else set(real_apps)
-        else:
+        if real_apps is None:
             self.real_apps = set()
+        else:
+            assert isinstance(real_apps, set), "ProjectState.real_apps must be a set."
+            self.real_apps = real_apps
         self.is_delayed = False
         # {remote_model_key: {model_key: [(field_name, field)]}}
         self.relations = None


### PR DESCRIPTION
This PR simplifies `ProjectState.__init__()` handling of `real_apps`.

- When `real_apps` is `None`, default to an empty set.
- Otherwise, assert that `real_apps` is a set and assign directly.

Rationale: Following upstream changes (see linked Issue), all callers now pass `real_apps` as a set (or `None`), so internal normalization is unnecessary and can be enforced with an assertion.

Refs: #444

Local verification
- Targeted migrations tests ran successfully against this branch using Python 3.12:

  ```
  python3 -m venv venv
  . venv/bin/activate
  python -m pip install -U pip setuptools
  python -m pip install -e .
  python -Wd tests/runtests.py migrations.test_state migrations.test_executor migrations.test_operations migrations.test_autodetector
  ```

- Results: 336 tests, OK (skipped=1). No failures observed.

Notes
- This is internal API territory; callers providing non-set iterables would now hit an assertion.