### PR TITLE
Fix JSONField has_key/has_keys/has_any_keys for numeric string keys (swev-id: django__django-15503)

### DIFF
--- a/django/db/backends/base/features.py
+++ b/django/db/backends/base/features.py
@@ -318,6 +318,8 @@ class BaseDatabaseFeatures:
     json_key_contains_list_matching_requires_list = False
     # Does the backend support JSONObject() database function?
     has_json_object_function = True
+    # Does the backend support negative JSON array indexing?
+    supports_json_negative_indexing = True
 
     # Does the backend support column collations?
     supports_collation_on_charfield = True

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import json
 from importlib import import_module
 
 import sqlparse
@@ -342,6 +343,35 @@ class BaseDatabaseOperations:
             for statement in sqlparse.split(sql)
             if statement
         ]
+
+    def format_json_path_numeric_index(self, num):
+        """
+        Hook for backends to customize array indexing in JSON paths.
+        """
+        return "[%s]" % num
+
+    def compile_json_path(self, key_transforms, include_root=True):
+        """
+        Hook for backends to customize all aspects of JSON path construction.
+        """
+        path = ["$"] if include_root else []
+        for key_transform in key_transforms:
+            try:
+                num = int(key_transform)
+            except (TypeError, ValueError):  # Non-integer.
+                path.append(".")
+                path.append(json.dumps(key_transform))
+            else:
+                if (
+                    num < 0
+                    and not self.connection.features.supports_json_negative_indexing
+                ):
+                    raise NotSupportedError(
+                        "Using negative JSON array indices is not supported on this "
+                        "database backend."
+                    )
+                path.append(self.format_json_path_numeric_index(num))
+        return "".join(path)
 
     def process_clob(self, value):
         """

--- a/django/db/backends/mysql/features.py
+++ b/django/db/backends/mysql/features.py
@@ -48,6 +48,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_order_by_nulls_modifier = False
     order_by_nulls_first = True
     supports_logical_xor = True
+    supports_json_negative_indexing = False
 
     @cached_property
     def minimum_database_version(self):

--- a/django/db/backends/oracle/features.py
+++ b/django/db/backends/oracle/features.py
@@ -74,6 +74,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     }
     test_now_utc_template = "CURRENT_TIMESTAMP AT TIME ZONE 'UTC'"
 
+    @cached_property
+    def supports_json_negative_indexing(self):
+        return self.connection.oracle_version >= (21,)
+
     django_test_skips = {
         "Oracle doesn't support SHA224.": {
             "db_functions.text.test_sha224.SHA224Tests.test_basic",

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -126,19 +126,6 @@ class JSONField(CheckFieldDefaultMixin, Field):
         )
 
 
-def compile_json_path(key_transforms, include_root=True):
-    path = ["$"] if include_root else []
-    for key_transform in key_transforms:
-        try:
-            num = int(key_transform)
-        except ValueError:  # non-integer
-            path.append(".")
-            path.append(json.dumps(key_transform))
-        else:
-            path.append("[%s]" % num)
-    return "".join(path)
-
-
 class DataContains(PostgresOperatorLookup):
     lookup_name = "contains"
     postgres_operator = "@>"
@@ -172,44 +159,49 @@ class ContainedBy(PostgresOperatorLookup):
 class HasKeyLookup(PostgresOperatorLookup):
     logical_operator = None
 
-    def as_sql(self, compiler, connection, template=None):
-        # Process JSON path from the left-hand side.
+    def _compile_json_paths(self, compiler, connection):
         if isinstance(self.lhs, KeyTransform):
-            lhs, lhs_params, lhs_key_transforms = self.lhs.preprocess_lhs(
+            lhs_sql, lhs_params, lhs_key_transforms = self.lhs.preprocess_lhs(
                 compiler, connection
             )
-            lhs_json_path = compile_json_path(lhs_key_transforms)
+            lhs_json_path = connection.ops.compile_json_path(lhs_key_transforms)
         else:
-            lhs, lhs_params = self.process_lhs(compiler, connection)
+            lhs_sql, lhs_params = self.process_lhs(compiler, connection)
             lhs_json_path = "$"
-        sql = template % lhs
-        # Process JSON path from the right-hand side.
+
         rhs = self.rhs
-        rhs_params = []
         if not isinstance(rhs, (list, tuple)):
             rhs = [rhs]
+
         treat_numeric_as_string = getattr(
             self, "_treat_numeric_keys_as_strings", True
         )
+        json_paths = []
         for key in rhs:
             if isinstance(key, KeyTransform):
                 *_, rhs_key_transforms = key.preprocess_lhs(compiler, connection)
             else:
                 rhs_key_transforms = [str(key)]
+            rhs_key_transforms = [str(part) for part in rhs_key_transforms]
             prefix_transforms = rhs_key_transforms[:-1]
-            final_key = str(rhs_key_transforms[-1])
-            prefix_path = compile_json_path(prefix_transforms, include_root=False)
+            final_key = rhs_key_transforms[-1]
+            prefix_path = connection.ops.compile_json_path(
+                prefix_transforms, include_root=False
+            )
             final_leg = self._compile_final_leg(
                 connection, final_key, treat_numeric_as_string
             )
-            json_path = f"{lhs_json_path}{prefix_path}{final_leg}"
-            if connection.vendor == "oracle":
-                json_path = self._escape_oracle_percent(json_path)
-            rhs_params.append(json_path)
-        # Add condition for each key.
+            json_paths.append(f"{lhs_json_path}{prefix_path}{final_leg}")
+        return lhs_sql, lhs_params, json_paths
+
+    def as_sql(self, compiler, connection, template=None):
+        lhs_sql, lhs_params, json_paths = self._compile_json_paths(
+            compiler, connection
+        )
+        sql = template % lhs_sql
         if self.logical_operator:
-            sql = "(%s)" % self.logical_operator.join([sql] * len(rhs_params))
-        return sql, tuple(lhs_params) + tuple(rhs_params)
+            sql = "(%s)" % self.logical_operator.join([sql] * len(json_paths))
+        return sql, tuple(lhs_params) + tuple(json_paths)
 
     def as_mysql(self, compiler, connection):
         return self.as_sql(
@@ -217,12 +209,20 @@ class HasKeyLookup(PostgresOperatorLookup):
         )
 
     def as_oracle(self, compiler, connection):
-        sql, params = self.as_sql(
-            compiler, connection, template="JSON_EXISTS(%s, '%%s')"
+        lhs_sql, lhs_params, json_paths = self._compile_json_paths(
+            compiler, connection
         )
-        # Add paths directly into SQL because path expressions cannot be passed
-        # as bind variables on Oracle.
-        return sql % tuple(params), []
+        template = "JSON_EXISTS(%s, '%s')"
+        sql_parts = []
+        params = []
+        for path in json_paths:
+            sql_parts.append(template % (lhs_sql, path.replace("'", "''")))
+            params.extend(lhs_params)
+        if self.logical_operator:
+            sql = "(%s)" % self.logical_operator.join(sql_parts)
+        else:
+            sql = "".join(sql_parts)
+        return sql, tuple(params)
 
     def as_postgresql(self, compiler, connection):
         if isinstance(self.rhs, KeyTransform):
@@ -238,30 +238,12 @@ class HasKeyLookup(PostgresOperatorLookup):
         )
 
     def _compile_final_leg(self, connection, key, treat_numeric_as_string):
+        key = str(key)
         if not treat_numeric_as_string:
-            return compile_json_path([key], include_root=False)
+            return connection.ops.compile_json_path([key], include_root=False)
         if connection.vendor == "mysql":
             return f"[{json.dumps(key)}]"
         return ".%s" % json.dumps(key)
-
-    @staticmethod
-    def _escape_oracle_percent(path):
-        result = []
-        i = 0
-        length = len(path)
-        while i < length:
-            char = path[i]
-            if char == "%":
-                if i + 1 < length and path[i + 1] == "%":
-                    result.append("%%")
-                    i += 2
-                else:
-                    result.append("%%")
-                    i += 1
-                continue
-            result.append(char)
-            i += 1
-        return "".join(result)
 
 
 class HasKey(HasKeyLookup):
@@ -355,12 +337,12 @@ class KeyTransform(Transform):
 
     def as_mysql(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         return "JSON_EXTRACT(%s, %%s)" % lhs, tuple(params) + (json_path,)
 
     def as_oracle(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         return (
             "COALESCE(JSON_QUERY(%s, '%s'), JSON_VALUE(%s, '%s'))"
             % ((lhs, json_path) * 2)
@@ -379,7 +361,7 @@ class KeyTransform(Transform):
 
     def as_sqlite(self, compiler, connection):
         lhs, params, key_transforms = self.preprocess_lhs(compiler, connection)
-        json_path = compile_json_path(key_transforms)
+        json_path = connection.ops.compile_json_path(key_transforms)
         datatype_values = ",".join(
             [repr(datatype) for datatype in connection.ops.jsonfield_datatype_values]
         )

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -188,18 +188,24 @@ class HasKeyLookup(PostgresOperatorLookup):
         rhs_params = []
         if not isinstance(rhs, (list, tuple)):
             rhs = [rhs]
+        treat_numeric_as_string = getattr(
+            self, "_treat_numeric_keys_as_strings", True
+        )
         for key in rhs:
             if isinstance(key, KeyTransform):
                 *_, rhs_key_transforms = key.preprocess_lhs(compiler, connection)
             else:
-                rhs_key_transforms = [key]
-            rhs_params.append(
-                "%s%s"
-                % (
-                    lhs_json_path,
-                    compile_json_path(rhs_key_transforms, include_root=False),
-                )
+                rhs_key_transforms = [str(key)]
+            prefix_transforms = rhs_key_transforms[:-1]
+            final_key = str(rhs_key_transforms[-1])
+            prefix_path = compile_json_path(prefix_transforms, include_root=False)
+            final_leg = self._compile_final_leg(
+                connection, final_key, treat_numeric_as_string
             )
+            json_path = f"{lhs_json_path}{prefix_path}{final_leg}"
+            if connection.vendor == "oracle":
+                json_path = self._escape_oracle_percent(json_path)
+            rhs_params.append(json_path)
         # Add condition for each key.
         if self.logical_operator:
             sql = "(%s)" % self.logical_operator.join([sql] * len(rhs_params))
@@ -230,6 +236,32 @@ class HasKeyLookup(PostgresOperatorLookup):
         return self.as_sql(
             compiler, connection, template="JSON_TYPE(%s, %%s) IS NOT NULL"
         )
+
+    def _compile_final_leg(self, connection, key, treat_numeric_as_string):
+        if not treat_numeric_as_string:
+            return compile_json_path([key], include_root=False)
+        if connection.vendor == "mysql":
+            return f"[{json.dumps(key)}]"
+        return ".%s" % json.dumps(key)
+
+    @staticmethod
+    def _escape_oracle_percent(path):
+        result = []
+        i = 0
+        length = len(path)
+        while i < length:
+            char = path[i]
+            if char == "%":
+                if i + 1 < length and path[i + 1] == "%":
+                    result.append("%%")
+                    i += 2
+                else:
+                    result.append("%%")
+                    i += 1
+                continue
+            result.append(char)
+            i += 1
+        return "".join(result)
 
 
 class HasKey(HasKeyLookup):
@@ -387,10 +419,12 @@ class KeyTransformTextLookupMixin:
 class KeyTransformIsNull(lookups.IsNull):
     # key__isnull=False is the same as has_key='key'
     def as_oracle(self, compiler, connection):
-        sql, params = HasKey(
+        lookup = HasKey(
             self.lhs.lhs,
             self.lhs.key_name,
-        ).as_oracle(compiler, connection)
+        )
+        lookup._treat_numeric_keys_as_strings = False
+        sql, params = lookup.as_oracle(compiler, connection)
         if not self.rhs:
             return sql, params
         # Column doesn't have a key or IS NULL.
@@ -401,7 +435,9 @@ class KeyTransformIsNull(lookups.IsNull):
         template = "JSON_TYPE(%s, %%s) IS NULL"
         if not self.rhs:
             template = "JSON_TYPE(%s, %%s) IS NOT NULL"
-        return HasKey(self.lhs.lhs, self.lhs.key_name).as_sql(
+        lookup = HasKey(self.lhs.lhs, self.lhs.key_name)
+        lookup._treat_numeric_keys_as_strings = False
+        return lookup.as_sql(
             compiler,
             connection,
             template=template,

--- a/tests/model_fields/test_jsonfield.py
+++ b/tests/model_fields/test_jsonfield.py
@@ -564,16 +564,51 @@ class TestQuerying(TestCase):
                     [obj],
                 )
 
+    def test_has_key_numeric_string(self):
+        obj = NullableJSONModel.objects.create(value={"1111": "value"})
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__has_key="1111"),
+            [obj],
+        )
+
+    def test_has_key_numeric_string_nested(self):
+        obj = NullableJSONModel.objects.create(value={"a": {"1111": "value"}})
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__a__has_key="1111"),
+            [obj],
+        )
+
+    def test_has_key_numeric_string_after_array(self):
+        obj = NullableJSONModel.objects.create(value={"d": [{"1111": "value"}]})
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__d__0__has_key="1111"),
+            [obj],
+        )
+
     def test_has_keys(self):
         self.assertSequenceEqual(
             NullableJSONModel.objects.filter(value__has_keys=["a", "c", "h"]),
             [self.objs[4]],
         )
 
+    def test_has_keys_numeric_string(self):
+        obj = NullableJSONModel.objects.create(value={"a": 1, "1111": 2})
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__has_keys=["a", "1111"]),
+            [obj],
+        )
+
     def test_has_any_keys(self):
         self.assertSequenceEqual(
             NullableJSONModel.objects.filter(value__has_any_keys=["c", "l"]),
             [self.objs[3], self.objs[4], self.objs[6]],
+        )
+
+    def test_has_any_keys_numeric_string(self):
+        obj = NullableJSONModel.objects.create(value={"1111": "value"})
+        self.assertSequenceEqual(
+            NullableJSONModel.objects.filter(value__has_any_keys=["1111", "2222"]),
+            [obj],
         )
 
     @skipUnlessDBFeature("supports_json_field_contains")


### PR DESCRIPTION
## Summary
- ensure has_key/has_keys/has_any_keys build object paths for numeric strings on SQLite/MySQL/Oracle
- keep KeyTransform isnull lookups treating numeric path segments as array indexes
- add regression coverage for numeric string key queries

## Testing
- PYTHONPATH=$PWD:$HOME/.local/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py model_fields.test_jsonfield --parallel=1
- PATH=$HOME/.local/bin:$PATH flake8 django/db/models/fields/json.py tests/model_fields/test_jsonfield.py

Resolves #493

## Observed failure, stack trace, and reproduction steps
This is a reproduction of the issue described in #493: JSONField has_key, has_keys, and has_any_keys lookups don't handle numeric keys on SQLite/MySQL/Oracle.

Problem
When using models.JSONField() has_key lookup with numerical keys on SQLite database it fails to find the keys.

Versions:
- Django: 4.0.3
- Python: 3.9.6 (tags/v3.9.6:db3ff76, Jun 28 2021, 15:26:21) [MSC v.1929 64 bit (AMD64)] on win32
- sqlite3.version: '2.6.0'
- sqlite3.sqlite_version: '3.35.5'

Example:
Database
```
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.sqlite3',
        'NAME': 'db.sqlite3',
    }
}
```
Model
```
class JsonFieldHasKeyTest(models.Model):
    data = models.JSONField()
```
Test
```
from django.test import TestCase
from .models import JsonFieldHasKeyTest
class JsonFieldHasKeyTestCase(TestCase):
    def setUp(self) -> None:
        test = JsonFieldHasKeyTest(data={'foo': 'bar'})
        test2 = JsonFieldHasKeyTest(data={'1111': 'bar'})
        test.save()
        test2.save()
    def test_json_field_has_key(self):
        c1 = JsonFieldHasKeyTest.objects.filter(data__has_key='foo').count()
        c2 = JsonFieldHasKeyTest.objects.filter(data__has_key='1111').count()
        self.assertEqual(c1, 1, "Should have found 1 entry with key 'foo'")
        self.assertEqual(c2, 1, "Should have found 1 entry with key '1111'")
```
Result
```
FAIL: test_json_field_has_key (markers.tests.JsonFieldHasKeyTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
 File "H:\\Files\\Projects\\Electaco\\Webservice\\elecserve\\markers\\tests.py", line 16, in test_json_field_has_key  
    self.assertEqual(c2, 1, "Should have found 1 entry with key '1111'")
AssertionError: 0 != 1 : Should have found 1 entry with key '1111'
```

Additional info
- Reproduced on SQLite, MySQL, and Oracle backends; works on PostgreSQL.

## Task Reference
This PR addresses the task to fix numeric key handling for JSONField lookups in branch `django__django-15503`.