### PR TITLE
swev-id: django__django-15277 - Guard CharField validators for None max_length; add regression test

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -1010,7 +1010,8 @@ class CharField(Field):
     def __init__(self, *args, db_collation=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.db_collation = db_collation
-        self.validators.append(validators.MaxLengthValidator(self.max_length))
+        if self.max_length is not None:
+            self.validators.append(validators.MaxLengthValidator(self.max_length))
 
     def check(self, **kwargs):
         databases = kwargs.get('databases') or []

--- a/tests/expressions/test_value_output_field.py
+++ b/tests/expressions/test_value_output_field.py
@@ -1,0 +1,21 @@
+from django.db.models import Value
+from django.test import SimpleTestCase
+
+
+class ValueResolveOutputFieldTests(SimpleTestCase):
+    def test_value_resolves_charfield_without_max_length_validator(self):
+        """
+        Value._resolve_output_field() should return a CharField without attaching
+        a MaxLengthValidator when no max_length is provided. Previously a
+        MaxLengthValidator(None) was added which caused TypeError during clean().
+        """
+        x = Value('test')
+        y = x._resolve_output_field()
+
+        # Ensure no MaxLengthValidator is attached when max_length is None.
+        self.assertFalse(
+            any(v.__class__.__name__ == 'MaxLengthValidator' for v in y.validators)
+        )
+
+        # This should not raise (it used to crash with TypeError in compare()).
+        y.clean('1', model_instance=None)


### PR DESCRIPTION
Fixes #470

Summary
- Micro-optimisation and correctness fix: avoid attaching MaxLengthValidator when CharField.max_length is None.
- Adds a regression test for Value._resolve_output_field() ensuring no MaxLengthValidator is added and .clean() does not error.

Context
Value._resolve_output_field() returns a CharField() for string Values. CharField.__init__ unconditionally appended MaxLengthValidator(self.max_length), which is None in this case. This leads to two problems:
- Functional: Value('test')._resolve_output_field().clean('1', None) raises a TypeError inside MaxLengthValidator.compare (int > NoneType).
- Performance: creation of an unnecessary deconstructible validator on hot paths.

Change
In django/db/models/fields/__init__.py:
- CharField.__init__: add validator only if self.max_length is not None (mirrors BinaryField precedent).

Tests
- New test: tests/expressions/test_value_output_field.py:ValueResolveOutputFieldTests.test_value_resolves_charfield_without_max_length_validator

Observed failure prior to this change
Running the expressions test app with only the new test present shows the failure:

```
FAIL: test_value_resolves_charfield_without_max_length_validator (expressions.test_value_output_field.ValueResolveOutputFieldTests)
AssertionError: True is not false
```

Additionally, the TypeError reproduced via a minimal script before the fix:

```
from django.db.models import Value
x = Value('test')
y = x._resolve_output_field()
print('validators:', [type(v).__name__ for v in y.validators])
y.clean('1', model_instance=None)
```

Stack trace:

```
validators: ['MaxLengthValidator']
Traceback (most recent call last):
  File "<stdin>", line 6, in <module>
  File "django/db/models/fields/__init__.py", line 672, in clean
    self.run_validators(value)
  File "django/db/models/fields/__init__.py", line 624, in run_validators
    v(value)
  File "django/core/validators.py", line 330, in __call__
    if self.compare(cleaned, limit_value):
  File "django/core/validators.py", line 391, in compare
    return a > b
TypeError: '>' not supported between instances of 'int' and 'NoneType'
```

After this change, the new test passes and the snippet above runs without error (no MaxLengthValidator is attached when max_length is None).

Performance reference (from upstream report): avoiding validator instantiation improves Value._resolve_output_field() by ~2µs in microbenchmarks.

Upstream reference
- Original discussion/PR: https://github.com/django/django/pull/15277

Notes
- Target base branch: django__django-15277 (per task requirements).
- CI is not triggered by me (per task rules). Local tests for the expressions app pass with Python 3.12 and minimal dependencies.
- Task reference: swev-id: django__django-15277