### PR TITLE
swev-id: django__django-15499 - fold CreateModel + AlterModelManagers

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -171,6 +171,19 @@ class CreateModel(ModelOperation):
                 ),
             ]
         elif (
+            isinstance(operation, AlterModelManagers)
+            and self.name_lower == operation.name_lower
+        ):
+            return [
+                CreateModel(
+                    self.name,
+                    fields=self.fields,
+                    options=self.options,
+                    bases=self.bases,
+                    managers=list(operation.managers),
+                ),
+            ]
+        elif (
             isinstance(operation, AlterTogetherOptionOperation)
             and self.name_lower == operation.name_lower
         ):

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -165,6 +165,115 @@ class OptimizerTests(SimpleTestCase):
             ],
         )
 
+    def test_create_alter_model_managers(self):
+        managers = [("featured", EmptyManager())]
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel("Foo", fields=[]),
+                migrations.AlterModelManagers(name="Foo", managers=managers),
+            ],
+            [
+                migrations.CreateModel(
+                    "Foo",
+                    fields=[],
+                    managers=managers,
+                ),
+            ],
+        )
+
+    def test_create_alter_model_managers_multiple(self):
+        original_managers = [("old", EmptyManager())]
+        first_managers = [("primary", EmptyManager())]
+        final_managers = [("secondary", EmptyManager())]
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel(
+                    "Foo",
+                    fields=[],
+                    managers=original_managers,
+                ),
+                migrations.AlterModelManagers(name="Foo", managers=first_managers),
+                migrations.AlterModelManagers(name="Foo", managers=final_managers),
+            ],
+            [
+                migrations.CreateModel(
+                    "Foo",
+                    fields=[],
+                    managers=final_managers,
+                ),
+            ],
+        )
+
+    def test_create_alter_model_managers_identity(self):
+        managers = [("objects", EmptyManager())]
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel("Foo", fields=[], managers=managers),
+                migrations.AlterModelManagers(name="Foo", managers=managers),
+            ],
+            [
+                migrations.CreateModel(
+                    "Foo",
+                    fields=[],
+                    managers=managers,
+                ),
+            ],
+        )
+
+    def test_create_proxy_alter_model_managers(self):
+        managers = [("objects", EmptyManager())]
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel(
+                    "FooProxy",
+                    fields=[],
+                    options={"proxy": True},
+                    bases=(UnicodeModel,),
+                ),
+                migrations.AlterModelManagers(name="FooProxy", managers=managers),
+            ],
+            [
+                migrations.CreateModel(
+                    "FooProxy",
+                    fields=[],
+                    options={"proxy": True},
+                    bases=(UnicodeModel,),
+                    managers=managers,
+                ),
+            ],
+        )
+
+    def test_create_alter_model_managers_then_alter_options(self):
+        managers = [("objects", EmptyManager())]
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel(
+                    "Foo",
+                    fields=[("name", models.CharField(max_length=255))],
+                    options={"verbose_name": "Foo"},
+                ),
+                migrations.AlterModelManagers(name="Foo", managers=managers),
+                migrations.AlterModelOptions(
+                    name="Foo",
+                    options={
+                        "verbose_name": "Foo",
+                        "verbose_name_plural": "Foos",
+                    },
+                ),
+            ],
+            [
+                migrations.CreateModel(
+                    "Foo",
+                    fields=[("name", models.CharField(max_length=255))],
+                    options={
+                        "verbose_name": "Foo",
+                        "verbose_name_plural": "Foos",
+                    },
+                    managers=managers,
+                ),
+            ],
+        )
+
     def _test_create_alter_foo_delete_model(self, alter_foo):
         """
         CreateModel, AlterModelTable, AlterUniqueTogether/AlterIndexTogether/


### PR DESCRIPTION
Fixes #492

## Observed failure (pre-fix)
```
FAIL: test_create_alter_model_managers (migrations.test_optimizer.OptimizerTests.test_create_alter_model_managers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/migrations/test_optimizer.py", line 170, in test_create_alter_model_managers
    self.assertOptimizesTo(
  File "/workspace/django/tests/migrations/test_optimizer.py", line 31, in assertOptimizesTo
    self.assertEqual(expected, result)
AssertionError: Lists differ: ["migrations.CreateModel(\n    name='Foo',\n    fields=[\n    ],\n)"] != ["migrations.CreateModel(\n    name='Foo',\n    fields=[\n    ],\n)", "migrations.AlterModelManagers(\n    name='Foo',\n    managers=[\n        ('featured', migrations.models.EmptyManager()),\n    ],\n)"]
```

## Reproduction
1. tox -e py3 -- migrations.test_optimizer.OptimizerTests.test_create_alter_model_managers

## Summary
- extend CreateModel.reduce() to fold AlterModelManagers for the same model
- copy manager definitions when folding to avoid shared mutable state
- add optimizer coverage for manager folding, multiple updates, identity, proxy models, and option chaining
- verified migrations optimizer suite and flake8 on touched files