### PR TITLE
swev-id: django__django-15098 support BCP 47 script-region tags

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -322,8 +322,11 @@ class LocalePrefixPattern:
 
     def match(self, path):
         language_prefix = self.language_prefix
-        if path.startswith(language_prefix):
-            return path[len(language_prefix):], (), {}
+        if not language_prefix:
+            return path, (), {}
+        prefix_len = len(language_prefix)
+        if path[:prefix_len].lower() == language_prefix.lower():
+            return path[prefix_len:], (), {}
         return None
 
     def check(self):

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -511,40 +511,78 @@ def get_language_from_path(path, strict=False):
     if not language_code_re.match(segment):
         return None
     subtags = segment.split('-')
-    if len(subtags) > 3:
-        return None
-    if len(subtags) == 3:
-        first, second = subtags[1], subtags[2]
-        script_region_pattern = (
-            len(first) == 4 and first.isalpha() and
-            ((len(second) == 2 and second.isalpha()) or (len(second) == 3 and second.isdigit()))
-        )
-        region_variant_pattern = (
-            ((len(first) == 2 and first.isalpha()) or (len(first) == 3 and first.isdigit())) and
-            (4 <= len(second) <= 8) and second.isalnum()
-        )
-        if not (script_region_pattern or region_variant_pattern):
-            return None
-    elif len(subtags) == 2:
-        subtag = subtags[1]
-        if not (
+
+    def is_script(subtag):
+        return len(subtag) == 4 and subtag.isalpha()
+
+    def is_region(subtag):
+        return (
             (len(subtag) == 2 and subtag.isalpha()) or
-            (len(subtag) == 3 and subtag.isdigit()) or
-            (len(subtag) == 4 and subtag.isalpha()) or
-            (4 <= len(subtag) <= 8 and subtag.isalnum())
-        ):
+            (len(subtag) == 3 and subtag.isdigit())
+        )
+
+    def normalize_bcp47(code):
+        parts = code.split('-')
+        if not parts:
+            return code
+        normalized = [parts[0].lower()]
+        for part in parts[1:]:
+            if len(part) == 4 and part.isalpha():
+                normalized.append(part.title())
+            elif len(part) == 2 and part.isalpha():
+                normalized.append(part.upper())
+            elif len(part) == 3 and part.isdigit():
+                normalized.append(part)
+            else:
+                normalized.append(part.lower())
+        return '-'.join(normalized)
+
+    supported_languages = get_languages()
+    compare_map = {}
+    for code in supported_languages:
+        key = normalize_bcp47(code).casefold()
+        compare_map.setdefault(key, []).append(code)
+
+    def find_configured_variant(original_segment):
+        key = normalize_bcp47(original_segment).casefold()
+        candidates = compare_map.get(key)
+        if not candidates:
             return None
+        for code in candidates:
+            if code == original_segment:
+                return code
+        for code in candidates:
+            if code.casefold() == original_segment.casefold():
+                return code
+        return candidates[0]
+
+    is_script_region = (
+        len(subtags) >= 3 and is_script(subtags[1]) and is_region(subtags[2])
+    )
+    if is_script_region:
+        return find_configured_variant(segment)
+
+    if len(subtags) == 2 and is_region(subtags[1]):
+        configured = find_configured_variant(segment)
+        if configured:
+            return configured
+        if strict:
+            return None
+        try:
+            return get_supported_language_variant(segment.lower(), strict=False)
+        except LookupError:
+            return None
+
+    configured = find_configured_variant(segment)
+    if configured:
+        return configured
     try:
         matched_code = get_supported_language_variant(segment.lower(), strict=strict)
     except LookupError:
         return None
     if len(subtags) > 2 and '-' not in matched_code:
         return None
-    supported_languages = get_languages()
-    if segment in supported_languages:
-        return segment
-    lower_map = {code.lower(): code for code in supported_languages}
-    return lower_map.get(matched_code.lower(), matched_code)
+    return matched_code
 
 
 def get_language_from_request(request, check_path=False):

--- a/django/utils/translation/trans_real.py
+++ b/django/utils/translation/trans_real.py
@@ -43,8 +43,6 @@ language_code_re = _lazy_re_compile(
     re.IGNORECASE
 )
 
-language_code_prefix_re = _lazy_re_compile(r'^/(\w+([@-]\w+)?)(/|$)')
-
 
 @receiver(setting_changed)
 def reset_cache(**kwargs):
@@ -505,14 +503,48 @@ def get_language_from_path(path, strict=False):
     If `strict` is False (the default), look for a country-specific variant
     when neither the language code nor its generic variant is found.
     """
-    regex_match = language_code_prefix_re.match(path)
-    if not regex_match:
+    if not path:
         return None
-    lang_code = regex_match[1]
+    segment = path.lstrip('/').split('/', 1)[0]
+    if not segment:
+        return None
+    if not language_code_re.match(segment):
+        return None
+    subtags = segment.split('-')
+    if len(subtags) > 3:
+        return None
+    if len(subtags) == 3:
+        first, second = subtags[1], subtags[2]
+        script_region_pattern = (
+            len(first) == 4 and first.isalpha() and
+            ((len(second) == 2 and second.isalpha()) or (len(second) == 3 and second.isdigit()))
+        )
+        region_variant_pattern = (
+            ((len(first) == 2 and first.isalpha()) or (len(first) == 3 and first.isdigit())) and
+            (4 <= len(second) <= 8) and second.isalnum()
+        )
+        if not (script_region_pattern or region_variant_pattern):
+            return None
+    elif len(subtags) == 2:
+        subtag = subtags[1]
+        if not (
+            (len(subtag) == 2 and subtag.isalpha()) or
+            (len(subtag) == 3 and subtag.isdigit()) or
+            (len(subtag) == 4 and subtag.isalpha()) or
+            (4 <= len(subtag) <= 8 and subtag.isalnum())
+        ):
+            return None
     try:
-        return get_supported_language_variant(lang_code, strict=strict)
+        matched_code = get_supported_language_variant(segment.lower(), strict=strict)
     except LookupError:
         return None
+    if len(subtags) > 2 and '-' not in matched_code:
+        return None
+    supported_languages = get_languages()
+    if segment in supported_languages:
+        return segment
+    lower_map = {code.lower(): code for code in supported_languages}
+    return lower_map.get(matched_code.lower(), matched_code)
 
 
 def get_language_from_request(request, check_path=False):

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -387,6 +387,16 @@ class ScriptRegionURLTests(URLTestCaseBase):
         response = self.client.get('/en-Latn-GB/prefixed/')
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(
+        LANGUAGES=[
+            ('en', 'English'),
+            ('en-us', 'English (US)'),
+        ]
+    )
+    def test_script_region_prefix_not_configured(self):
+        response = self.client.get('/en-Latn-US/prefixed/')
+        self.assertEqual(response.status_code, 404)
+
 
 class URLTagTests(URLTestCaseBase):
     """

--- a/tests/i18n/patterns/tests.py
+++ b/tests/i18n/patterns/tests.py
@@ -361,6 +361,33 @@ class URLRedirectWithScriptAliasTests(URLTestCaseBase):
             self.assertRedirects(response, '%s/en/prefixed/' % prefix, target_status_code=404)
 
 
+@override_settings(
+    LANGUAGES=[
+        ('nl', 'Dutch'),
+        ('en', 'English'),
+        ('en-latn-us', 'English (Latin US lower)'),
+        ('en-Latn-US', 'English (Latin US)'),
+        ('pt-br', 'Brazilian Portuguese'),
+    ]
+)
+class ScriptRegionURLTests(URLTestCaseBase):
+
+    def test_supported_script_region_prefix(self):
+        response = self.client.get('/en-latn-us/prefixed/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers['content-language'], 'en-latn-us')
+        self.assertEqual(response.context['LANGUAGE_CODE'], 'en-latn-us')
+
+        response = self.client.get('/en-Latn-US/prefixed/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers['content-language'], 'en-latn-us')
+        self.assertEqual(response.context['LANGUAGE_CODE'], 'en-latn-us')
+
+    def test_unlisted_script_region_prefix(self):
+        response = self.client.get('/en-Latn-GB/prefixed/')
+        self.assertEqual(response.status_code, 404)
+
+
 class URLTagTests(URLTestCaseBase):
     """
     Test if the language tag works.

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1607,13 +1607,27 @@ class MiscTests(SimpleTestCase):
         self.assertIsNone(g('/xyz/'))
         self.assertEqual(g('/en/'), 'en')
         self.assertEqual(g('/en-gb/'), 'en')
+        self.assertIsNone(g('/en-gb/', strict=True))
         self.assertEqual(g('/en-latn-us/'), 'en-latn-us')
+        self.assertEqual(g('/en-latn-us/', strict=True), 'en-latn-us')
         self.assertEqual(g('/en-Latn-US/'), 'en-Latn-US')
+        self.assertEqual(g('/en-Latn-US/', strict=True), 'en-Latn-US')
         self.assertEqual(g('/de/'), 'de')
         self.assertEqual(g('/de-at/'), 'de-at')
         self.assertEqual(g('/de-ch/'), 'de')
         self.assertIsNone(g('/de-simple-page/'))
         self.assertIsNone(g('/en-Latn-GB/'))
+
+    @override_settings(
+        LANGUAGES=[
+            ('en', 'English'),
+            ('en-us', 'English (US)'),
+        ],
+    )
+    def test_script_region_requires_configured_variant(self):
+        g = trans_real.get_language_from_path
+        self.assertIsNone(g('/en-Latn-US/'))
+        self.assertIsNone(g('/en-Latn-US/', strict=True))
 
     def test_get_language_from_path_null(self):
         g = trans_null.get_language_from_path

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1593,6 +1593,8 @@ class MiscTests(SimpleTestCase):
     @override_settings(
         LANGUAGES=[
             ('en', 'English'),
+            ('en-latn-us', 'English (Latin US lower)'),
+            ('en-Latn-US', 'English (Latin US)'),
             ('de', 'German'),
             ('de-at', 'Austrian German'),
             ('pl', 'Polish'),
@@ -1605,10 +1607,13 @@ class MiscTests(SimpleTestCase):
         self.assertIsNone(g('/xyz/'))
         self.assertEqual(g('/en/'), 'en')
         self.assertEqual(g('/en-gb/'), 'en')
+        self.assertEqual(g('/en-latn-us/'), 'en-latn-us')
+        self.assertEqual(g('/en-Latn-US/'), 'en-Latn-US')
         self.assertEqual(g('/de/'), 'de')
         self.assertEqual(g('/de-at/'), 'de-at')
         self.assertEqual(g('/de-ch/'), 'de')
         self.assertIsNone(g('/de-simple-page/'))
+        self.assertIsNone(g('/en-Latn-GB/'))
 
     def test_get_language_from_path_null(self):
         g = trans_null.get_language_from_path


### PR DESCRIPTION
## Summary
- parse the first URL segment with `language_code_re` and resolve through `get_supported_language_variant`
- normalize locale prefixes using case-insensitive matching so script+region tags work regardless of casing
- add coverage for mixed-case script-region tags and ensure unsupported variants still return 404

## Reproduction
1. Configure `LANGUAGES` to include `('en', 'English')`, `('en-latn-us', 'English (Latin US lower)')`, and `('en-Latn-US', 'English (Latin US)')` with LocaleMiddleware enabled (mirrors issue #455).
2. Request `/en-latn-us/prefixed/` and `/en-Latn-US/prefixed/` against `i18n.patterns.urls.default`.

### Observed failure (pre-fix)
- Both requests returned **404 Not Found**. No stack trace was emitted because the resolver never matched a view.

### Post-fix verification
- `/en-latn-us/prefixed/` → 200 with `Content-Language: en-latn-us`
- `/en-Latn-US/prefixed/` → 200 with `Content-Language: en-latn-us`

## Testing
- `PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.11 tests/runtests.py i18n --parallel=1`
- `flake8 django/utils/translation/trans_real.py django/urls/resolvers.py tests/i18n/tests.py tests/i18n/patterns/tests.py --extend-ignore=F824`

Installed via nix: `python311`, `python311Packages.asgiref`, `python311Packages.sqlparse`, `python311Packages.flake8`

Resolves #455.