### PR TITLE
fix(sqlite): ignore choices-only alters (swev-id: django__django-15561)

### DIFF
--- a/django/db/backends/sqlite3/schema.py
+++ b/django/db/backends/sqlite3/schema.py
@@ -173,6 +173,35 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         else:
             super().alter_field(model, old_field, new_field, strict=strict)
 
+    def _field_should_be_altered(self, old_field, new_field):
+        _, old_path, old_args, old_kwargs = old_field.deconstruct()
+        _, new_path, new_args, new_kwargs = new_field.deconstruct()
+        # Don't alter when:
+        # - changing only a field name
+        # - changing an attribute that doesn't affect the schema
+        # - adding only a db_column and the column name is not changed
+        non_database_attrs = [
+            "blank",
+            "choices",
+            "db_column",
+            "editable",
+            "error_messages",
+            "help_text",
+            "limit_choices_to",
+            # Database-level options are not supported, see #21961.
+            "on_delete",
+            "related_name",
+            "related_query_name",
+            "validators",
+            "verbose_name",
+        ]
+        for attr in non_database_attrs:
+            old_kwargs.pop(attr, None)
+            new_kwargs.pop(attr, None)
+        return self.quote_name(old_field.column) != self.quote_name(
+            new_field.column
+        ) or (old_path, old_args, old_kwargs) != (new_path, new_args, new_kwargs)
+
     def _remake_table(
         self, model, create_field=None, delete_field=None, alter_field=None
     ):

--- a/tests/backends/sqlite/tests.py
+++ b/tests/backends/sqlite/tests.py
@@ -168,6 +168,21 @@ class SchemaTests(TransactionTestCase):
             self.assertFalse(constraint_checks_enabled())
         self.assertTrue(constraint_checks_enabled())
 
+    def test_alter_field_choices_noop(self):
+        new_field = CharField(
+            max_length=255,
+            unique=True,
+            choices=[("A", "A"), ("B", "B")],
+        )
+        new_field.set_attributes_from_name("name")
+        with connection.schema_editor(collect_sql=True) as editor:
+            editor.alter_field(
+                Author,
+                Author._meta.get_field("name"),
+                new_field,
+            )
+        self.assertEqual(editor.collected_sql, [])
+
     @skipIfDBFeature("supports_atomic_references_rename")
     def test_field_rename_inside_atomic_block(self):
         """


### PR DESCRIPTION
## Problem
- Altering a CharField on SQLite that only changes `choices` currently triggers a table rebuild.
- These unnecessary rebuilds slow migrations and risk lock contention even though the schema is unchanged.

## Fix
- Override `_field_should_be_altered()` in the SQLite schema editor to treat `choices` as a non-database attribute so choices-only updates are skipped.
- Add a regression test verifying `alter_field()` collects no SQL for a choices-only update.

## Issue
- Closes #499

## Observed failure (pre-fix)
```text
AssertionError: Lists differ: ['CREATE TABLE "new__backends_author" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "name" varchar(255) NOT NULL UNIQUE);', 'INSERT INTO "new__backends_author" ("id", "name") SELECT "id", "name" FROM "backends_author";', 'DROP TABLE "backends_author";', 'ALTER TABLE "new__backends_author" RENAME TO "backends_author";'] != []

CREATE TABLE "new__backends_author" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "name" varchar(255) NOT NULL UNIQUE);
INSERT INTO "new__backends_author" ("id", "name") SELECT "id", "name" FROM "backends_author";
DROP TABLE "backends_author";
ALTER TABLE "new__backends_author" RENAME TO "backends_author";
```

### Traceback (pre-fix)
```text
Traceback (most recent call last):
  File "django/tests/backends/sqlite/tests.py", line 214, in test_alter_field_choices_noop
    self.assertEqual(editor.collected_sql, [])
AssertionError: Lists differ: [...SQL statements...] != []
```

## Reproduction
- `./runtests.py backends.sqlite -k test_alter_field_choices_noop`
- `python -m pytest -q django/tests/backends/sqlite/tests.py::SchemaTests::test_alter_field_choices_noop`

Reference: internal task swev-id: django__django-15561.