### PR TITLE
swev-id: django__django-15103 make json_script id optional

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -83,7 +83,7 @@ def escapejs_filter(value):
 
 
 @register.filter(is_safe=True)
-def json_script(value, element_id):
+def json_script(value, element_id=None):
     """
     Output value JSON-encoded, wrapped in a <script type="application/json">
     tag.

--- a/django/utils/html.py
+++ b/django/utils/html.py
@@ -61,7 +61,7 @@ _json_script_escapes = {
 }
 
 
-def json_script(value, element_id):
+def json_script(value, element_id=None):
     """
     Escape all the HTML/XML special characters with their unicode escapes, so
     value is safe to be output anywhere except for inside a tag attribute. Wrap
@@ -69,9 +69,14 @@ def json_script(value, element_id):
     """
     from django.core.serializers.json import DjangoJSONEncoder
     json_str = json.dumps(value, cls=DjangoJSONEncoder).translate(_json_script_escapes)
+    if element_id is not None:
+        return format_html(
+            '<script id="{}" type="application/json">{}</script>',
+            element_id, mark_safe(json_str)
+        )
     return format_html(
-        '<script id="{}" type="application/json">{}</script>',
-        element_id, mark_safe(json_str)
+        '<script type="application/json">{}</script>',
+        mark_safe(json_str)
     )
 
 

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -1832,13 +1832,23 @@ If ``value`` is the list ``['a', 'b', 'c']``, the output will be the string
 Safely outputs a Python object as JSON, wrapped in a ``<script>`` tag, ready
 for use with JavaScript.
 
-**Argument:** HTML "id" of the ``<script>`` tag.
+**Argument:** Optional HTML "id" of the ``<script>`` tag.
 
-For example::
+For example, without an ``id`` attribute::
+
+    {{ value|json_script }}
+
+If ``value`` is the dictionary ``{'hello': 'world'}``, the output will be:
+
+.. code-block:: html
+
+    <script type="application/json">{"hello": "world"}</script>
+
+Providing an ``id`` allows referencing the element later::
 
     {{ value|json_script:"hello-data" }}
 
-If ``value`` is the dictionary ``{'hello': 'world'}``, the output will be:
+Which renders as:
 
 .. code-block:: html
 

--- a/docs/releases/4.1.txt
+++ b/docs/releases/4.1.txt
@@ -210,7 +210,9 @@ Signals
 Templates
 ~~~~~~~~~
 
-* ...
+* The :tfilter:`json_script` template filter now accepts an optional
+  element ``id``. When omitted or ``None``, the rendered ``<script>`` tag has
+  no ``id`` attribute.
 
 Tests
 ~~~~~

--- a/tests/template_tests/filter_tests/test_json_script.py
+++ b/tests/template_tests/filter_tests/test_json_script.py
@@ -17,3 +17,31 @@ class JsonScriptTests(SimpleTestCase):
             '{"a": "testing\\r\\njson \'string\\" \\u003Cb\\u003Eescaping\\u003C/b\\u003E"}'
             '</script>'
         )
+
+    @setup({'json-tag02': '{{ value|json_script }}'})
+    def test_without_id(self):
+        output = self.engine.render_to_string(
+            'json-tag02',
+            {'value': '&<>'}
+        )
+        self.assertEqual(
+            output,
+            (
+                '<script type="application/json">'
+                '"\\u0026\\u003C\\u003E"</script>'
+            )
+        )
+
+    @setup({'json-tag03': '{{ value|json_script:element_id }}'})
+    def test_none_id(self):
+        output = self.engine.render_to_string(
+            'json-tag03',
+            {'value': '&<>', 'element_id': None}
+        )
+        self.assertEqual(
+            output,
+            (
+                '<script type="application/json">'
+                '"\\u0026\\u003C\\u003E"</script>'
+            )
+        )

--- a/tests/utils_tests/test_html.py
+++ b/tests/utils_tests/test_html.py
@@ -173,6 +173,15 @@ class TestUtilsHtml(SimpleTestCase):
             with self.subTest(arg=arg):
                 self.assertEqual(json_script(arg, 'test_id'), expected)
 
+        no_id_expected = (
+            '<script type="application/json">'
+            '"\\u0026\\u003C\\u003E"</script>'
+        )
+        with self.subTest(element_id='default'):
+            self.assertEqual(json_script('&<>'), no_id_expected)
+        with self.subTest(element_id=None):
+            self.assertEqual(json_script('&<>', None), no_id_expected)
+
     def test_smart_urlquote(self):
         items = (
             ('http://öäü.com/', 'http://xn--4ca9at.com/'),


### PR DESCRIPTION
## Summary
- allow omitting the `element_id` argument for `django.utils.html.json_script`
- update the `json_script` template filter, tests, docs, and release notes to reflect the optional id

Fixes #457.

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py utils_tests.test_html.TestUtilsHtml.test_json_script --parallel=1
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py template_tests.filter_tests.test_json_script.JsonScriptTests --parallel=1
- PYTHONPATH=$PWD .venv/bin/flake8 django/utils/html.py django/template/defaultfilters.py tests/utils_tests/test_html.py tests/template_tests/filter_tests/test_json_script.py