### PR TITLE
swev-id: django__django-15554 Fix FilteredRelation join reuse

### DIFF
--- a/django/db/models/sql/datastructures.py
+++ b/django/db/models/sql/datastructures.py
@@ -162,8 +162,16 @@ class Join:
         return hash(self.identity)
 
     def equals(self, other):
-        # Ignore filtered_relation in equality check.
-        return self.identity[:-1] == other.identity[:-1]
+        if self.identity[:-1] != other.identity[:-1]:
+            return False
+        if self.filtered_relation is None or other.filtered_relation is None:
+            return True
+        return (
+            self.filtered_relation.relation_name
+            == other.filtered_relation.relation_name
+            and self.filtered_relation.condition
+            == other.filtered_relation.condition
+        )
 
     def demote(self):
         new = self.relabeled_clone({})

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -164,6 +164,27 @@ class FilteredRelationTests(TestCase):
             [self.author1, self.author2],
         )
 
+    def test_filtered_relations_with_distinct_conditions(self):
+        qs = (
+            Author.objects.alias(
+                books_alice=FilteredRelation(
+                    "book",
+                    condition=Q(book__title__icontains="alice"),
+                ),
+                books_jane=FilteredRelation(
+                    "book",
+                    condition=Q(book__title__icontains="jane"),
+                ),
+            )
+            .annotate(
+                alice_count=Count("books_alice"),
+                jane_count=Count("books_jane"),
+            )
+            .order_by("pk")
+            .values_list("alice_count", "jane_count")
+        )
+        self.assertEqual(list(qs), [(2, 0), (0, 2)])
+
     def test_with_join(self):
         self.assertSequenceEqual(
             Author.objects.annotate(


### PR DESCRIPTION
## Summary
- prevent Join.equals() from collapsing filtered joins with different FilteredRelation conditions
- add regression coverage for multiple FilteredRelation annotations on the same path

## Reproduction
1. Ensure dependencies are available: `nix profile install nixpkgs#python311 nixpkgs#python311Packages.asgiref nixpkgs#python311Packages.sqlparse nixpkgs#python311Packages.pytz`
2. From the repo root, run:
   ```
   PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages \
   DJANGO_SETTINGS_MODULE=tests.test_sqlite \
   python3.11 tests/runtests.py \
   filtered_relation.tests.FilteredRelationTests.test_filtered_relations_with_distinct_conditions \
   --parallel=1
   ```

## Observed failure
```
FAIL: test_filtered_relations_with_distinct_conditions (filtered_relation.tests.FilteredRelationTests.test_filtered_relations_with_distinct_conditions)
...
AssertionError: Lists differ: [(2, 2), (0, 0)] != [(2, 0), (0, 2)]
```

## Fix
- treat joins with FilteredRelation metadata as equal only when both the relation name and condition match; still allow reuse when either side lacks FilteredRelation so lookup resolution continues to work
- add a regression test ensuring two distinct FilteredRelation annotations on the same relation path each retain their own join

Fixes #498