### PR TITLE
fix: swev-id: django__django-15375 mark aggregate defaults

### DIFF
--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -65,7 +65,9 @@ class Aggregate(Func):
         if hasattr(default, 'resolve_expression'):
             default = default.resolve_expression(query, allow_joins, reuse, summarize)
         c.default = None  # Reset the default argument before wrapping.
-        return Coalesce(c, default, output_field=c._output_field_or_none)
+        coalesce = Coalesce(c, default, output_field=c._output_field_or_none)
+        coalesce.is_summary = True
+        return coalesce
 
     @property
     def default_alias(self):

--- a/django/db/models/aggregates.py
+++ b/django/db/models/aggregates.py
@@ -66,7 +66,7 @@ class Aggregate(Func):
             default = default.resolve_expression(query, allow_joins, reuse, summarize)
         c.default = None  # Reset the default argument before wrapping.
         coalesce = Coalesce(c, default, output_field=c._output_field_or_none)
-        coalesce.is_summary = True
+        coalesce.is_summary = c.is_summary
         return coalesce
 
     @property

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -220,6 +220,22 @@ class AggregateTestCase(TestCase):
             lambda r: (r.id, r.isbn, r.page_sum, r.contact.name, r.name)
         )
 
+    def test_annotate_aggregate_default_non_empty_queryset(self):
+        annotated = Book.objects.annotate(author_count=Count('authors'))
+        result = annotated.aggregate(total_authors=Sum('author_count', default=0))
+        expected_total = sum(annotated.values_list('author_count', flat=True))
+        self.assertEqual(result['total_authors'], expected_total)
+
+    def test_annotate_aggregate_default_empty_queryset(self):
+        annotated = Book.objects.annotate(author_count=Count('authors')).filter(pk__lt=0)
+        result = annotated.aggregate(total_authors=Sum('author_count', default=0))
+        self.assertEqual(result['total_authors'], 0)
+
+    def test_annotate_aggregate_without_default_empty_queryset(self):
+        annotated = Book.objects.annotate(author_count=Count('authors')).filter(pk__lt=0)
+        result = annotated.aggregate(total_authors=Sum('author_count'))
+        self.assertIsNone(result['total_authors'])
+
     def test_annotate_m2m(self):
         books = Book.objects.filter(rating__lt=4.5).annotate(Avg("authors__age")).order_by("name")
         self.assertQuerysetEqual(


### PR DESCRIPTION
## Summary
- mark the Coalesce wrapper generated by Aggregate(default=...) as a summary expression
- add regression coverage for annotate().aggregate() with and without default values over empty and non-empty querysets

## Reproduction Steps
1. Create an annotated queryset, e.g. `Book.objects.annotate(idx=F("id"))`.
2. Call `aggregate(Sum("id", default=0))` on the annotated queryset.

## Observed Failure / Stack Trace
```
OperationalError: near "FROM": syntax error
```

## Generated SQL
```
SELECT FROM (
  SELECT "core_book"."id" AS "idx",
         COALESCE(SUM("core_book"."id"), ?) AS "id__sum"
  FROM "core_book"
) subquery
```

## Root Cause and Fix
- Aggregate(default=...) wraps the aggregate in `Coalesce`, but the wrapper was not marked with `is_summary=True`.
- When operating on annotated querysets, the query compiler prunes non-summary expressions from the outer select list, producing `SELECT FROM (...)` and triggering the OperationalError above.
- Explicitly flag the Coalesce wrapper as a summary expression so the aggregate remains in the select list.

## Tests Added
- `test_annotate_aggregate_default_non_empty_queryset`
- `test_annotate_aggregate_default_empty_queryset`
- `test_annotate_aggregate_without_default_empty_queryset`

## Testing
- `.venv/bin/python tests/runtests.py aggregation`
- `.venv/bin/flake8 django/db/models/aggregates.py tests/aggregation/tests.py`