### PR TITLE
swev-id: django__django-15022 - Avoid duplicate JOINs in admin changelist multi-word search

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -1031,17 +1031,37 @@ class ModelAdmin(BaseModelAdmin):
         if search_fields and search_term:
             orm_lookups = [construct_search(str(search_field))
                            for search_field in search_fields]
+            lookup_infos = [
+                (orm_lookup, lookup_spawns_duplicates(self.opts, orm_lookup))
+                for orm_lookup in orm_lookups
+            ]
+
+            # Build a single combined Q: AND across terms, OR across fields per term.
+            base_queryset = queryset
+            term_qs = []
             for bit in smart_split(search_term):
                 if bit.startswith(('"', "'")) and bit[0] == bit[-1]:
                     bit = unescape_string_literal(bit)
-                or_queries = models.Q(
-                    *((orm_lookup, bit) for orm_lookup in orm_lookups),
-                    _connector=models.Q.OR,
-                )
-                queryset = queryset.filter(or_queries)
+                or_q = models.Q()
+                for orm_lookup, spawns_duplicates in lookup_infos:
+                    if spawns_duplicates:
+                        related_qs = base_queryset.filter(
+                            **{orm_lookup: bit}
+                        ).values('pk').order_by()
+                        or_q |= models.Q(pk__in=models.Subquery(related_qs))
+                    else:
+                        or_q |= models.Q(**{orm_lookup: bit})
+                term_qs.append(or_q)
+
+            if term_qs:
+                combined_q = term_qs[0]
+                for q in term_qs[1:]:
+                    combined_q &= q
+                queryset = queryset.filter(combined_q)
+
             may_have_duplicates |= any(
-                lookup_spawns_duplicates(self.opts, search_spec)
-                for search_spec in orm_lookups
+                spawns_duplicates
+                for _, spawns_duplicates in lookup_infos
             )
         return queryset, may_have_duplicates
 

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -489,6 +489,22 @@ class ChangeListTests(TestCase):
         cl.queryset.delete()
         self.assertEqual(cl.queryset.count(), 0)
 
+    def test_multi_word_search_avoids_duplicate_fk_joins(self):
+        class ChildSearchAdmin(admin.ModelAdmin):
+            search_fields = ['parent__name']
+
+        parent = Parent.objects.create(name='Alpha Parent')
+        Child.objects.create(parent=parent, name='child')
+
+        m = ChildSearchAdmin(Child, custom_site)
+        request = self.factory.get('/child/', data={SEARCH_VAR: 'alpha beta gamma'})
+        request.user = self.superuser
+        cl = m.get_changelist_instance(request)
+        sql = str(cl.queryset.query).lower()
+
+        parent_table = Parent._meta.db_table.lower()
+        self.assertEqual(sql.count(f'join "{parent_table}"'), 1)
+
     def test_no_duplicates_for_many_to_many_at_second_level_in_search_fields(self):
         """
         When using a ManyToMany in search_fields at the second level behind a

--- a/tests/admin_changelist/tests.py
+++ b/tests/admin_changelist/tests.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
@@ -500,10 +501,11 @@ class ChangeListTests(TestCase):
         request = self.factory.get('/child/', data={SEARCH_VAR: 'alpha beta gamma'})
         request.user = self.superuser
         cl = m.get_changelist_instance(request)
-        sql = str(cl.queryset.query).lower()
+        sql = str(cl.queryset.query)
 
-        parent_table = Parent._meta.db_table.lower()
-        self.assertEqual(sql.count(f'join "{parent_table}"'), 1)
+        parent_table = Parent._meta.db_table
+        pattern = re.compile(rf"\bjoin\s+[`\"]?{re.escape(parent_table)}[`\"]?", re.IGNORECASE)
+        self.assertEqual(len(pattern.findall(sql)), 1)
 
     def test_no_duplicates_for_many_to_many_at_second_level_in_search_fields(self):
         """


### PR DESCRIPTION
Fix: Build a single AND-of-ORs Q across all terms and call filter() once, preventing duplicate JOINs when related fields appear in search_fields.

Semantics unchanged (AND across terms, OR across fields). construct_search() and may_have_duplicates logic preserved.

Observed failure (pre-fix): multi-word search (≥3 terms) with related lookup `parent__name` produced N JOINs to the parent table (one per term), causing slow queries.

Reproduction:
1. Define ModelAdmin search_fields=['parent__name']
2. Search: `alpha beta gamma`
3. Inspect SQL: multiple JOINs to the parent table

Post-fix behavior: single JOIN per related path for the same search, while tests like ChangeListTests.test_multiple_search_fields pass unchanged.

Refs: Issue #452