### PR TITLE
swev-id: django__django-15467 respect admin radio empty label overrides

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -269,7 +269,8 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
                         "class": get_ul_class(self.radio_fields[db_field.name]),
                     }
                 )
-                kwargs["empty_label"] = _("None") if db_field.blank else None
+                if "empty_label" not in kwargs:
+                    kwargs["empty_label"] = _("None") if db_field.blank else None
 
         if "queryset" not in kwargs:
             queryset = self.get_field_queryset(db, db_field, request)

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -699,6 +699,41 @@ class ModelAdminTests(TestCase):
             ["extra", "transport", "id", "DELETE", "main_band"],
         )
 
+    def test_radio_fields_foreignkey_respects_empty_label_string(self):
+        class ConcertAdmin(ModelAdmin):
+            radio_fields = {"opening_band": VERTICAL}
+
+            def formfield_for_foreignkey(self, db_field, request, **kwargs):
+                if db_field.name == "opening_band":
+                    kwargs["empty_label"] = "—Select—"
+                return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+        admin_form = ConcertAdmin(Concert, self.site).get_form(request)
+        opening_band_field = admin_form.base_fields["opening_band"]
+
+        self.assertIsInstance(opening_band_field.widget.widget, AdminRadioSelect)
+        self.assertEqual(
+            list(opening_band_field.widget.choices)[0], ("", "—Select—")
+        )
+
+    def test_radio_fields_foreignkey_respects_empty_label_none(self):
+        class ConcertAdmin(ModelAdmin):
+            radio_fields = {"opening_band": VERTICAL}
+
+            def formfield_for_foreignkey(self, db_field, request, **kwargs):
+                if db_field.name == "opening_band":
+                    kwargs["empty_label"] = None
+                return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+        admin_form = ConcertAdmin(Concert, self.site).get_form(request)
+        opening_band_field = admin_form.base_fields["opening_band"]
+
+        self.assertIsInstance(opening_band_field.widget.widget, AdminRadioSelect)
+        self.assertEqual(
+            list(opening_band_field.widget.choices),
+            [(self.band.id, "The Doors")],
+        )
+
     def test_log_actions(self):
         ma = ModelAdmin(Band, self.site)
         mock_request = MockRequest()


### PR DESCRIPTION
## Summary
- ensure `BaseModelAdmin` keeps custom `empty_label` for radio `ForeignKey` widgets
- add regression coverage for string and `None` empty labels on admin radio fields

## Testing
- Before fix:
  - `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv311/bin/tox -e py3 -- modeladmin.tests.ModelAdminTests.test_radio_fields_foreignkey_respects_empty_label_string`
    ```
    FAIL: test_radio_fields_foreignkey_respects_empty_label_string
    AssertionError: Tuples differ: ('', 'None') != ('', '—Select—')
    ```
  - `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv311/bin/tox -e py3 -- modeladmin.tests.ModelAdminTests.test_radio_fields_foreignkey_respects_empty_label_none`
    ```
    FAIL: test_radio_fields_foreignkey_respects_empty_label_none
    AssertionError: Lists differ: [('', 'None'), (<django.forms.models.ModelChoiceIteratorValue object at ...>, 'The Doors')] != [(1, 'The Doors')]
    ```
- After fix:
  - `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv311/bin/tox -e py3 -- modeladmin.tests.ModelAdminTests.test_radio_fields_foreignkey_respects_empty_label_string`
  - `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv311/bin/tox -e py3 -- modeladmin.tests.ModelAdminTests.test_radio_fields_foreignkey_respects_empty_label_none`
  - `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv311/bin/tox -e py3 -- modeladmin.tests`
  - `.venv311/bin/flake8 django/contrib/admin/options.py tests/modeladmin/tests.py`

Fixes #491