### PR TITLE
swev-id: django__django-15315 Make Field.__hash__ immutable

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -542,11 +542,7 @@ class Field(RegisterLookupMixin):
         return NotImplemented
 
     def __hash__(self):
-        return hash((
-            self.creation_counter,
-            self.model._meta.app_label if hasattr(self, 'model') else None,
-            self.model._meta.model_name if hasattr(self, 'model') else None,
-        ))
+        return hash(self.creation_counter)
 
     def __deepcopy__(self, memodict):
         # We don't have to deepcopy very much here, since most things are not

--- a/tests/model_fields/tests.py
+++ b/tests/model_fields/tests.py
@@ -1,9 +1,11 @@
+import copy
 import pickle
 
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import isolate_apps
 from django.utils.functional import lazy
 
 from .models import (
@@ -131,6 +133,79 @@ class BasicFieldTests(SimpleTestCase):
         self.assertNotEqual(hash(abstract_model_field), hash(inherit1_model_field))
         self.assertNotEqual(hash(abstract_model_field), hash(inherit2_model_field))
         self.assertNotEqual(hash(inherit1_model_field), hash(inherit2_model_field))
+
+
+class FieldHashTests(SimpleTestCase):
+
+    @isolate_apps('model_fields')
+    def test_dict_membership_survives_assignment(self):
+        field = models.CharField(max_length=200)
+        cache = {field: 'value'}
+
+        class Book(models.Model):
+            title = field
+
+        self.assertIn(field, cache)
+        self.assertEqual(cache[field], 'value')
+
+    @isolate_apps('model_fields')
+    def test_hash_consistency_across_assignment(self):
+        field = models.CharField(max_length=200)
+        hash_before = hash(field)
+
+        class Book(models.Model):
+            title = field
+
+        self.assertEqual(hash(field), hash_before)
+
+    @isolate_apps('model_fields')
+    def test_clone_hash_and_equality(self):
+        field = models.CharField(max_length=200)
+        clone = field.clone()
+
+        self.assertNotEqual(field, clone)
+        self.assertNotEqual(hash(field), hash(clone))
+
+    @isolate_apps('model_fields')
+    def test_shallow_copy_keeps_equality(self):
+
+        class Book(models.Model):
+            title = models.CharField(max_length=200)
+
+        original = Book._meta.get_field('title')
+        duplicate = copy.copy(original)
+
+        self.assertEqual(original, duplicate)
+        self.assertEqual(hash(original), hash(duplicate))
+
+    @isolate_apps('model_fields')
+    def test_abstract_base_inheritance_hash_usage(self):
+
+        class AbstractBook(models.Model):
+            title = models.CharField(max_length=200)
+
+            class Meta:
+                abstract = True
+
+        class Novel(AbstractBook):
+            pass
+
+        class Textbook(AbstractBook):
+            pass
+
+        abstract_field = AbstractBook._meta.get_field('title')
+        novel_field = Novel._meta.get_field('title')
+        textbook_field = Textbook._meta.get_field('title')
+
+        lookup = {
+            abstract_field: 'abstract',
+            novel_field: 'novel',
+            textbook_field: 'textbook',
+        }
+
+        self.assertEqual(lookup[abstract_field], 'abstract')
+        self.assertEqual(lookup[novel_field], 'novel')
+        self.assertEqual(lookup[textbook_field], 'textbook')
 
 
 class ChoicesTests(SimpleTestCase):


### PR DESCRIPTION
Resolves #478.

## Summary
- make Field.__hash__ depend solely on creation_counter to keep hashes immutable
- add regression tests covering assignment, cloning, copying, and abstract inheritance scenarios

## Reproduction
1. `. .venv/bin/activate`
2. `python tests/runtests.py model_fields.tests.FieldHashTests`
   ```
   Testing against Django installed in '/workspace/django/django' with up to 16 processes
   Found 5 test(s).
   System check identified no issues (0 silenced).
   ..FF.
   =======================================================================
   FAIL: test_dict_membership_survives_assignment (model_fields.tests.FieldHashTests.test_dict_membership_survives_assignment)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/workspace/django/django/test/utils.py", line 437, in inner
       return func(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^
     File "/workspace/django/tests/model_fields/tests.py", line 148, in test_dict_membership_survives_assignment
       self.assertIn(field, cache)
   AssertionError: <django.db.models.fields.CharField: title> not found in {<django.db.models.fields.CharField: title>: 'value'}
   
   =======================================================================
   FAIL: test_hash_consistency_across_assignment (model_fields.tests.FieldHashTests.test_hash_consistency_across_assignment)
   ----------------------------------------------------------------------
   Traceback (most recent call last):
     File "/workspace/django/django/test/utils.py", line 437, in inner
       return func(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^
     File "/workspace/django/tests/model_fields/tests.py", line 159, in test_hash_consistency_across_assignment
       self.assertEqual(hash(field), hash_before)
   AssertionError: -8710046496540565281 != -4077595348002855019
   
   ----------------------------------------------------------------------
   Ran 5 tests in 0.002s
   
   FAILED (failures=2)
   ```

## Testing
- `python tests/runtests.py model_fields.tests.FieldHashTests`
- `flake8 django/db/models/fields/__init__.py tests/model_fields/tests.py`
- `isort --check-only django/db/models/fields/__init__.py tests/model_fields/tests.py`
