### PR TITLE
fix: swev-id: django__django-15569 clear lookup cache after unregister

### DIFF
--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -217,6 +217,7 @@ class RegisterLookupMixin:
         if lookup_name is None:
             lookup_name = lookup.lookup_name
         del cls.class_lookups[lookup_name]
+        cls._clear_cached_lookups()
 
 
 def select_related_descend(field, restricted, requested, load_fields, reverse=False):

--- a/tests/custom_lookups/tests.py
+++ b/tests/custom_lookups/tests.py
@@ -324,6 +324,8 @@ class LookupTests(TestCase):
             # getting the lookups again should re-cache
             self.assertIn("exactly", field.get_lookups())
 
+        self.assertNotIn("exactly", field.get_lookups())
+
 
 class BilateralTransformTests(TestCase):
     def test_bilateral_upper(self):

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2770,20 +2770,20 @@ class SchemaTests(TransactionTestCase):
             with connection.schema_editor() as editor:
                 editor.add_constraint(Author, constraint)
                 sql = constraint.create_sql(Author, editor)
+            table = Author._meta.db_table
+            constraints = self.get_constraints(table)
+            self.assertIn(constraint.name, constraints)
+            self.assertIs(constraints[constraint.name]["unique"], True)
+            # SQL contains columns.
+            self.assertIs(sql.references_column(table, "name"), True)
+            self.assertIs(sql.references_column(table, "weight"), True)
+            # Remove constraint.
+            with connection.schema_editor() as editor:
+                editor.remove_constraint(Author, constraint)
         name_field = Author._meta.get_field("name")
         weight_field = Author._meta.get_field("weight")
         self.assertIsNone(name_field.get_transform("lower"))
         self.assertIsNone(weight_field.get_transform("abs"))
-        table = Author._meta.db_table
-        constraints = self.get_constraints(table)
-        self.assertIn(constraint.name, constraints)
-        self.assertIs(constraints[constraint.name]["unique"], True)
-        # SQL contains columns.
-        self.assertIs(sql.references_column(table, "name"), True)
-        self.assertIs(sql.references_column(table, "weight"), True)
-        # Remove constraint.
-        with connection.schema_editor() as editor:
-            editor.remove_constraint(Author, constraint)
         self.assertNotIn(constraint.name, self.get_constraints(table))
 
     @skipUnlessDBFeature("supports_expression_indexes")

--- a/tests/schema/tests.py
+++ b/tests/schema/tests.py
@@ -2770,6 +2770,10 @@ class SchemaTests(TransactionTestCase):
             with connection.schema_editor() as editor:
                 editor.add_constraint(Author, constraint)
                 sql = constraint.create_sql(Author, editor)
+        name_field = Author._meta.get_field("name")
+        weight_field = Author._meta.get_field("weight")
+        self.assertIsNone(name_field.get_transform("lower"))
+        self.assertIsNone(weight_field.get_transform("abs"))
         table = Author._meta.db_table
         constraints = self.get_constraints(table)
         self.assertIn(constraint.name, constraints)


### PR DESCRIPTION
## Summary
- clear stale lookup cache entries when a lookup is unregistered so transforms disappear immediately
- add regression assertions exercising lookup cache invalidation for ForeignObject and functional unique constraints
- keep constraint teardown inside the temporary registration scope so removal works once the cache is purged

Fixes #505.

## Reproduction Steps
1. cd tests
2. PYTHONPATH=$PWD:$PWD/.. ../.venv/bin/python runtests.py --parallel 1 custom_lookups.tests.LookupTests.test_lookups_caching
3. PYTHONPATH=$PWD:$PWD/.. ../.venv/bin/python runtests.py --parallel 1 schema.tests.SchemaTests.test_func_unique_constraint_lookups

## Observed Failures
```text
Creating test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
Found 1 test(s).
System check identified no issues (0 silenced).
F
======================================================================
FAIL: test_lookups_caching (custom_lookups.tests.LookupTests.test_lookups_caching)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/custom_lookups/tests.py", line 327, in test_lookups_caching
    self.assertNotIn("exactly", field.get_lookups())
AssertionError: 'exactly' unexpectedly found in {'in': <class 'django.db.models.fields.related_lookups.RelatedIn'>, 'exact': <class 'django.db.models.fields.related_lookups.RelatedExact'>, 'lt': <class 'django.db.models.fields.related_lookups.RelatedLessThan'>, 'gt': <class 'django.db.models.fields.related_lookups.RelatedGreaterThan'>, 'gte': <class 'django.db.models.fields.related_lookups.RelatedGreaterThanOrEqual'>, 'lte': <class 'django.db.models.fields.related_lookups.RelatedLessThanOrEqual'>, 'isnull': <class 'django.db.models.fields.related_lookups.RelatedIsNull'>, 'exactly': <class 'custom_lookups.tests.Exactly'>}

----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (failures=1)
Destroying test database for alias 'default'...
```

```text
Creating test database for alias 'default'...
Testing against Django installed in '/workspace/django/django'
Found 1 test(s).
System check identified no issues (0 silenced).
F
======================================================================
FAIL: test_func_unique_constraint_lookups (schema.tests.SchemaTests.test_func_unique_constraint_lookups)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/django/test/testcases.py", line 1571, in skip_wrapper
    return test_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/schema/tests.py", line 2775, in test_func_unique_constraint_lookups
    self.assertIsNone(name_field.get_transform("lower"))
AssertionError: <class 'django.db.models.functions.text.Lower'> is not None

----------------------------------------------------------------------
Ran 1 test in 0.003s

FAILED (failures=1)
Destroying test database for alias 'default'...
```

## Testing
- cd tests && PYTHONPATH=$PWD:$PWD/.. ../.venv/bin/python runtests.py --parallel 1 custom_lookups.tests.LookupTests.test_lookups_caching
- cd tests && PYTHONPATH=$PWD:$PWD/.. ../.venv/bin/python runtests.py --parallel 1 schema.tests.SchemaTests.test_func_unique_constraint_lookups
- .venv/bin/flake8 django/db/models/query_utils.py
- .venv/bin/flake8 tests/custom_lookups/tests.py
- .venv/bin/flake8 --extend-ignore=E721 tests/schema/tests.py