### PR TITLE
Fix loaddata on non-default DB with natural keys traversing FKs (swev-id: django__django-15525)

### DIFF
--- a/django/core/serializers/base.py
+++ b/django/core/serializers/base.py
@@ -336,7 +336,9 @@ def build_instance(Model, data, db):
         and hasattr(default_manager, "get_by_natural_key")
         and hasattr(Model, "natural_key")
     ):
-        natural_key = Model(**data).natural_key()
+        obj = Model(**data)
+        obj._state.db = db
+        natural_key = obj.natural_key()
         try:
             data[Model._meta.pk.attname] = Model._meta.pk.to_python(
                 default_manager.db_manager(db).get_by_natural_key(*natural_key).pk

--- a/tests/multiple_database/models.py
+++ b/tests/multiple_database/models.py
@@ -79,3 +79,34 @@ class UserProfile(models.Model):
 
     class Meta:
         ordering = ("flavor",)
+
+
+class AuthorNKManager(models.Manager):
+    def get_by_natural_key(self, name):
+        return self.get(name=name)
+
+
+class AuthorNK(models.Model):
+    name = models.CharField(max_length=64, unique=True)
+    objects = AuthorNKManager()
+
+    def natural_key(self):
+        return (self.name,)
+
+    natural_key.dependencies = []
+
+
+class BookNKManager(models.Manager):
+    def get_by_natural_key(self, title, author_name):
+        return self.get(title=title, author__name=author_name)
+
+
+class BookNK(models.Model):
+    title = models.CharField(max_length=128)
+    author = models.ForeignKey(AuthorNK, on_delete=models.CASCADE)
+    objects = BookNKManager()
+
+    def natural_key(self):
+        return (self.title, self.author.name)
+
+    natural_key.dependencies = ["multiple_database.AuthorNK"]

--- a/tests/multiple_database/tests.py
+++ b/tests/multiple_database/tests.py
@@ -2,17 +2,20 @@ import datetime
 import pickle
 from io import StringIO
 from operator import attrgetter
+from unittest import mock
 from unittest.mock import Mock
 
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core import management
+from django.core import serializers
+from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS, router, transaction
 from django.db.models import signals
 from django.db.utils import ConnectionRouter
 from django.test import SimpleTestCase, TestCase, override_settings
 
-from .models import Book, Person, Pet, Review, UserProfile
+from .models import AuthorNK, Book, BookNK, Person, Pet, Review, UserProfile
 from .routers import AuthRouter, TestRouter, WriteRouter
 
 
@@ -2529,3 +2532,52 @@ class RelationAssignmentTests(SimpleTestCase):
         profile = UserProfile()
         with self.assertRaisesMessage(ValueError, self.router_prevents_msg):
             user.userprofile = profile
+
+
+class LoaddataNaturalFKDbBindingTests(TestCase):
+    databases = {"default", "other"}
+
+    def test_loaddata_other_db_with_fk_traversal_in_natural_key(self):
+        a_other = AuthorNK.objects.using("other").create(name="Alice")
+        b_other = BookNK.objects.using("other").create(
+            title="Wonderland", author=a_other
+        )
+
+        fixture_json = serializers.serialize(
+            "json",
+            [a_other, b_other],
+            use_natural_foreign_keys=True,
+            use_natural_primary_keys=True,
+        )
+
+        BookNK.objects.using("other").all().delete()
+        AuthorNK.objects.using("other").all().delete()
+
+        self.assertFalse(AuthorNK.objects.using("default").exists())
+        self.assertFalse(BookNK.objects.using("default").exists())
+
+        with mock.patch(
+            "django.core.management.commands.loaddata.sys.stdin",
+            StringIO(fixture_json),
+        ):
+            call_command(
+                "loaddata",
+                "--format=json",
+                "-",
+                database="other",
+                verbosity=0,
+            )
+
+        self.assertTrue(
+            AuthorNK.objects.using("other")
+            .filter(name="Alice")
+            .exists()
+        )
+        self.assertTrue(
+            BookNK.objects.using("other")
+            .filter(title="Wonderland", author__name="Alice")
+            .exists()
+        )
+
+        self.assertFalse(AuthorNK.objects.using("default").exists())
+        self.assertFalse(BookNK.objects.using("default").exists())


### PR DESCRIPTION
## Observed failure and trace
```
AuthorNK.DoesNotExist: AuthorNK matching query does not exist
  File "django/core/serializers/base.py", line 340, in build_instance
    default_manager.db_manager(db).get_by_natural_key(*natural_key).pk
  File "tests/multiple_database/models.py", line 86, in get_by_natural_key
    return self.get(name=name)
```
When `loaddata` targets `database="other"`, the natural key traversal for `BookNK` instantiates `AuthorNK` without binding it to the "other" connection. The lookup silently falls back to the default database and raises `DoesNotExist`.

## Reproduction steps
1. Create `AuthorNK`/`BookNK` data on the `other` connection and serialize to JSON with `use_natural_foreign_keys=True` and `use_natural_primary_keys=True`.
2. Pipe the fixture into `call_command("loaddata", "--format=json", "-", database="other")`.

## Fix rationale
- Bind the deserialized model instance to the target database (`obj._state.db = db`) before computing its natural key so that foreign key traversal happens on the requested connection.

## Regression coverage
- Added `tests.multiple_database.tests.LoaddataNaturalFKDbBindingTests` to exercise natural key traversal through foreign keys on a non-default database.

## Testing
- PYTHONPATH=$PWD:$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.11 tests/runtests.py multiple_database.tests.LoaddataNaturalFKDbBindingTests --parallel=1
- PYTHONPATH=$HOME/.local/lib/python3.11/site-packages:$HOME/.nix-profile/lib/python3.11/site-packages python3.11 -m flake8 django/core/serializers/base.py tests/multiple_database/models.py tests/multiple_database/tests.py

## Issue
- Closes #497