### PR TITLE
Optimize AlterUnique/IndexTogether optimizer collapse (swev-id: django__django-15268)

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -528,6 +528,19 @@ class AlterTogetherOptionOperation(ModelOptionOperation):
     def migration_name_fragment(self):
         return 'alter_%s_%s' % (self.name_lower, self.option_name)
 
+    def reduce(self, operation, app_label):
+        default = super().reduce(operation, app_label)
+        if isinstance(default, list):
+            return default
+        if (
+            isinstance(operation, AlterTogetherOptionOperation) and
+            self.name_lower == operation.name_lower and
+            not self.option_value and
+            bool(operation.option_value)
+        ):
+            return True
+        return default
+
 
 class AlterUniqueTogether(AlterTogetherOptionOperation):
     """

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -218,6 +218,68 @@ class OptimizerTests(SimpleTestCase):
             migrations.AlterOrderWithRespectTo("Foo", "b"),
         )
 
+    def test_alter_together_collapses_empty_pairs(self):
+        operations = [
+            migrations.AlterUniqueTogether("Book", []),
+            migrations.AlterIndexTogether("Book", []),
+            migrations.AlterUniqueTogether("Book", [["title"]]),
+            migrations.AlterIndexTogether("Book", [["title"]]),
+        ]
+        expected = [
+            migrations.AlterUniqueTogether("Book", [["title"]]),
+            migrations.AlterIndexTogether("Book", [["title"]]),
+        ]
+        self.assertOptimizesTo(operations, expected)
+
+    def test_alter_together_blocked_by_field_changes(self):
+        operations = [
+            migrations.AlterUniqueTogether("Book", []),
+            migrations.AlterIndexTogether("Book", []),
+            migrations.AlterField("Book", "title", models.CharField(max_length=128)),
+            migrations.AlterUniqueTogether("Book", [["title"]]),
+            migrations.AlterIndexTogether("Book", [["title"]]),
+        ]
+        self.assertOptimizesTo(operations, operations[:])
+
+    def test_alter_together_independent_per_type(self):
+        operations = [
+            migrations.AlterUniqueTogether("Book", []),
+            migrations.AlterIndexTogether("Book", []),
+            migrations.AlterUniqueTogether("Book", [["title"]]),
+            migrations.AlterIndexTogether("Book", [["author"]]),
+        ]
+        expected = [
+            migrations.AlterUniqueTogether("Book", [["title"]]),
+            migrations.AlterIndexTogether("Book", [["author"]]),
+        ]
+        self.assertOptimizesTo(operations, expected)
+
+    def test_alter_together_collapses_multiple_pairs(self):
+        operations = [
+            migrations.AlterUniqueTogether("Book", []),
+            migrations.AlterUniqueTogether("Book", [["title"]]),
+            migrations.AlterUniqueTogether("Book", []),
+            migrations.AlterUniqueTogether("Book", [["author"]]),
+            migrations.AlterIndexTogether("Book", []),
+            migrations.AlterIndexTogether("Book", [["title"]]),
+            migrations.AlterIndexTogether("Book", []),
+            migrations.AlterIndexTogether("Book", [["author"]]),
+        ]
+        expected = [
+            migrations.AlterUniqueTogether("Book", [["author"]]),
+            migrations.AlterIndexTogether("Book", [["author"]]),
+        ]
+        self.assertOptimizesTo(operations, expected)
+
+    def test_alter_together_different_models_do_not_collapse(self):
+        operations = [
+            migrations.AlterUniqueTogether("Book", []),
+            migrations.AlterUniqueTogether("Author", [["name"]]),
+            migrations.AlterIndexTogether("Book", []),
+            migrations.AlterIndexTogether("Author", [["name"]]),
+        ]
+        self.assertOptimizesTo(operations, operations[:])
+
     def test_optimize_through_create(self):
         """
         We should be able to optimize away create/delete through a create or delete


### PR DESCRIPTION
## Summary
- Fixes #471 by allowing empty AlterUniqueTogether/AlterIndexTogether removals to step over later non-empty operations on the same model.
- Override `AlterTogetherOptionOperation.reduce()` to forward non-blocking reductions while preserving existing collapse semantics.
- Add migration optimizer regression tests covering collapse, blocking field mutations, multiple pairs, and cross-model independence.

## Reproduction
- Before: `U(empty), I(empty), U({('title',)}), I({('title',)})` optimized to the original sequence, leaving redundant operations.
- After: The same sequence now optimizes to `U({('title',)}), I({('title',)})` and analogous patterns collapse while respecting field changes and model boundaries.
- Covered scenarios include differing constraint targets per type, multiple empty/non-empty pairs, and interleaved operations for other models.

## Testing
- `PYTHONPATH=/workspace/django ./runtests.py migrations.test_optimizer --parallel=1` (40 passed)
- `flake8 django/db/migrations/operations/models.py tests/migrations/test_optimizer.py` (no issues)

No local failures encountered.