### PR TITLE
Fix RenameModel noop when db_table unchanged (swev-id: django__django-14999)

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -321,30 +321,40 @@ class RenameModel(ModelOperation):
         if self.allow_migrate_model(schema_editor.connection.alias, new_model):
             old_model = from_state.apps.get_model(app_label, self.old_name)
             # Move the main table
+            old_db_table = old_model._meta.db_table
+            new_db_table = new_model._meta.db_table
             schema_editor.alter_db_table(
                 new_model,
-                old_model._meta.db_table,
-                new_model._meta.db_table,
+                old_db_table,
+                new_db_table,
             )
+            ignores_table_name_case = bool(
+                schema_editor.connection.features.ignores_table_name_case
+            )
+            if ignores_table_name_case:
+                table_unchanged = old_db_table.casefold() == new_db_table.casefold()
+            else:
+                table_unchanged = old_db_table == new_db_table
             # Alter the fields pointing to us
-            for related_object in old_model._meta.related_objects:
-                if related_object.related_model == old_model:
-                    model = new_model
-                    related_key = (app_label, self.new_name_lower)
-                else:
-                    model = related_object.related_model
-                    related_key = (
-                        related_object.related_model._meta.app_label,
-                        related_object.related_model._meta.model_name,
+            if not table_unchanged:
+                for related_object in old_model._meta.related_objects:
+                    if related_object.related_model == old_model:
+                        model = new_model
+                        related_key = (app_label, self.new_name_lower)
+                    else:
+                        model = related_object.related_model
+                        related_key = (
+                            related_object.related_model._meta.app_label,
+                            related_object.related_model._meta.model_name,
+                        )
+                    to_field = to_state.apps.get_model(
+                        *related_key
+                    )._meta.get_field(related_object.field.name)
+                    schema_editor.alter_field(
+                        model,
+                        related_object.field,
+                        to_field,
                     )
-                to_field = to_state.apps.get_model(
-                    *related_key
-                )._meta.get_field(related_object.field.name)
-                schema_editor.alter_field(
-                    model,
-                    related_object.field,
-                    to_field,
-                )
             # Rename M2M fields whose name is based on this model's name.
             fields = zip(old_model._meta.local_many_to_many, new_model._meta.local_many_to_many)
             for (old_field, new_field) in fields:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1,7 +1,10 @@
+from unittest import mock
+
 from django.core.exceptions import FieldDoesNotExist
 from django.db import (
     IntegrityError, connection, migrations, models, transaction,
 )
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.migration import Migration
 from django.db.migrations.operations.fields import FieldOperation
 from django.db.migrations.state import ModelState, ProjectState
@@ -650,6 +653,46 @@ class OperationTests(OperationTestBase):
         self.assertEqual(definition[0], "RenameModel")
         self.assertEqual(definition[1], [])
         self.assertEqual(definition[2], {'old_name': "Pony", 'new_name': "Horse"})
+
+    def test_rename_model_noop_db_table_skips_alter_field(self):
+        app_label = "test_rename_model_noop_db_table"
+        project_state = self.apply_operations(app_label, ProjectState(), operations=[
+            migrations.CreateModel(
+                "Tracked", fields=[
+                    ("id", models.AutoField(primary_key=True)),
+                ], options={"db_table": "rename_model_noop_table"},
+            ),
+            migrations.CreateModel(
+                "Watcher", fields=[
+                    ("id", models.AutoField(primary_key=True)),
+                    ("tracked", models.ForeignKey(
+                        f"{app_label}.Tracked", models.CASCADE,
+                    )),
+                ],
+            ),
+        ])
+        rename_operation = migrations.RenameModel("Tracked", "TrackedRenamed")
+        new_state = project_state.clone()
+        rename_operation.state_forwards(app_label, new_state)
+
+        with mock.patch.object(
+            BaseDatabaseSchemaEditor,
+            "alter_field",
+            wraps=BaseDatabaseSchemaEditor.alter_field,
+            autospec=True,
+        ) as mocked_alter_field:
+            with connection.schema_editor(
+                atomic=connection.features.supports_atomic_references_rename,
+            ) as editor:
+                rename_operation.database_forwards(
+                    app_label,
+                    editor,
+                    project_state,
+                    new_state,
+                )
+
+        mocked_alter_field.assert_not_called()
+        self.assertTableExists("rename_model_noop_table")
 
     def test_rename_model_state_forwards(self):
         """


### PR DESCRIPTION
## Summary
- skip altering incoming relations in `RenameModel.database_forwards()` when the resolved table name is unchanged (with case-folding on case-insensitive backends)
- keep the table rename call and existing M2M rename handling intact
- add a regression test that spies on `BaseDatabaseSchemaEditor.alter_field()` to guard against unintended FK churn when `db_table` doesn't change

## Issue
- Fixes #449

## Reproduction
1. Checkout `django__django-14999`.
2. Apply the regression test from this PR (or cherry-pick 124a0b072c without the fix).
3. Run `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv/bin/python tests/runtests.py migrations.test_operations.OperationTests.test_rename_model_noop_db_table_skips_alter_field --parallel=1`.

## Observed failure (before fix)
- `RenameModel` still calls `alter_field()` on incoming relations, forcing a table rebuild on SQLite.

```
FAIL: test_rename_model_noop_db_table_skips_alter_field (migrations.test_operations.OperationTests.test_rename_model_noop_db_table_skips_alter_field)
Traceback (most recent call last):
  File "/workspace/django/tests/migrations/test_operations.py", line 694, in test_rename_model_noop_db_table_skips_alter_field
    mocked_alter_field.assert_not_called()
AssertionError: Expected 'alter_field' to not have been called. Called 1 times.
Calls: [call(<django.db.backends.sqlite3.schema.DatabaseSchemaEditor object at 0xffffbb00fcd0>, <class '__fake__.Watcher'>, <django.db.models.fields.related.ForeignKey: tracked>, <django.db.models.fields.related.ForeignKey: tracked>, strict=False)].
```

## Collected SQL before fix (SQLite)
- Captured with `collect_sql=True`; the watcher table is rebuilt even though the target table name is unchanged.

```
CREATE TABLE "new__tmp_sql_capture_watcher" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "tracked_id" integer NOT NULL REFERENCES "rename_model_noop_table_sql" ("id") DEFERRABLE INITIALLY DEFERRED);
INSERT INTO "new__tmp_sql_capture_watcher" ("id", "tracked_id") SELECT "id", "tracked_id" FROM "tmp_sql_capture_watcher";
DROP TABLE "tmp_sql_capture_watcher";
ALTER TABLE "new__tmp_sql_capture_watcher" RENAME TO "tmp_sql_capture_watcher";
CREATE INDEX "tmp_sql_capture_watcher_tracked_id_d8956d1f" ON "tmp_sql_capture_watcher" ("tracked_id");
```

## After fix
- The regression test passes and no dependent tables are touched when the table name is stable.
- Additional validation:
  - `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv/bin/python tests/runtests.py migrations.test_operations.OperationTests.test_rename_model_noop_db_table_skips_alter_field --parallel=1`
  - `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv/bin/python tests/runtests.py migrations.test_operations --parallel=1`
  - `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite /workspace/.venv/bin/flake8 django/db/migrations/operations/models.py tests/migrations/test_operations.py`