### PR TITLE
fix: block migration recorder on disallowed DBs (swev-id: django__django-15252)

### DIFF
--- a/django/core/management/commands/migrate.py
+++ b/django/core/management/commands/migrate.py
@@ -12,6 +12,7 @@ from django.core.management.sql import (
 from django.db import DEFAULT_DB_ALIAS, connections, router
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.exceptions import MigrationRecorderNotAllowed
 from django.db.migrations.loader import AmbiguityError
 from django.db.migrations.state import ModelState, ProjectState
 from django.utils.module_loading import module_has_submodule
@@ -250,10 +251,18 @@ class Command(BaseCommand):
         else:
             fake = options['fake']
             fake_initial = options['fake_initial']
-        post_migrate_state = executor.migrate(
-            targets, plan=plan, state=pre_migrate_state.clone(), fake=fake,
-            fake_initial=fake_initial,
-        )
+        try:
+            post_migrate_state = executor.migrate(
+                targets, plan=plan, state=pre_migrate_state.clone(), fake=fake,
+                fake_initial=fake_initial,
+            )
+        except MigrationRecorderNotAllowed as e:
+            message = "Skipping migrations for database '%s': %s" % (connection.alias, e)
+            if run_syncdb:
+                self.stdout.write(self.style.WARNING(message))
+                post_migrate_state = pre_migrate_state.clone()
+            else:
+                raise CommandError(str(e))
         # post_migrate signals have access to all models. Ensure that all models
         # are reloaded in case any are delayed.
         post_migrate_state.clear_delayed_apps_cache()

--- a/django/db/backends/base/creation.py
+++ b/django/db/backends/base/creation.py
@@ -7,6 +7,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core import serializers
 from django.db import router
+from django.db.migrations.exceptions import MigrationRecorderNotAllowed
 from django.db.transaction import atomic
 from django.utils.module_loading import import_string
 
@@ -71,13 +72,16 @@ class BaseDatabaseCreation:
             # We report migrate messages at one level lower than that
             # requested. This ensures we don't get flooded with messages during
             # testing (unless you really ask to be flooded).
-            call_command(
-                'migrate',
-                verbosity=max(verbosity - 1, 0),
-                interactive=False,
-                database=self.connection.alias,
-                run_syncdb=True,
-            )
+            try:
+                call_command(
+                    'migrate',
+                    verbosity=max(verbosity - 1, 0),
+                    interactive=False,
+                    database=self.connection.alias,
+                    run_syncdb=True,
+                )
+            except MigrationRecorderNotAllowed as e:
+                self.log("Skipping migrations for database '%s': %s" % (self.connection.alias, e))
         finally:
             if self.connection.settings_dict['TEST']['MIGRATE'] is False:
                 settings.MIGRATION_MODULES = old_migration_modules

--- a/django/db/migrations/exceptions.py
+++ b/django/db/migrations/exceptions.py
@@ -50,5 +50,10 @@ class MigrationSchemaMissing(DatabaseError):
     pass
 
 
+class MigrationRecorderNotAllowed(DatabaseError):
+    """Migrations are disallowed for recorder per router."""
+    pass
+
+
 class InvalidMigrationPlan(ValueError):
     pass

--- a/django/db/migrations/executor.py
+++ b/django/db/migrations/executor.py
@@ -1,7 +1,7 @@
 from django.apps.registry import apps as global_apps
 from django.db import migrations, router
 
-from .exceptions import InvalidMigrationPlan
+from .exceptions import InvalidMigrationPlan, MigrationRecorderNotAllowed
 from .loader import MigrationLoader
 from .recorder import MigrationRecorder
 from .state import ProjectState
@@ -95,6 +95,8 @@ class MigrationExecutor:
         Django first needs to create all project states before a migration is
         (un)applied and in a second step run all the database operations.
         """
+        if not router.allow_migrate_model(self.connection.alias, self.recorder.Migration):
+            raise MigrationRecorderNotAllowed("Migrations are disallowed for recorder per router.")
         # The django_migrations table must be present to record applied
         # migrations.
         self.recorder.ensure_schema()

--- a/django/db/migrations/recorder.py
+++ b/django/db/migrations/recorder.py
@@ -1,9 +1,9 @@
 from django.apps.registry import Apps
-from django.db import DatabaseError, models
+from django.db import DatabaseError, models, router
 from django.utils.functional import classproperty
 from django.utils.timezone import now
 
-from .exceptions import MigrationSchemaMissing
+from .exceptions import MigrationRecorderNotAllowed, MigrationSchemaMissing
 
 
 class MigrationRecorder:
@@ -50,8 +50,13 @@ class MigrationRecorder:
     def migration_qs(self):
         return self.Migration.objects.using(self.connection.alias)
 
+    def _is_allowed(self):
+        return router.allow_migrate_model(self.connection.alias, self.Migration)
+
     def has_table(self):
         """Return True if the django_migrations table exists."""
+        if not self._is_allowed():
+            return False
         with self.connection.cursor() as cursor:
             tables = self.connection.introspection.table_names(cursor)
         return self.Migration._meta.db_table in tables
@@ -60,6 +65,8 @@ class MigrationRecorder:
         """Ensure the table exists and has the correct schema."""
         # If the table's there, that's fine - we've never changed its schema
         # in the codebase.
+        if not self._is_allowed():
+            raise MigrationRecorderNotAllowed("Migrations are disallowed for recorder per router.")
         if self.has_table():
             return
         # Make the table
@@ -83,14 +90,20 @@ class MigrationRecorder:
 
     def record_applied(self, app, name):
         """Record that a migration was applied."""
+        if not self._is_allowed():
+            raise MigrationRecorderNotAllowed("Migrations are disallowed for recorder per router.")
         self.ensure_schema()
         self.migration_qs.create(app=app, name=name)
 
     def record_unapplied(self, app, name):
         """Record that a migration was unapplied."""
+        if not self._is_allowed():
+            raise MigrationRecorderNotAllowed("Migrations are disallowed for recorder per router.")
         self.ensure_schema()
         self.migration_qs.filter(app=app, name=name).delete()
 
     def flush(self):
         """Delete all migration records. Useful for testing migrations."""
+        if not self._is_allowed():
+            raise MigrationRecorderNotAllowed("Migrations are disallowed for recorder per router.")
         self.migration_qs.all().delete()

--- a/tests/migrations/test_recorder_router.py
+++ b/tests/migrations/test_recorder_router.py
@@ -1,0 +1,110 @@
+import copy
+import os
+import tempfile
+from io import StringIO
+
+from django.conf import settings
+from django.core.management import CommandError, call_command
+from django.db import connections
+from django.db.migrations.exceptions import MigrationRecorderNotAllowed
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.recorder import MigrationRecorder
+from django.test import TransactionTestCase, override_settings
+
+
+class RecorderDisallowRouter:
+    blocked_aliases = {'other', 'router'}
+
+    def allow_migrate(self, db, app_label, **hints):
+        if db in self.blocked_aliases and app_label == 'migrations':
+            return False
+        return None
+
+
+@override_settings(DATABASE_ROUTERS=[RecorderDisallowRouter()])
+class MigrationRecorderRouterTests(TransactionTestCase):
+    databases = {'default', 'other'}
+    available_apps = None
+
+    MESSAGE = "Migrations are disallowed for recorder per router."
+
+    def setUp(self):
+        super().setUp()
+        self.connection = connections['other']
+        self.addCleanup(self.connection.close)
+        self.recorder = MigrationRecorder(self.connection)
+
+    def test_ensure_schema_disallowed(self):
+        with self.assertRaisesMessage(MigrationRecorderNotAllowed, self.MESSAGE):
+            self.recorder.ensure_schema()
+
+    def test_record_operations_disallowed(self):
+        self.assertEqual(self.recorder.applied_migrations(), {})
+        with self.assertRaisesMessage(MigrationRecorderNotAllowed, self.MESSAGE):
+            self.recorder.record_applied('test_app', '0001_initial')
+        with self.assertRaisesMessage(MigrationRecorderNotAllowed, self.MESSAGE):
+            self.recorder.record_unapplied('test_app', '0001_initial')
+        with self.assertRaisesMessage(MigrationRecorderNotAllowed, self.MESSAGE):
+            self.recorder.flush()
+
+    def test_executor_migrate_disallowed(self):
+        executor = MigrationExecutor(self.connection)
+        targets = executor.loader.graph.leaf_nodes()
+        with self.assertRaisesMessage(MigrationRecorderNotAllowed, self.MESSAGE):
+            executor.migrate(targets)
+
+    def test_migrate_command_run_syncdb_warns_and_skips(self):
+        out = StringIO()
+        call_command(
+            'migrate',
+            database='other',
+            run_syncdb=True,
+            verbosity=1,
+            stdout=out,
+        )
+        self.assertIn("Skipping migrations for database 'other'", out.getvalue())
+        self.assertEqual(self.recorder.applied_migrations(), {})
+
+    def test_migrate_command_without_run_syncdb_errors(self):
+        with self.assertRaisesMessage(CommandError, self.MESSAGE):
+            call_command('migrate', database='other', verbosity=0)
+
+    def test_test_runner_migrate_false_skips_migrations(self):
+        original_name = self.connection.settings_dict['NAME']
+        original_test_settings = copy.deepcopy(self.connection.settings_dict['TEST'])
+        original_db_settings = copy.deepcopy(settings.DATABASES['other'])
+        original_handler_settings = copy.deepcopy(connections.databases['other'])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_name = os.path.join(tmpdir, 'router.sqlite3')
+            new_test_settings = copy.deepcopy(original_test_settings)
+            new_test_settings.update({'NAME': new_name, 'MIGRATE': False})
+            settings.DATABASES['other'] = {
+                **original_db_settings,
+                'NAME': new_name,
+                'TEST': copy.deepcopy(new_test_settings),
+            }
+            connections.databases['other'] = {
+                **original_handler_settings,
+                'NAME': new_name,
+                'TEST': copy.deepcopy(new_test_settings),
+            }
+            self.connection.close()
+            self.connection.settings_dict['NAME'] = new_name
+            self.connection.settings_dict['TEST'] = copy.deepcopy(new_test_settings)
+            try:
+                self.connection.creation.create_test_db(
+                    verbosity=0,
+                    autoclobber=True,
+                    serialize=False,
+                    keepdb=False,
+                )
+                with self.connection.cursor() as cursor:
+                    tables = set(self.connection.introspection.table_names(cursor))
+                self.assertNotIn('django_migrations', tables)
+            finally:
+                self.connection.creation.destroy_test_db(original_name, verbosity=0, keepdb=False)
+                self.connection.settings_dict['NAME'] = original_name
+                self.connection.settings_dict['TEST'] = original_test_settings
+                settings.DATABASES['other'] = original_db_settings
+                connections.databases['other'] = original_handler_settings
+                self.connection.close()


### PR DESCRIPTION
## Summary
- raise and surface a dedicated MigrationRecorderNotAllowed error when routers disallow the recorder model
- stop recorder methods, migration executor, management command, and test runner from touching disallowed databases
- add regression coverage for recorder, executor, migrate command, and test runner behaviour when migrations are blocked

## Observed Failure
Running migrations against a router-disallowed database forced `MigrationRecorder.ensure_schema()` to create `django_migrations`, eventually exploding as `MigrationSchemaMissing`. Representative stack (pre-fix):

```
  File "django/core/management/commands/migrate.py", line 244, in handle
    post_migrate_state = executor.migrate(...)
  File "django/db/migrations/executor.py", line 101, in migrate
    self.recorder.ensure_schema()
  File "django/db/migrations/recorder.py", line 70, in ensure_schema
    editor.create_model(self.Migration)
  File "django/db/backends/base/schema.py", line 475, in create_model
    self.execute(sql, params or None)
  File "django/db/backends/sqlite3/schema.py", line 43, in execute
    cursor.execute(sql, params)
sqlite3.OperationalError: not authorized
```

The error is wrapped as `MigrationSchemaMissing` and bubbles out to the migrate command.

## Reproduction Steps
1. Configure a second database alias (e.g. `readonly`) and a router that returns `False` from `allow_migrate()` for that alias.
2. Run `python manage.py migrate --database=readonly` or let the test runner set up databases with `TEST: {'MIGRATE': False}`.
3. Observe `MigrationSchemaMissing` triggered from `MigrationRecorder.ensure_schema()` while creating `django_migrations`.

## Fix Details
- Define `MigrationRecorderNotAllowed` and guard `MigrationRecorder` helpers; they now refuse and raise when routers block migrations, and `applied_migrations()` simply returns `{}`.
- Teach `MigrationExecutor` to bail out early on disallowed recorders so `ensure_schema()` is never attempted.
- Update the migrate command and test database creation to catch the new exception: warn & skip when `--run-syncdb` is active, otherwise surface a `CommandError`.
- Add targeted tests covering recorder methods, executor, management command paths, and test-runner setup for disallowed databases.

## Tests
- `PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py migrations.test_recorder_router --parallel=1`
- `PYTHONPATH=$PWD .venv/bin/flake8 django/db/migrations/recorder.py django/db/migrations/executor.py django/core/management/commands/migrate.py django/db/backends/base/creation.py tests/migrations/test_recorder_router.py`

Closes #468