### PR TITLE
swev-id: django__django-15127 Refresh message level tags on override

### DIFF
--- a/django/contrib/messages/storage/base.py
+++ b/django/contrib/messages/storage/base.py
@@ -1,7 +1,16 @@
 from django.conf import settings
 from django.contrib.messages import constants, utils
+from django.core.signals import setting_changed
+from django.dispatch import receiver
 
 LEVEL_TAGS = utils.get_level_tags()
+
+
+@receiver(setting_changed)
+def _message_tags_setting_changed(**kwargs):
+    if kwargs['setting'] == 'MESSAGE_TAGS':
+        global LEVEL_TAGS
+        LEVEL_TAGS = utils.get_level_tags()
 
 
 class Message:

--- a/tests/messages_tests/base.py
+++ b/tests/messages_tests/base.py
@@ -381,3 +381,23 @@ class BaseTests:
         add_level_messages(storage)
         tags = [msg.tags for msg in storage]
         self.assertEqual(tags, ['info', 'custom', 'extra-tag', '', 'bad', 'success'])
+
+    @override_settings(MESSAGE_TAGS={29: 'custom'})
+    def test_message_tags_update_on_override_settings(self):
+        storage = self.get_storage()
+        storage.level = 0
+        storage.add(29, 'Some custom level')
+        tags = [msg.level_tag for msg in storage]
+        self.assertEqual(tags, ['custom'])
+
+    @override_settings(MESSAGE_TAGS={
+        constants.INFO: 'information',
+        29: 'custom',
+    })
+    def test_message_tags_update_on_override_settings_multiple_values(self):
+        storage = self.get_storage()
+        storage.level = 0
+        storage.add(constants.INFO, 'Info message')
+        storage.add(29, 'Some custom level')
+        tags = [msg.level_tag for msg in storage]
+        self.assertEqual(tags, ['information', 'custom'])


### PR DESCRIPTION
## Summary
- refresh `LEVEL_TAGS` when `MESSAGE_TAGS` changes via a `setting_changed` receiver
- add regression coverage ensuring `override_settings` picks up new message tags without custom helpers

## Issue
- Closes #463

## Reproduction steps
1. Run:
   ```
   PYTHONPATH=$PWD:$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py messages_tests.test_cookie --parallel=1
   ```

## Observed failure (pre-fix)
```
FAIL: test_message_tags_update_on_override_settings (messages_tests.test_cookie.CookieTests.test_message_tags_update_on_override_settings)
Traceback (most recent call last):
  File "/workspace/django/django/test/utils.py", line 437, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/messages_tests/base.py", line 391, in test_message_tags_update_on_override_settings
    self.assertEqual(tags, ['custom'])
AssertionError: Lists differ: [''] != ['custom']

FAIL: test_message_tags_update_on_override_settings_multiple_values (messages_tests.test_cookie.CookieTests.test_message_tags_update_on_override_settings_multiple_values)
Traceback (most recent call last):
  File "/workspace/django/django/test/utils.py", line 437, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/messages_tests/base.py", line 403, in test_message_tags_update_on_override_settings_multiple_values
    self.assertEqual(tags, ['information', 'custom'])
AssertionError: Lists differ: ['info', ''] != ['information', 'custom']
```

The receiver refreshes `LEVEL_TAGS` so the above tests now pass.

## Testing
- `PYTHONPATH=$PWD:$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py messages_tests.test_cookie --parallel=1`
- `PYTHONPATH=$PWD:$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py messages_tests.test_session --parallel=1`
- `PYTHONPATH=$PWD:$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages python3 -m flake8 django/contrib/messages/storage/base.py tests/messages_tests/base.py`

CI not run (per instructions).