### PR TITLE
fix: swev-id: django__django-15368 bulk_update duck-typing

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -17,7 +17,7 @@ from django.db import (
 from django.db.models import AutoField, DateField, DateTimeField, sql
 from django.db.models.constants import LOOKUP_SEP, OnConflict
 from django.db.models.deletion import Collector
-from django.db.models.expressions import Case, Expression, F, Ref, Value, When
+from django.db.models.expressions import Case, F, Ref, Value, When
 from django.db.models.functions import Cast, Trunc
 from django.db.models.query_utils import FilteredRelation, Q
 from django.db.models.sql.constants import CURSOR, GET_ITERATOR_CHUNK_SIZE
@@ -670,7 +670,7 @@ class QuerySet:
                 when_statements = []
                 for obj in batch_objs:
                     attr = getattr(obj, field.attname)
-                    if not isinstance(attr, Expression):
+                    if not hasattr(attr, 'resolve_expression'):
                         attr = Value(attr, output_field=field)
                     when_statements.append(When(pk=obj.pk, then=attr))
                 case_statement = Case(*when_statements, output_field=field)

--- a/tests/queries/test_bulk_update.py
+++ b/tests/queries/test_bulk_update.py
@@ -1,9 +1,11 @@
 import datetime
 
 from django.core.exceptions import FieldDoesNotExist
+from django.db import connection
 from django.db.models import F
 from django.db.models.functions import Lower
 from django.test import TestCase, skipUnlessDBFeature
+from django.test.utils import CaptureQueriesContext
 
 from .models import (
     Article, CustomDbColumn, CustomPk, Detail, Individual, JSONFieldNullable,
@@ -96,6 +98,19 @@ class BulkUpdateNoteTests(TestCase):
         Note.objects.bulk_update(self.notes, ['note'])
         self.assertEqual(set(Note.objects.values_list('note', flat=True)), {'test'})
 
+    def test_bulk_update_accepts_F_expression_for_charfield(self):
+        note = Note.objects.create(note='orig', misc='extra')
+        note.note = F('note')
+        with CaptureQueriesContext(connection) as queries:
+            Note.objects.bulk_update([note], ['note'])
+        update_sql = queries[-1]['sql']
+        note.refresh_from_db()
+        self.assertEqual(note.note, 'orig', update_sql)
+        self.assertNotIn("'F(note)'", update_sql)
+        quoted_table = connection.ops.quote_name(Note._meta.db_table)
+        quoted_column = connection.ops.quote_name('note')
+        self.assertIn(f'{quoted_table}.{quoted_column}', update_sql)
+
     # Tests that use self.notes go here, otherwise put them in another class.
 
 
@@ -104,6 +119,24 @@ class BulkUpdateTests(TestCase):
         msg = 'Field names must be given to bulk_update().'
         with self.assertRaisesMessage(ValueError, msg):
             Note.objects.bulk_update([], fields=[])
+
+    def test_bulk_update_supports_arithmetic_F_expression(self):
+        numbers = [
+            Number.objects.create(num=1, other_num=10, another_num=20),
+            Number.objects.create(num=3, other_num=30, another_num=40),
+        ]
+        numbers[0].num = F('num') + 1
+        numbers[1].num = F('num') + 2
+        with CaptureQueriesContext(connection) as queries:
+            Number.objects.bulk_update(numbers, ['num'])
+        update_sql = queries[-1]['sql']
+        for expected, number in zip((2, 5), numbers):
+            number.refresh_from_db()
+            self.assertEqual(number.num, expected, update_sql)
+        self.assertNotIn("'F(num)'", update_sql)
+        quoted_table = connection.ops.quote_name(Number._meta.db_table)
+        quoted_column = connection.ops.quote_name('num')
+        self.assertIn(f'{quoted_table}.{quoted_column}', update_sql)
 
     def test_invalid_batch_size(self):
         msg = 'Batch size must be a positive integer.'


### PR DESCRIPTION
## Summary
- duck-type `QuerySet.bulk_update()` expression handling by using `resolve_expression`
- add regression coverage for CharField and IntegerField updates via `F()` expressions

Fixes #477

## Reproduction
1. On `django__django-15368` with the regression test from this PR applied (prior to the fix), run:
   `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py queries --parallel=1`
2. Observe `BulkUpdateNoteTests.test_bulk_update_accepts_F_expression_for_charfield` failing with:
   ```
   AssertionError: 'F(note)' != 'orig'
   - F(note)
   + orig
    : UPDATE "queries_note" SET "note" = CASE WHEN ("queries_note"."id" = 11) THEN 'F(note)' ELSE NULL END WHERE "queries_note"."id" IN (11)
   ```

## Resolution
- treat any object exposing `resolve_expression()` as an expression so `F()` instances are preserved through CASE construction

## Testing
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py queries.test_bulk_update --parallel=1`
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py queries --parallel=1`
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages flake8 django/db/models/query.py tests/queries/test_bulk_update.py`