### PR TITLE
feat: propagate CPython -X options (swev-id: django__django-14771)

### DIFF
--- a/django/utils/autoreload.py
+++ b/django/utils/autoreload.py
@@ -220,6 +220,16 @@ def get_child_arguments():
     py_script = Path(sys.argv[0])
 
     args = [sys.executable] + ['-W%s' % o for o in sys.warnoptions]
+    if (
+        sys.implementation.name == 'cpython' and
+        hasattr(sys, '_xoptions') and
+        sys._xoptions
+    ):
+        for key, value in sys._xoptions.items():
+            if value is True or value is None:
+                args += ['-X', key]
+            else:
+                args += ['-X', f'{key}={value}']
     # __spec__ is set when the server was started with the `-m` option,
     # see https://docs.python.org/3/reference/import.html#main-spec
     # __spec__ may not exist, e.g. when running in a Conda env.

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -9,6 +9,7 @@ import time
 import types
 import weakref
 import zipfile
+from collections import OrderedDict
 from importlib import import_module
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -204,6 +205,82 @@ class TestChildArguments(SimpleTestCase):
         )
 
     @mock.patch('__main__.__spec__', None)
+    @mock.patch('sys.argv', [__file__, 'runserver'])
+    @mock.patch('sys.warnoptions', [])
+    def test_cpython_xoptions_flags(self):
+        options = OrderedDict([
+            ('utf8', True),
+            ('dev', True),
+            ('faulthandler', True),
+            ('warn_default_encoding', True),
+        ])
+        with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
+            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [
+                        sys.executable,
+                        '-X', 'utf8',
+                        '-X', 'dev',
+                        '-X', 'faulthandler',
+                        '-X', 'warn_default_encoding',
+                        __file__,
+                        'runserver',
+                    ],
+                )
+
+    @mock.patch('__main__.__spec__', None)
+    @mock.patch('sys.argv', [__file__, 'runserver'])
+    @mock.patch('sys.warnoptions', [])
+    def test_cpython_xoptions_key_value(self):
+        options = OrderedDict([
+            ('pycache_prefix', '/tmp/py cache'),
+            ('tracemalloc', 5),
+        ])
+        with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
+            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [
+                        sys.executable,
+                        '-X', 'pycache_prefix=/tmp/py cache',
+                        '-X', 'tracemalloc=5',
+                        __file__,
+                        'runserver',
+                    ],
+                )
+
+    @mock.patch('__main__.__spec__', None)
+    @mock.patch('sys.argv', [__file__, 'runserver'])
+    @mock.patch('sys.warnoptions', [])
+    def test_non_cpython_ignores_xoptions(self):
+        options = OrderedDict([('dev', True)])
+        with mock.patch.object(autoreload.sys.implementation, 'name', 'pypy'):
+            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [sys.executable, __file__, 'runserver']
+                )
+
+    @mock.patch('__main__.__spec__', None)
+    @mock.patch('sys.argv', [__file__, 'runserver'])
+    @mock.patch('sys.warnoptions', ['error'])
+    def test_warnoptions_before_xoptions(self):
+        options = OrderedDict([('dev', True)])
+        with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
+            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+                self.assertEqual(
+                    autoreload.get_child_arguments(),
+                    [
+                        sys.executable,
+                        '-Werror',
+                        '-X', 'dev',
+                        __file__,
+                        'runserver',
+                    ],
+                )
+
+    @mock.patch('__main__.__spec__', None)
     @mock.patch('sys.warnoptions', [])
     def test_exe_fallback(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -214,6 +291,21 @@ class TestChildArguments(SimpleTestCase):
                     autoreload.get_child_arguments(),
                     [exe_path, 'runserver']
                 )
+
+    @mock.patch('__main__.__spec__', None)
+    @mock.patch('sys.warnoptions', [])
+    def test_exe_fallback_ignores_xoptions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exe_path = Path(tmpdir) / 'django-admin.exe'
+            exe_path.touch()
+            options = OrderedDict([('dev', True)])
+            with mock.patch('sys.argv', [exe_path.with_suffix(''), 'runserver']):
+                with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
+                    with mock.patch('django.utils.autoreload.sys._xoptions', options):
+                        self.assertEqual(
+                            autoreload.get_child_arguments(),
+                            [exe_path, 'runserver']
+                        )
 
     @mock.patch('__main__.__spec__', None)
     @mock.patch('sys.warnoptions', [])

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -215,7 +215,7 @@ class TestChildArguments(SimpleTestCase):
             ('warn_default_encoding', True),
         ])
         with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
-            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+            with mock.patch.dict(autoreload.sys._xoptions, options, clear=True):
                 self.assertEqual(
                     autoreload.get_child_arguments(),
                     [
@@ -238,7 +238,7 @@ class TestChildArguments(SimpleTestCase):
             ('tracemalloc', 5),
         ])
         with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
-            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+            with mock.patch.dict(autoreload.sys._xoptions, options, clear=True):
                 self.assertEqual(
                     autoreload.get_child_arguments(),
                     [
@@ -256,7 +256,7 @@ class TestChildArguments(SimpleTestCase):
     def test_non_cpython_ignores_xoptions(self):
         options = OrderedDict([('dev', True)])
         with mock.patch.object(autoreload.sys.implementation, 'name', 'pypy'):
-            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+            with mock.patch.dict(autoreload.sys._xoptions, options, clear=True):
                 self.assertEqual(
                     autoreload.get_child_arguments(),
                     [sys.executable, __file__, 'runserver']
@@ -268,7 +268,7 @@ class TestChildArguments(SimpleTestCase):
     def test_warnoptions_before_xoptions(self):
         options = OrderedDict([('dev', True)])
         with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
-            with mock.patch('django.utils.autoreload.sys._xoptions', options):
+            with mock.patch.dict(autoreload.sys._xoptions, options, clear=True):
                 self.assertEqual(
                     autoreload.get_child_arguments(),
                     [
@@ -301,7 +301,7 @@ class TestChildArguments(SimpleTestCase):
             options = OrderedDict([('dev', True)])
             with mock.patch('sys.argv', [exe_path.with_suffix(''), 'runserver']):
                 with mock.patch.object(autoreload.sys.implementation, 'name', 'cpython'):
-                    with mock.patch('django.utils.autoreload.sys._xoptions', options):
+                    with mock.patch.dict(autoreload.sys._xoptions, options, clear=True):
                         self.assertEqual(
                             autoreload.get_child_arguments(),
                             [exe_path, 'runserver']


### PR DESCRIPTION
## Summary
- forward CPython `-X` options from the autoreload parent to the child process
- insert the propagated flags after existing warning mappings and before module/script arguments
- add targeted tests to cover CPython flag/key=value cases, non-CPython behavior, warnoption ordering, and the Windows `.exe` limitation

## Issue
Closes #447

## Observed failure and reproduction
```sh
$ winpty python -m django startproject my_project
$ cd my_project/
$ winpty python -m django startapp my_app
$ vi my_app/apps.py # demo for xoptions ...
$ cat -n my_app/apps.py
     1 from django.apps import AppConfig
     2
     3 class MyAppConfig(AppConfig):
     4     default_auto_field = 'django.db.models.BigAutoField'
     5     name = 'my_app'
     6
     7 # myapp global initial_demo ...
     8 with open("manage.py", mode="r") as stream:
     9     print("=== %s" % stream.encoding)
$ vi my_project/settings.py # INSTALLED_APPS
$ winpty python -X utf8 manage.py runserver 0.0.0.0:8005 -v3
=== UTF-8
=== cp936
Watching for file changes with StatReloader
Performing system checks...
... ...
$ winpty python -X utf8 manage.py runserver 0.0.0.0:8005 -v3 --noreload
=== UTF-8
Performing system checks...
... ...
```

## Notes
- Propagation remains CPython-only and skips the Windows `.exe` launcher case where interpreter flags cannot be passed.

## Testing
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py utils_tests.test_autoreload --parallel=1
- flake8 django/utils/autoreload.py tests/utils_tests/test_autoreload.py