### PR TITLE
Fix nested prefetch backref deferred fields (swev-id: django__django-15280)

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1762,7 +1762,58 @@ def prefetch_related_objects(model_instances, *related_lookups):
 
             obj_to_fetch = None
             if prefetcher is not None:
-                obj_to_fetch = [obj for obj in obj_list if not is_fetched(obj)]
+                if (level == len(through_attrs) - 1) and (lookup.queryset is not None):
+                    lookup_sig = str(lookup.queryset.query)
+                    required_field_map = lookup.queryset.query.get_loaded_field_names()
+                    to_attr, as_attr = lookup.get_current_to_attr(level)
+
+                    def relation_requires_override(instance):
+                        attr_name = to_attr if as_attr else through_attr
+                        try:
+                            related = getattr(instance, attr_name)
+                        except AttributeError:
+                            return False
+                        if related is None:
+                            return False
+                        if isinstance(related, list):
+                            related_iterable = related
+                        elif hasattr(related, '_meta'):
+                            related_iterable = [related]
+                        else:
+                            cache = getattr(instance, '_prefetched_objects_cache', {})
+                            cached_qs = cache.get(attr_name)
+                            if cached_qs is None:
+                                cached_qs = cache.get(through_attr)
+                            if cached_qs is None or getattr(cached_qs, '_result_cache', None) is None:
+                                return False
+                            related_iterable = cached_qs._result_cache
+                        for rel_obj in related_iterable:
+                            required_fields = required_field_map.get(rel_obj.__class__, set())
+                            if not required_fields:
+                                continue
+                            if any(field in rel_obj.get_deferred_fields() for field in required_fields):
+                                return True
+                        return False
+
+                    fetched_objs = []
+                    unfetched_objs = []
+                    for obj in obj_list:
+                        if is_fetched(obj):
+                            signatures = getattr(obj, '_prefetched_queryset_signatures', {})
+                            signature = signatures.get(through_attr)
+                            sig_value = sig_marker = None
+                            if isinstance(signature, tuple):
+                                sig_value, sig_marker = signature
+                            elif signature is not None:
+                                sig_value = signature
+                            if sig_value == lookup_sig and sig_marker == through_attr and not relation_requires_override(obj):
+                                continue
+                            fetched_objs.append(obj)
+                        else:
+                            unfetched_objs.append(obj)
+                    obj_to_fetch = obj_list if fetched_objs else unfetched_objs
+                else:
+                    obj_to_fetch = [obj for obj in obj_list if not is_fetched(obj)]
 
             if obj_to_fetch:
                 obj_list, additional_lookups = prefetch_one_level(
@@ -1928,8 +1979,21 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
             msg = 'to_attr={} conflicts with a field on the {} model.'
             raise ValueError(msg.format(to_attr, model.__name__))
 
-    # Whether or not we're prefetching the last part of the lookup.
-    leaf = len(lookup.prefetch_through.split(LOOKUP_SEP)) - 1 == level
+    through_attrs = lookup.prefetch_through.split(LOOKUP_SEP)
+    leaf = len(through_attrs) - 1 == level
+    current_through_attr = through_attrs[level]
+    lookup_sig = None
+    if leaf and lookup.queryset is not None:
+        lookup_sig = str(lookup.queryset.query)
+
+    def set_signature(target_obj):
+        if lookup_sig is None:
+            return
+        signatures = getattr(target_obj, '_prefetched_queryset_signatures', None)
+        if signatures is None:
+            signatures = {}
+            setattr(target_obj, '_prefetched_queryset_signatures', signatures)
+        signatures[current_through_attr] = (lookup_sig, current_through_attr)
 
     for obj in instances:
         instance_attr_val = instance_attr(obj)
@@ -1949,6 +2013,9 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
                 # cache_name does not point to a descriptor. Store the value of
                 # the field in the object's field cache.
                 obj._state.fields_cache[cache_name] = val
+            if val is not None:
+                set_signature(val)
+            set_signature(obj)
         else:
             if as_attr:
                 setattr(obj, to_attr, vals)
@@ -1963,6 +2030,9 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
                 # since we have merged this into the current work.
                 qs._prefetch_done = True
                 obj._prefetched_objects_cache[cache_name] = qs
+                if lookup_sig is not None:
+                    qs._prefetched_queryset_signature = (lookup_sig, current_through_attr)
+            set_signature(obj)
     return all_related_objects, additional_lookups
 
 

--- a/tests/prefetch_related/test_deferred_prefetch_backref.py
+++ b/tests/prefetch_related/test_deferred_prefetch_backref.py
@@ -8,7 +8,7 @@ from django.test.utils import CaptureQueriesContext, isolate_apps
 
 
 class RegressConfig(AppConfig):
-    name = 'tests.prefetch_related.test_deferred_prefetch_backref'
+    name = 'prefetch_related.test_deferred_prefetch_backref'
     label = 'regress'
     path = str(Path(__file__).resolve().parent)
 
@@ -32,7 +32,7 @@ class DeferredNestedPrefetchTests(TransactionTestCase):
                 for model in models:
                     editor.delete_model(model)
 
-    @isolate_apps('tests.prefetch_related.test_deferred_prefetch_backref.RegressConfig')
+    @isolate_apps('prefetch_related.test_deferred_prefetch_backref.RegressConfig')
     def test_onetoone_nested_prefetch_backref_deferred(self):
         class SimpleUser(models.Model):
             email = models.CharField(max_length=255)
@@ -73,7 +73,7 @@ class DeferredNestedPrefetchTests(TransactionTestCase):
             _ = inner_user.email
         self.assertNotIn('kind', inner_user.get_deferred_fields())
 
-    @isolate_apps('tests.prefetch_related.test_deferred_prefetch_backref.RegressConfig')
+    @isolate_apps('prefetch_related.test_deferred_prefetch_backref.RegressConfig')
     def test_foreignkey_nested_prefetch_backref_deferred(self):
         class SimpleUser(models.Model):
             email = models.CharField(max_length=255)

--- a/tests/prefetch_related/test_deferred_prefetch_backref.py
+++ b/tests/prefetch_related/test_deferred_prefetch_backref.py
@@ -30,10 +30,7 @@ class DeferredNestedPrefetchTests(TransactionTestCase):
         with connection.constraint_checks_disabled():
             with connection.schema_editor(atomic=False) as editor:
                 for model in models:
-                    try:
-                        editor.delete_model(model)
-                    except Exception:
-                        pass
+                    editor.delete_model(model)
 
     @isolate_apps('tests.prefetch_related.test_deferred_prefetch_backref.RegressConfig')
     def test_onetoone_nested_prefetch_backref_deferred(self):

--- a/tests/prefetch_related/test_deferred_prefetch_backref.py
+++ b/tests/prefetch_related/test_deferred_prefetch_backref.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+from django.apps import AppConfig
+from django.db import connection, models
+from django.db.models import Prefetch
+from django.test import TransactionTestCase
+from django.test.utils import CaptureQueriesContext, isolate_apps
+
+
+class RegressConfig(AppConfig):
+    name = 'tests.prefetch_related.test_deferred_prefetch_backref'
+    label = 'regress'
+    path = str(Path(__file__).resolve().parent)
+
+    def import_models(self):
+        # Models are defined dynamically within isolated tests.
+        self.models = self.apps.all_models[self.label]
+
+
+class DeferredNestedPrefetchTests(TransactionTestCase):
+    available_apps = []
+
+    def _create_models(self, *models):
+        with connection.constraint_checks_disabled():
+            with connection.schema_editor(atomic=False) as editor:
+                for model in models:
+                    editor.create_model(model)
+
+    def _delete_models(self, *models):
+        with connection.constraint_checks_disabled():
+            with connection.schema_editor(atomic=False) as editor:
+                for model in models:
+                    try:
+                        editor.delete_model(model)
+                    except Exception:
+                        pass
+
+    @isolate_apps('tests.prefetch_related.test_deferred_prefetch_backref.RegressConfig')
+    def test_onetoone_nested_prefetch_backref_deferred(self):
+        class SimpleUser(models.Model):
+            email = models.CharField(max_length=255)
+            KIND_CHOICES = ((0, 'basic'), (1, 'pro'))
+            kind = models.IntegerField(choices=KIND_CHOICES, default=0)
+
+            class Meta:
+                app_label = 'regress'
+
+        class SimpleProfile(models.Model):
+            full_name = models.CharField(max_length=255)
+            user = models.OneToOneField(SimpleUser, models.CASCADE, related_name='profile')
+
+            class Meta:
+                app_label = 'regress'
+
+        self.addCleanup(self._delete_models, SimpleProfile, SimpleUser)
+        self._create_models(SimpleUser, SimpleProfile)
+
+        u = SimpleUser.objects.create(email='u@example.com', kind=1)
+        SimpleProfile.objects.create(full_name='User One', user=u)
+
+        qs = SimpleUser.objects.only('email').prefetch_related(
+            Prefetch(
+                'profile',
+                queryset=SimpleProfile.objects.prefetch_related(
+                    Prefetch('user', queryset=SimpleUser.objects.only('kind'))
+                ),
+            )
+        )
+        users = list(qs)
+        inner_user = users[0].profile.user
+        # kind should not trigger a query
+        with self.assertNumQueries(0):
+            _ = inner_user.kind
+        # email should be deferred and trigger a query when accessed
+        with self.assertNumQueries(1):
+            _ = inner_user.email
+        self.assertNotIn('kind', inner_user.get_deferred_fields())
+
+    @isolate_apps('tests.prefetch_related.test_deferred_prefetch_backref.RegressConfig')
+    def test_foreignkey_nested_prefetch_backref_deferred(self):
+        class SimpleUser(models.Model):
+            email = models.CharField(max_length=255)
+            KIND_CHOICES = ((0, 'basic'), (1, 'pro'))
+            kind = models.IntegerField(choices=KIND_CHOICES, default=0)
+
+            class Meta:
+                app_label = 'regress'
+
+        class SimpleProfile(models.Model):
+            full_name = models.CharField(max_length=255)
+            user = models.ForeignKey(SimpleUser, models.CASCADE)
+
+            class Meta:
+                app_label = 'regress'
+
+        self.addCleanup(self._delete_models, SimpleProfile, SimpleUser)
+        self._create_models(SimpleUser, SimpleProfile)
+
+        u = SimpleUser.objects.create(email='u@example.com', kind=1)
+        SimpleProfile.objects.create(full_name='User One', user=u)
+
+        qs = SimpleUser.objects.only('email').prefetch_related(
+            Prefetch(
+                'simpleprofile_set',
+                queryset=SimpleProfile.objects.prefetch_related(
+                    Prefetch('user', queryset=SimpleUser.objects.only('kind'))
+                ),
+            )
+        )
+        users = list(qs)
+        with CaptureQueriesContext(connection) as ctx:
+            profiles = list(users[0].simpleprofile_set.all())
+        self.assertEqual(len(ctx.captured_queries), 0)
+
+        p = profiles[0]
+        with self.assertNumQueries(0):
+            _ = p.user.kind
+        with self.assertNumQueries(1):
+            _ = p.user.email
+        self.assertNotIn('kind', p.user.get_deferred_fields())


### PR DESCRIPTION
### Summary
Fix nested prefetch where a leaf Prefetch(queryset=...) back to parent loses the inner queryset projection and triggers an extra SELECT, causing deferred fields to be incorrect.

### Reproduction
See Issue #480 for the original report and expected behavior.
A focused test module is added in `tests/prefetch_related/test_deferred_prefetch_backref.py` that reproduces the issue using `@isolate_apps` with inline models.

### Observed Failure (before fix)
When evaluating:
```python
qs = SimpleUser.objects.only('email').prefetch_related(
    Prefetch(
        'profile',
        queryset=SimpleProfile.objects.prefetch_related(
            Prefetch('user', queryset=SimpleUser.objects.only('kind'))
        ),
    )
)
users = list(qs)
_ = users[0].profile.user.kind
```
An extra SQL query occurs on access to `.kind`:
```
SELECT "tests_user"."id", "tests_user"."kind"
FROM "tests_user"
WHERE "tests_user"."id" = <user_id>
```
This matches the failure: `AssertionError: 1 != 0 : 1 queries executed, 0 expected`.

### Root Cause
The reverse prefetch (`User -> profile`) pre-caches `Profile.user` to the origin `User` instance loaded with `only('email')`. At the next level (`Profile -> user`), the relation is considered already fetched and the explicit inner `Prefetch(queryset=SimpleUser.objects.only('kind'))` is skipped, discarding the intended projection.

### Fix
In `prefetch_related_objects()`, at the leaf level and when `Prefetch` provides an explicit queryset, prefetch for all objects at that level regardless of a pre-cached relation to ensure the projection takes effect and overrides the cached instance.

### Tests
- OneToOne nested prefetch back to parent: assert 0 queries for `users[0].profile.user.kind`; verify deferred fields reflect the inner queryset.
- ForeignKey (`profile_set`) back to user: assert 0 queries when accessing `p.user.kind`.

### Notes
- Behavior change is narrowly scoped to leaf lookups with an explicit queryset. Identity of the related instance may differ across paths, which is acceptable to honor projections.