### PR TITLE
Fix autoreload regression for empty template DIRS (swev-id: django__django-15572)

### DIFF
--- a/django/template/autoreload.py
+++ b/django/template/autoreload.py
@@ -17,16 +17,20 @@ def get_template_directories():
         if not isinstance(backend, DjangoTemplates):
             continue
 
-        items.update(cwd / to_path(dir) for dir in backend.engine.dirs)
+        for directory in backend.engine.dirs:
+            if isinstance(directory, str) and directory.strip() == "":
+                continue
+            items.add(cwd / to_path(directory))
 
         for loader in backend.engine.template_loaders:
             if not hasattr(loader, "get_dirs"):
                 continue
-            items.update(
-                cwd / to_path(directory)
-                for directory in loader.get_dirs()
-                if not is_django_path(directory)
-            )
+            for directory in loader.get_dirs():
+                if isinstance(directory, str) and directory.strip() == "":
+                    continue
+                if is_django_path(directory):
+                    continue
+                items.add(cwd / to_path(directory))
     return items
 
 

--- a/tests/template_tests/test_autoreloader_empty_dirs.py
+++ b/tests/template_tests/test_autoreloader_empty_dirs.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from django.template import autoreload
+from django.test import SimpleTestCase, override_settings
+
+
+class TemplateAutoreloadEmptyDirsTests(SimpleTestCase):
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [""],
+                "APP_DIRS": True,
+                "OPTIONS": {},
+            }
+        ]
+    )
+    def test_empty_string_dirs_are_ignored(self):
+        directories = autoreload.get_template_directories()
+        self.assertNotIn(Path.cwd(), directories)


### PR DESCRIPTION
## Summary
- filter empty string entries before normalizing template directories
- ensure template loaders ignore empty strings and add regression coverage

## Testing
- PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py template_tests.test_autoreloader_empty_dirs --parallel=1
- flake8 django/template/autoreload.py tests/template_tests/test_autoreloader_empty_dirs.py

## Regression details
**Reproduction steps**
1. Configure `TEMPLATES[0]['DIRS'] = ['']` in a Django project (or via settings override).
2. Start the development server with `python manage.py runserver`.
3. Edit any non-`.py` file under the project root (e.g., `requirements.txt`).

**Observed behavior**
- `get_template_directories()` normalizes the empty string to `Path.cwd()`, so `template_changed()` returns `True` for unrelated filesystem changes, and the autoreloader never schedules a full restart.

**DEBUG signal output (before fix)**
```
DEBUG django.utils.autoreload: /abs/path/requirements.txt notified as changed. Signal results: [(<function template_changed at django/template/autoreload.py:73>, True)]
```

**Upstream context**
- Issue #506
- Regression introduced by https://github.com/django/django/commit/68357b2ca9e88c40fc00d848799813241be39129 and https://github.com/django/django/commit/c0d506f5ef253f006dbff0b0092c8eecbd45eedf (Ticket https://code.djangoproject.com/ticket/32744)