### PR TITLE
swev-id: django__django-16612 — Preserve query string in AdminSite.catch_all_view redirect

### DIFF
--- a/django/contrib/admin/sites.py
+++ b/django/contrib/admin/sites.py
@@ -453,7 +453,9 @@ class AdminSite:
                 pass
             else:
                 if getattr(match.func, "should_append_slash", True):
-                    return HttpResponsePermanentRedirect("%s/" % request.path)
+                    return HttpResponsePermanentRedirect(
+                        request.get_full_path(force_append_slash=True)
+                    )
         raise Http404
 
     def _build_app_dict(self, request, label=None):

--- a/tests/admin_views/test_adminsite.py
+++ b/tests/admin_views/test_adminsite.py
@@ -108,3 +108,20 @@ class SiteActionsTests(SimpleTestCase):
         self.assertEqual(self.site.get_action(action_name), delete_selected)
         self.site.disable_action(action_name)
         self.assertEqual(self.site.get_action(action_name), delete_selected)
+
+
+@override_settings(ROOT_URLCONF="admin_views.test_adminsite", APPEND_SLASH=True)
+class SiteAppendSlashRedirectTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="password"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_catch_all_preserves_querystring_on_slash_redirect(self):
+        resp = self.client.get("/test_admin/admin/auth?id=123", follow=False)
+        self.assertEqual(resp.status_code, 301)
+        self.assertEqual(resp["Location"], "/test_admin/admin/auth/?id=123")


### PR DESCRIPTION
Fixes #507

## Reproduction
1. .venv/bin/python tests/runtests.py admin_views.test_adminsite.SiteAppendSlashRedirectTests.test_catch_all_preserves_querystring_on_slash_redirect

Observed failure:
```
FAIL: test_catch_all_preserves_querystring_on_slash_redirect (admin_views.test_adminsite.SiteAppendSlashRedirectTests.test_catch_all_preserves_querystring_on_slash_redirect)
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"/workspace/django/tests/admin_views/test_adminsite.py\", line 127, in test_catch_all_preserves_querystring_on_slash_redirect
    self.assertEqual(resp[\"Location\"], \"/test_admin/admin/auth/?id=123\")
AssertionError: '/test_admin/admin/auth/' != '/test_admin/admin/auth/?id=123'
```

## Fix
- Redirect using request.get_full_path(force_append_slash=True) so the querystring is preserved.
- Add a regression test enforcing the behavior when APPEND_SLASH is True.
- Regression was introduced in ba31b0103442ac891fb3cb98f316781254e366c3.

## Testing
- .venv/bin/python tests/runtests.py admin_views.test_adminsite.SiteAppendSlashRedirectTests.test_catch_all_preserves_querystring_on_slash_redirect