### PR TITLE
swev-id: django__django-14787 support wraps in method_decorator

### DIFF
--- a/django/utils/decorators.py
+++ b/django/utils/decorators.py
@@ -1,6 +1,6 @@
 "Functions that help with dynamically creating decorators for views."
 
-from functools import partial, update_wrapper, wraps
+from functools import update_wrapper, wraps
 
 
 class classonlymethod(classmethod):
@@ -37,7 +37,10 @@ def _multi_decorate(decorators, method):
         # 'self' argument, but it's a closure over self so it can call
         # 'func'. Also, wrap method.__get__() in a function because new
         # attributes can't be set on bound method objects, only on functions.
-        bound_method = partial(method.__get__(self, type(self)))
+        def bound_method(*inner_args, **inner_kwargs):
+            return method.__get__(self, type(self))(*inner_args, **inner_kwargs)
+
+        bound_method = update_wrapper(bound_method, method)
         for dec in decorators:
             bound_method = dec(bound_method)
         return bound_method(*args, **kwargs)

--- a/tests/decorators/tests.py
+++ b/tests/decorators/tests.py
@@ -184,6 +184,55 @@ def myattr2_dec(func):
 myattr2_dec_m = method_decorator(myattr2_dec)
 
 
+wraps_recorded_names = []
+wraps_attribute_assignments = []
+
+
+def name_recording_dec(func):
+    recorded_name = func.__name__
+    wraps_recorded_names.append(recorded_name)
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    wrapper.recorded_name = recorded_name
+    return wrapper
+
+
+name_recording_dec_m = method_decorator(name_recording_dec)
+
+
+def suffixing_name_dec(func):
+    suffix_source = func.__name__
+    wraps_recorded_names.append(suffix_source)
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return f"{func(*args, **kwargs)}:{suffix_source}"
+
+    wrapper.suffix_source = suffix_source
+    return wrapper
+
+
+suffixing_name_dec_m = method_decorator(suffixing_name_dec)
+
+
+def attr_setting_wraps_dec(func):
+    func.wraps_attribute = func.__name__
+    wraps_attribute_assignments.append(func.wraps_attribute)
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    wrapper.wraps_attribute = func.wraps_attribute
+    return wrapper
+
+
+attr_setting_wraps_dec_m = method_decorator(attr_setting_wraps_dec)
+
+
 class ClsDec:
     def __init__(self, myattr):
         self.myattr = myattr
@@ -270,6 +319,43 @@ class MethodDecoratorTests(SimpleTestCase):
                 self.assertIs(getattr(Test.method, 'myattr2', False), True)
                 self.assertEqual(Test.method.__doc__, 'A method')
                 self.assertEqual(Test.method.__name__, 'method')
+
+    def test_wraps_decorator_referencing_name(self):
+        wraps_recorded_names.clear()
+
+        class Greeter:
+            @name_recording_dec_m
+            def greet(self):
+                return "hello"
+
+        greeter = Greeter()
+        self.assertEqual(greeter.greet(), "hello")
+        self.assertGreaterEqual(wraps_recorded_names.count("greet"), 1)
+
+    def test_multiple_wraps_decorators(self):
+        wraps_recorded_names.clear()
+
+        class Greeter:
+            @name_recording_dec_m
+            @suffixing_name_dec_m
+            def greet(self):
+                return "hello"
+
+        greeter = Greeter()
+        self.assertEqual(greeter.greet(), "hello:greet")
+        self.assertGreaterEqual(wraps_recorded_names.count("greet"), 2)
+
+    def test_wraps_decorator_setting_attribute_on_input(self):
+        wraps_attribute_assignments.clear()
+
+        class Marker:
+            @attr_setting_wraps_dec_m
+            def tag(self):
+                return "tagged"
+
+        marker = Marker()
+        self.assertEqual(marker.tag(), "tagged")
+        self.assertIn("tag", wraps_attribute_assignments)
 
     def test_new_attribute(self):
         """A decorator that sets a new attribute on the method."""


### PR DESCRIPTION
## Summary
- replace the partial used in `_multi_decorate()` with a closure that rebinds the method and copies metadata via `update_wrapper()`
- ensure decorators relying on `@wraps()` and mutating the passed function see a real function object
- add regression coverage for single and stacked `@wraps`-based decorators and for decorators setting attributes on the input function

Fixes #448.

## Testing
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py decorators --parallel=1`

## Reproduction
1. Define a decorator that uses `@wraps(func)` and touches `func.__name__`.
2. Decorate a class method with `@method_decorator(the_decorator)`.
3. Call the method on an instance.

Observed failure: `AttributeError: 'functools.partial' object has no attribute '__name__'` raised from `functools.update_wrapper()` while applying the decorator.
Stack trace summary: `_multi_decorate()` passes a `functools.partial` into the decorator, which bubbles into `functools.update_wrapper()` and raises the AttributeError when it tries to read `func.__name__`.