### PR TITLE
swev-id: django__django-15104 guard fk autodetector pop

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -96,7 +96,7 @@ class MigrationAutodetector:
         for name, field in sorted(fields.items()):
             deconstruction = self.deep_deconstruct(field)
             if field.remote_field and field.remote_field.model:
-                del deconstruction[2]['to']
+                deconstruction[2].pop('to', None)
             fields_def.append(deconstruction)
         return fields_def
 

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -2106,6 +2106,36 @@ class AutodetectorTests(TestCase):
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["CreateModel"])
 
+    def test_custom_fk_deconstruct_removes_to_no_keyerror(self):
+        class CustomFKField(models.ForeignKey):
+            def __init__(self, *args, **kwargs):
+                kwargs['to'] = 'testapp.Publisher'
+                kwargs.setdefault('on_delete', models.CASCADE)
+                super().__init__(*args, **kwargs)
+
+            def deconstruct(self):
+                name, path, args, kwargs = super().deconstruct()
+                kwargs.pop('to', None)
+                return name, path, args, kwargs
+
+        test_model = ModelState(
+            'testapp',
+            'TestModel',
+            [
+                ('id', models.AutoField(primary_key=True)),
+                ('custom_fk', CustomFKField()),
+            ],
+        )
+        before = self.make_project_state([self.publisher])
+        after = self.make_project_state([self.publisher, test_model])
+
+        changes = MigrationAutodetector(before, after)._detect_changes()
+
+        self.assertIn('testapp', changes)
+        self.assertEqual(len(changes['testapp']), 1)
+        self.assertOperationTypes(changes, 'testapp', 0, ['CreateModel'])
+        self.assertOperationAttributes(changes, 'testapp', 0, 0, name='TestModel')
+
     def test_replace_string_with_foreignkey(self):
         """
         #22300 - Adding an FK in the same "spot" as a deleted CharField should


### PR DESCRIPTION
## Summary
- replace the unsafe deletion of the 'to' key with a safe pop in `MigrationAutodetector.only_relation_agnostic_fields()`
- add a regression test covering a custom `ForeignKey` that drops `to` during deconstruction

## Testing
- python -m flake8 django/db/migrations/autodetector.py tests/migrations/test_autodetector.py (pass)
- PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py migrations.test_autodetector --parallel=1 (migrations.test_autodetector, 139 passed)

Fixes #459