### PR TITLE
fix: swev-id: django__django-15382 preserve negated empty exists filters

### DIFF
--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -1211,13 +1211,18 @@ class Exists(Subquery):
 
     def as_sql(self, compiler, connection, template=None, **extra_context):
         query = self.query.exists(using=connection.alias)
-        sql, params = super().as_sql(
-            compiler,
-            connection,
-            template=template,
-            query=query,
-            **extra_context,
-        )
+        try:
+            sql, params = super().as_sql(
+                compiler,
+                connection,
+                template=template,
+                query=query,
+                **extra_context,
+            )
+        except EmptyResultSet:
+            if self.negated:
+                return '1 = 1', ()
+            raise
         if self.negated:
             sql = 'NOT {}'.format(sql)
         return sql, params

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -857,6 +857,12 @@ class BasicExpressionsTests(TestCase):
         self.gmbh.save()
         self.assertCountEqual(Employee.objects.filter(Q(Exists(is_poc))), [self.max])
 
+    def test_negated_empty_exists_does_not_clear_where(self):
+        base_qs = Company.objects.filter(num_employees__gt=10).order_by('name')
+        expected = list(base_qs)
+        filtered = base_qs.filter(~Exists(Company.objects.none())).order_by('name')
+        self.assertSequenceEqual(filtered, expected)
+
 
 class IterableLookupInnerExpressionsTests(TestCase):
     @classmethod


### PR DESCRIPTION
## Summary
- handle EmptyResultSet when compiling negated Exists() subqueries so other WHERE conditions remain intact
- add regression test covering ~Exists(qs.none()) to ensure filters are preserved

## Issue
- Fixes #487

## Reproduction Steps
1. PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py expressions.tests.BasicExpressionsTests.test_negated_empty_exists_does_not_clear_where --parallel=1

## Observed Failure
```
FAIL: test_negated_empty_exists_does_not_clear_where (expressions.tests.BasicExpressionsTests.test_negated_empty_exists_does_not_clear_where)
AssertionError: Sequences differ: <QuerySet []> != [<Company: Example Inc.>, <Company: Test GmbH>]
```

## Fix & Tests
- return a tautology for negated Exists() when the subquery raises EmptyResultSet; re-raise otherwise
- regression test ensures ~Exists(qs.none()) preserves prior filters
- PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py expressions.tests.BasicExpressionsTests.test_negated_empty_exists_does_not_clear_where --parallel=1
- PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py expressions --parallel=1
- PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages flake8 tests/expressions/tests.py django/db/models/expressions.py