### PR TITLE
[Admin] Add serialize_result extension point to AutocompleteJsonView (swev-id: django__django-14752)

### DIFF
--- a/django/contrib/admin/views/autocomplete.py
+++ b/django/contrib/admin/views/autocomplete.py
@@ -9,6 +9,17 @@ class AutocompleteJsonView(BaseListView):
     paginate_by = 20
     admin_site = None
 
+    def serialize_result(self, obj, to_field_name):
+        """Build the JSON result for ``obj``.
+
+        Subclasses may override this hook to add extra metadata, but the
+        returned mapping must always include ``id`` and ``text`` keys.
+        """
+        return {
+            'id': str(getattr(obj, to_field_name)),
+            'text': str(obj),
+        }
+
     def get(self, request, *args, **kwargs):
         """
         Return a JsonResponse with search results of the form:
@@ -26,7 +37,7 @@ class AutocompleteJsonView(BaseListView):
         context = self.get_context_data()
         return JsonResponse({
             'results': [
-                {'id': str(getattr(obj, to_field_name)), 'text': str(obj)}
+                self.serialize_result(obj, to_field_name)
                 for obj in context['object_list']
             ],
             'pagination': {'more': context['page_obj'].has_next()},

--- a/tests/admin_views/test_autocomplete_view.py
+++ b/tests/admin_views/test_autocomplete_view.py
@@ -48,6 +48,13 @@ site.register(PKChild, search_fields=['name'])
 site.register(Toy, autocomplete_fields=['child'])
 
 
+class CustomAutocompleteJsonView(AutocompleteJsonView):
+    def serialize_result(self, obj, to_field_name):
+        result = super().serialize_result(obj, to_field_name)
+        result['label'] = obj.question.upper()
+        return result
+
+
 @contextmanager
 def model_admin(model, model_admin, admin_site=site):
     org_admin = admin_site._registry.get(model)
@@ -153,6 +160,22 @@ class AutocompleteJsonViewTests(AdminViewBasicTestCase):
                     'results': [{'id': str(o.pk), 'text': o.name}],
                     'pagination': {'more': False},
                 })
+
+    def test_serialize_result_override(self):
+        custom_site = admin.AdminSite(name='custom_autocomplete_admin')
+        custom_site.register(Question, QuestionAdmin)
+        question = Question.objects.create(question='Is this a question?')
+        request = self.factory.get('/custom-admin/autocomplete/', {'term': 'is', **self.opts})
+        request.user = self.superuser
+        response = CustomAutocompleteJsonView.as_view(admin_site=custom_site)(request)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(data['results'], [{
+            'id': str(question.pk),
+            'text': question.question,
+            'label': question.question.upper(),
+        }])
+        self.assertEqual(data['pagination'], {'more': False})
 
     def test_to_field_resolution_with_fk_pk(self):
         p = Parent.objects.create(name="Bertie")


### PR DESCRIPTION
Closes #443. Adds serialize_result(...) and updates get() to delegate result building. Maintains backward compatibility.