### PR TITLE
fix: swev-id: django__django-15161 simplify deconstruct paths

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -8,12 +8,14 @@ from django.db.models.functions.comparison import Coalesce
 from django.db.models.functions.mixins import (
     FixDurationInputMixin, NumericOutputFieldMixin,
 )
+from django.utils.deconstruct import deconstructible
 
 __all__ = [
     'Aggregate', 'Avg', 'Count', 'Max', 'Min', 'StdDev', 'Sum', 'Variance',
 ]
 
 
+@deconstructible(path='django.db.models.Aggregate')
 class Aggregate(Func):
     template = '%(function)s(%(distinct)s%(expressions)s)'
     contains_aggregate = True
@@ -106,12 +108,14 @@ class Aggregate(Func):
         return options
 
 
+@deconstructible(path='django.db.models.Avg')
 class Avg(FixDurationInputMixin, NumericOutputFieldMixin, Aggregate):
     function = 'AVG'
     name = 'Avg'
     allow_distinct = True
 
 
+@deconstructible(path='django.db.models.Count')
 class Count(Aggregate):
     function = 'COUNT'
     name = 'Count'
@@ -127,16 +131,19 @@ class Count(Aggregate):
         super().__init__(expression, filter=filter, **extra)
 
 
+@deconstructible(path='django.db.models.Max')
 class Max(Aggregate):
     function = 'MAX'
     name = 'Max'
 
 
+@deconstructible(path='django.db.models.Min')
 class Min(Aggregate):
     function = 'MIN'
     name = 'Min'
 
 
+@deconstructible(path='django.db.models.StdDev')
 class StdDev(NumericOutputFieldMixin, Aggregate):
     name = 'StdDev'
 
@@ -148,12 +155,14 @@ class StdDev(NumericOutputFieldMixin, Aggregate):
         return {**super()._get_repr_options(), 'sample': self.function == 'STDDEV_SAMP'}
 
 
+@deconstructible(path='django.db.models.Sum')
 class Sum(FixDurationInputMixin, Aggregate):
     function = 'SUM'
     name = 'Sum'
     allow_distinct = True
 
 
+@deconstructible(path='django.db.models.Variance')
 class Variance(NumericOutputFieldMixin, Aggregate):
     name = 'Variance'
 

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -390,7 +390,7 @@ class BaseExpression:
         return sql, params
 
 
-@deconstructible
+@deconstructible(path='django.db.models.Expression')
 class Expression(BaseExpression, Combinable):
     """An expression that can be combined with other expressions."""
 
@@ -639,6 +639,7 @@ class ResolvedOuterRef(F):
         return []
 
 
+@deconstructible(path='django.db.models.OuterRef')
 class OuterRef(F):
     contains_aggregate = False
 
@@ -651,6 +652,7 @@ class OuterRef(F):
         return self
 
 
+@deconstructible(path='django.db.models.Func')
 class Func(SQLiteNumericMixin, Expression):
     """An SQL function call."""
     function = None
@@ -731,6 +733,7 @@ class Func(SQLiteNumericMixin, Expression):
         return copy
 
 
+@deconstructible(path='django.db.models.Value')
 class Value(SQLiteNumericMixin, Expression):
     """Represent a wrapped value as a node within an expression."""
     # Provide a default value for `for_save` in order to allow unresolved
@@ -912,6 +915,7 @@ class Ref(Expression):
         return [self]
 
 
+@deconstructible(path='django.db.models.ExpressionList')
 class ExpressionList(Func):
     """
     An expression containing multiple expressions. Can be used to provide a
@@ -953,6 +957,7 @@ class OrderByList(Func):
         return super().as_sql(*args, **kwargs)
 
 
+@deconstructible(path='django.db.models.ExpressionWrapper')
 class ExpressionWrapper(SQLiteNumericMixin, Expression):
     """
     An expression that can wrap another expression so that it can provide
@@ -985,6 +990,7 @@ class ExpressionWrapper(SQLiteNumericMixin, Expression):
         return "{}({})".format(self.__class__.__name__, self.expression)
 
 
+@deconstructible(path='django.db.models.When')
 class When(Expression):
     template = 'WHEN %(condition)s THEN %(result)s'
     # This isn't a complete conditional expression, must be used in Case().
@@ -1052,6 +1058,7 @@ class When(Expression):
         return cols
 
 
+@deconstructible(path='django.db.models.Case')
 class Case(SQLiteNumericMixin, Expression):
     """
     An SQL searched CASE expression:
@@ -1225,6 +1232,7 @@ class Exists(Subquery):
         return sql, params
 
 
+@deconstructible(path='django.db.models.OrderBy')
 class OrderBy(Expression):
     template = '%(expression)s %(ordering)s'
     conditional = False
@@ -1307,6 +1315,7 @@ class OrderBy(Expression):
         self.descending = True
 
 
+@deconstructible(path='django.db.models.Window')
 class Window(SQLiteNumericMixin, Expression):
     template = '%(expression)s OVER (%(window)s)'
     # Although the main expression may either be an aggregate or an
@@ -1412,6 +1421,7 @@ class Window(SQLiteNumericMixin, Expression):
         return []
 
 
+@deconstructible(path='django.db.models.WindowFrame')
 class WindowFrame(Expression):
     """
     Model the frame clause in window expressions. There are two types of frame
@@ -1471,6 +1481,7 @@ class WindowFrame(Expression):
         raise NotImplementedError('Subclasses must implement window_frame_start_end().')
 
 
+@deconstructible(path='django.db.models.RowRange')
 class RowRange(WindowFrame):
     frame_type = 'ROWS'
 
@@ -1478,6 +1489,7 @@ class RowRange(WindowFrame):
         return connection.ops.window_frame_rows_start_end(start, end)
 
 
+@deconstructible(path='django.db.models.ValueRange')
 class ValueRange(WindowFrame):
     frame_type = 'RANGE'
 

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -1763,14 +1763,14 @@ class ValueTests(TestCase):
     def test_deconstruct(self):
         value = Value('name')
         path, args, kwargs = value.deconstruct()
-        self.assertEqual(path, 'django.db.models.expressions.Value')
+        self.assertEqual(path, 'django.db.models.Value')
         self.assertEqual(args, (value.value,))
         self.assertEqual(kwargs, {})
 
     def test_deconstruct_output_field(self):
         value = Value('name', output_field=CharField())
         path, args, kwargs = value.deconstruct()
-        self.assertEqual(path, 'django.db.models.expressions.Value')
+        self.assertEqual(path, 'django.db.models.Value')
         self.assertEqual(args, (value.value,))
         self.assertEqual(len(kwargs), 1)
         self.assertEqual(kwargs['output_field'].deconstruct(), CharField().deconstruct())


### PR DESCRIPTION
## Summary
- add deconstructible path overrides for re-exported expressions and aggregates so deconstruct() emits django.db.models.*
- update Value deconstruct tests to expect the simplified path
- keep other expression and function classes untouched per scope and notes

## Testing
- PYTHONPATH=/workspace:/workspace/tests:/root/.venvs/django311/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite /root/.venvs/django311/bin/python tests/runtests.py expressions.tests.ValueTests.test_deconstruct --parallel=1
- PYTHONPATH=/workspace:/workspace/tests:/root/.venvs/django311/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite /root/.venvs/django311/bin/python tests/runtests.py expressions.tests.ValueTests.test_deconstruct_output_field --parallel=1
- /root/.venvs/django311/bin/flake8 django/db/models/expressions.py django/db/models/aggregates.py tests/expressions/tests.py

Closes #465
