### PR TITLE
Fix OR alias collisions in Query.combine to avoid change_aliases AssertionError (swev-id: django__django-15128)

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -572,6 +572,10 @@ class Query(BaseExpression):
         if self.distinct_fields != rhs.distinct_fields:
             raise TypeError('Cannot combine queries with different distinct fields.')
 
+        if connector == OR:
+            rhs = rhs.clone()
+            rhs.bump_prefix(self, preserve_base=True)
+
         # Work out how to relabel the rhs aliases, if necessary.
         change_map = {}
         conjunction = (connector == AND)
@@ -879,7 +883,7 @@ class Query(BaseExpression):
             for alias, aliased in self.external_aliases.items()
         }
 
-    def bump_prefix(self, outer_query):
+    def bump_prefix(self, outer_query, preserve_base=False):
         """
         Change the alias prefix to the next letter in the alphabet in a way
         that the outer query's aliases and this query's aliases will not
@@ -923,10 +927,14 @@ class Query(BaseExpression):
                 )
         self.subq_aliases = self.subq_aliases.union([self.alias_prefix])
         outer_query.subq_aliases = outer_query.subq_aliases.union(self.subq_aliases)
-        self.change_aliases({
+        base_alias = self.base_table if preserve_base else None
+        change_map = {
             alias: '%s%d' % (self.alias_prefix, pos)
             for pos, alias in enumerate(self.alias_map)
-        })
+            if alias != base_alias
+        }
+        if change_map:
+            self.change_aliases(change_map)
 
     def get_initial_alias(self):
         """

--- a/tests/queries/test_or_alias_collision.py
+++ b/tests/queries/test_or_alias_collision.py
@@ -1,0 +1,107 @@
+from django.db import connection, models
+from django.db.models import Q
+from django.test import TestCase
+from django.test.utils import isolate_apps
+
+
+@isolate_apps('queries', attr_name='apps')
+class OrAliasCollisionTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        class Baz(models.Model):
+            name = models.CharField(max_length=50, blank=True)
+
+            class Meta:
+                app_label = 'queries'
+
+        class Foo(models.Model):
+            name = models.CharField(max_length=50, blank=True)
+
+            class Meta:
+                app_label = 'queries'
+
+        class Bar(models.Model):
+            foo = models.ForeignKey(Foo, related_name='bars', on_delete=models.CASCADE)
+            baz = models.ForeignKey(Baz, related_name='bars', on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'queries'
+
+        class OtherBar(models.Model):
+            foo = models.ForeignKey(Foo, related_name='other_bars', on_delete=models.CASCADE)
+            baz = models.ForeignKey(Baz, related_name='other_bars', on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'queries'
+
+        class Qux(models.Model):
+            foos = models.ManyToManyField(Foo, related_name='quxes')
+            bazes = models.ManyToManyField(Baz, related_name='quxes')
+
+            class Meta:
+                app_label = 'queries'
+
+        cls.Baz = Baz
+        cls.Foo = Foo
+        cls.Bar = Bar
+        cls.OtherBar = OtherBar
+        cls.Qux = Qux
+        cls._created_models = [Baz, Foo, Bar, OtherBar, Qux]
+        with connection.schema_editor() as editor:
+            for model in cls._created_models:
+                editor.create_model(model)
+        try:
+            super().setUpClass()
+        except Exception:
+            with connection.schema_editor() as editor:
+                for model in reversed(cls._created_models):
+                    editor.delete_model(model)
+            raise
+        cls.addClassCleanup(cls._tearDownModels)
+
+    @classmethod
+    def setUpTestData(cls):
+        Baz = cls.Baz
+        Foo = cls.Foo
+        Bar = cls.Bar
+        OtherBar = cls.OtherBar
+        Qux = cls.Qux
+
+        baz = Baz.objects.create(name='B1')
+        foo = Foo.objects.create(name='Foo 1')
+        Bar.objects.create(foo=foo, baz=baz)
+        OtherBar.objects.create(foo=foo, baz=baz)
+        qux = Qux.objects.create()
+        qux.foos.add(foo)
+        qux.bazes.add(baz)
+
+        cls.baz = baz
+        cls.foo = foo
+        cls.qux = qux
+
+    @classmethod
+    def _tearDownModels(cls):
+        with connection.schema_editor() as editor:
+            for model in reversed(cls._created_models):
+                editor.delete_model(model)
+
+    def test_or_combine_avoids_alias_collision(self):
+        Foo = self.Foo
+        qux = self.qux
+        bazes = qux.bazes.all()
+
+        qs1 = qux.foos.all()
+        qs2 = Foo.objects.filter(
+            Q(bars__baz__in=bazes) | Q(other_bars__baz__in=bazes)
+        )
+
+        combined_12 = qs1 | qs2
+        combined_21 = qs2 | qs1
+
+        combined_12_ids = list(combined_12.order_by('pk').values_list('pk', flat=True))
+        combined_21_ids = list(combined_21.order_by('pk').values_list('pk', flat=True))
+
+        expected_ids = [self.foo.pk]
+        self.assertSequenceEqual(combined_12_ids, expected_ids)
+        self.assertSequenceEqual(combined_21_ids, expected_ids)
+        self.assertSequenceEqual(combined_12_ids, combined_21_ids)


### PR DESCRIPTION
## Summary
- prevent alias collisions when OR-combining querysets by cloning and bumping the RHS prefix while preserving its base alias
- allow Query.bump_prefix() to skip relabeling the base alias when requested
- add a regression test mirroring the reported Foo/Qux scenario to ensure both combination orders succeed

## Observed failure
```
AssertionError
  File "django/db/models/sql/query.py", line 861, in change_aliases
    assert set(change_map).isdisjoint(change_map.values())
```

## Reproduction
```python
from django.db.models import Q
from bug.app.models import Foo, Qux

qux = Qux.objects.create()
qs1 = qux.foos.all()
qs2 = Foo.objects.filter(
    Q(bars__baz__in=qux.bazes.all()) | Q(other_bars__baz__in=qux.bazes.all())
)
qs2 | qs1
qs1 | qs2  # AssertionError before fix
```

## Fix
`Query.combine()` now clones the RHS when using the OR connector and calls `bump_prefix(self, preserve_base=True)` so that alias relabeling never maps existing names onto the new prefix. `Query.bump_prefix()` accepts a new `preserve_base` flag to retain the base alias while rewriting the rest of the aliases.

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py queries.test_or_alias_collision --parallel=1
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py queries --parallel=1

Fixes #464
