### PR TITLE
Fix autodetector crash on model+field rename in one step (swev-id: django__django-15380)

### DIFF
--- a/django/db/migrations/autodetector.py
+++ b/django/db/migrations/autodetector.py
@@ -824,7 +824,7 @@ class MigrationAutodetector:
         for app_label, model_name, field_name in sorted(self.new_field_keys - self.old_field_keys):
             old_model_name = self.renamed_models.get((app_label, model_name), model_name)
             old_model_state = self.from_state.models[app_label, old_model_name]
-            new_model_state = self.to_state.models[app_label, old_model_name]
+            new_model_state = self.to_state.models[app_label, model_name]
             field = new_model_state.get_field(field_name)
             # Scan to see if this is actually a rename!
             field_dec = self.deep_deconstruct(field)

--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -1128,6 +1128,34 @@ class AutodetectorTests(TestCase):
         self.assertOperationTypes(changes, 'otherapp', 0, ["RenameField"])
         self.assertOperationAttributes(changes, 'otherapp', 0, 0, old_name="author", new_name="writer")
 
+    def test_rename_model_with_renamed_field_same_model(self):
+        before = [
+            ModelState('test_one', 'MyModel', [
+                ('id', models.AutoField(primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+            ]),
+        ]
+        after = [
+            ModelState('test_one', 'MyRenamedModel', [
+                ('id', models.AutoField(primary_key=True)),
+                ('new_name', models.CharField(max_length=255)),
+            ]),
+        ]
+        changes = self.get_changes(
+            before,
+            after,
+            MigrationQuestioner({'ask_rename_model': True, 'ask_rename': True}),
+        )
+        self.assertNumberMigrations(changes, 'test_one', 1)
+        self.assertOperationTypes(changes, 'test_one', 0, ['RenameModel', 'RenameField'])
+        self.assertOperationAttributes(
+            changes, 'test_one', 0, 0, old_name='MyModel', new_name='MyRenamedModel',
+        )
+        self.assertOperationAttributes(
+            changes, 'test_one', 0, 1,
+            model_name='myrenamedmodel', old_name='name', new_name='new_name',
+        )
+
     def test_rename_model_with_fks_in_different_position(self):
         """
         #24537 - The order of fields in a model does not influence


### PR DESCRIPTION
## Summary
- use the renamed model key when inspecting the target state during field rename detection
- add a regression test covering renaming a model and one of its fields in the same migration step

## Observed failure
```
$ python manage.py makemigrations
Did you rename the test_one.MyModel model to MyModel2? [y/N] y
Traceback (most recent call last):
  File "manage.py", line 22, in <module>
    main()
  File "manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/django/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/django/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/django/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/django/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/django/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/django/django/core/management/commands/makemigrations.py", line 172, in handle
    changes = autodetector.changes(
  File "/django/django/db/migrations/autodetector.py", line 43, in changes
    changes = self._detect_changes(convert_apps, graph)
  File "/django/django/db/migrations/autodetector.py", line 182, in _detect_changes
    self.generate_renamed_fields()
  File "/django/django/db/migrations/autodetector.py", line 823, in generate_renamed_fields
    new_model_state = self.to_state.models[app_label, old_model_name]
KeyError: ('test_one', 'mymodel')
```

## Reproduction steps
1. Create an app with a model `MyModel` containing a `name` field.
2. Rename the model to `MyModel2` and the `name` field to `new_name` in one `makemigrations` run.
3. Answer "Yes" when prompted to confirm the renames.
4. Without this patch, the autodetector looks up the renamed model by its old key and raises the `KeyError` shown above.

## Testing
- `cd tests && python ../tests/runtests.py migrations`
- `flake8 django/db/migrations/autodetector.py tests/migrations/test_autodetector.py`

## Issue
- Closes #486