### PR TITLE
feat(auth): session fallback upgrade (swev-id: django__django-16631)

### DIFF
--- a/django/contrib/auth/__init__.py
+++ b/django/contrib/auth/__init__.py
@@ -5,7 +5,7 @@ from django.apps import apps as django_apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.middleware.csrf import rotate_token
-from django.utils.crypto import constant_time_compare
+from django.utils.crypto import constant_time_compare, salted_hmac
 from django.utils.module_loading import import_string
 from django.views.decorators.debug import sensitive_variables
 
@@ -199,9 +199,38 @@ def get_user(request):
             # Verify the session
             if hasattr(user, "get_session_auth_hash"):
                 session_hash = request.session.get(HASH_SESSION_KEY)
-                session_hash_verified = session_hash and constant_time_compare(
-                    session_hash, user.get_session_auth_hash()
-                )
+                session_hash_verified = False
+                if session_hash:
+                    from django.contrib.auth.base_user import (
+                        AbstractBaseUser,
+                        SESSION_AUTH_HASH_KEY_SALT,
+                    )
+
+                    default_getter = AbstractBaseUser.get_session_auth_hash
+                    if user.__class__.get_session_auth_hash is default_getter:
+                        secrets = [settings.SECRET_KEY]
+                        secrets.extend(
+                            getattr(settings, "SECRET_KEY_FALLBACKS", ())
+                        )
+                        for secret in secrets:
+                            candidate = salted_hmac(
+                                SESSION_AUTH_HASH_KEY_SALT,
+                                user.password,
+                                secret=secret,
+                                algorithm="sha256",
+                            ).hexdigest()
+                            if constant_time_compare(session_hash, candidate):
+                                session_hash_verified = True
+                                if secret != settings.SECRET_KEY:
+                                    request.session.cycle_key()
+                                    request.session[
+                                        HASH_SESSION_KEY
+                                    ] = user.get_session_auth_hash()
+                                break
+                    if not session_hash_verified:
+                        session_hash_verified = constant_time_compare(
+                            session_hash, user.get_session_auth_hash()
+                        )
                 if not session_hash_verified:
                     request.session.flush()
                     user = None

--- a/django/contrib/auth/base_user.py
+++ b/django/contrib/auth/base_user.py
@@ -17,6 +17,11 @@ from django.utils.deprecation import RemovedInDjango51Warning
 from django.utils.translation import gettext_lazy as _
 
 
+SESSION_AUTH_HASH_KEY_SALT = (
+    "django.contrib.auth.models.AbstractBaseUser.get_session_auth_hash"
+)
+
+
 class BaseUserManager(models.Manager):
     @classmethod
     def normalize_email(cls, email):
@@ -135,9 +140,8 @@ class AbstractBaseUser(models.Model):
         """
         Return an HMAC of the password field.
         """
-        key_salt = "django.contrib.auth.models.AbstractBaseUser.get_session_auth_hash"
         return salted_hmac(
-            key_salt,
+            SESSION_AUTH_HASH_KEY_SALT,
             self.password,
             algorithm="sha256",
         ).hexdigest()

--- a/tests/auth_tests/test_session_auth_hash_fallbacks.py
+++ b/tests/auth_tests/test_session_auth_hash_fallbacks.py
@@ -1,0 +1,100 @@
+from unittest import mock
+
+from django.contrib.auth import HASH_SESSION_KEY, SESSION_KEY, get_user_model
+from django.test import TestCase, override_settings
+from django.utils.crypto import salted_hmac
+
+
+@override_settings(ROOT_URLCONF="auth_tests.urls")
+class SessionAuthHashFallbackTests(TestCase):
+    password = "passw0rd!"
+
+    def create_user(self, username):
+        return get_user_model().objects.create_user(
+            username=username,
+            password=self.password,
+        )
+
+    def login_with_secret(self, user, secret):
+        with override_settings(SECRET_KEY=secret, SECRET_KEY_FALLBACKS=[]):
+            logged_in = self.client.login(
+                username=user.get_username(),
+                password=self.password,
+            )
+            self.assertTrue(logged_in)
+            session = self.client.session
+            return session.session_key, session.get(HASH_SESSION_KEY)
+
+    def test_session_auth_hash_validated_against_fallbacks_and_upgraded(self):
+        user = self.create_user("fallback-upgrade")
+        original_session_key, original_hash = self.login_with_secret(user, "oldsecret")
+
+        with override_settings(
+            SECRET_KEY="newsecret",
+            SECRET_KEY_FALLBACKS=["oldsecret"],
+        ):
+            response = self.client.get("/auth_processor_user/")
+            self.assertTrue(response.wsgi_request.user.is_authenticated)
+            upgraded_session = self.client.session
+            self.assertNotEqual(upgraded_session.session_key, original_session_key)
+            self.assertEqual(
+                upgraded_session[HASH_SESSION_KEY],
+                user.get_session_auth_hash(),
+            )
+            self.assertNotEqual(upgraded_session[HASH_SESSION_KEY], original_hash)
+
+    def test_session_auth_hash_mismatch_flushes_session(self):
+        user = self.create_user("fallback-mismatch")
+        original_session_key, _ = self.login_with_secret(user, "oldsecret")
+
+        session = self.client.session
+        session[HASH_SESSION_KEY] = "invalid"
+        session.save()
+
+        with override_settings(
+            SECRET_KEY="newsecret",
+            SECRET_KEY_FALLBACKS=["oldsecret"],
+        ):
+            response = self.client.get("/auth_processor_user/")
+            self.assertFalse(response.wsgi_request.user.is_authenticated)
+            flushed_session = self.client.session
+            self.assertNotIn(SESSION_KEY, flushed_session)
+            self.assertNotIn(HASH_SESSION_KEY, flushed_session)
+
+    def test_no_fallbacks_configured_behaves_as_before(self):
+        user = self.create_user("fallback-disabled")
+        original_session_key, _ = self.login_with_secret(user, "oldsecret")
+
+        with override_settings(SECRET_KEY="newsecret", SECRET_KEY_FALLBACKS=[]):
+            response = self.client.get("/auth_processor_user/")
+            self.assertFalse(response.wsgi_request.user.is_authenticated)
+            flushed_session = self.client.session
+            self.assertNotIn(SESSION_KEY, flushed_session)
+            self.assertNotIn(HASH_SESSION_KEY, flushed_session)
+
+    def test_custom_get_session_auth_hash_is_respected(self):
+        user = self.create_user("fallback-custom")
+
+        def custom_get_session_auth_hash(self):
+            return salted_hmac(
+                "tests.auth_tests.custom_session_auth_hash_salt",
+                self.password,
+                algorithm="sha256",
+            ).hexdigest()
+
+        with mock.patch.object(
+            user.__class__,
+            "get_session_auth_hash",
+            custom_get_session_auth_hash,
+        ):
+            original_session_key, _ = self.login_with_secret(user, "oldsecret")
+
+            with override_settings(
+                SECRET_KEY="newsecret",
+                SECRET_KEY_FALLBACKS=["oldsecret"],
+            ):
+                response = self.client.get("/auth_processor_user/")
+                self.assertFalse(response.wsgi_request.user.is_authenticated)
+                flushed_session = self.client.session
+                self.assertNotIn(SESSION_KEY, flushed_session)
+                self.assertNotIn(HASH_SESSION_KEY, flushed_session)


### PR DESCRIPTION
## Issue
- Closes #510

## Observed Failure (pre-fix)
```
FAIL: test_session_auth_hash_validated_against_fallbacks_and_upgraded (auth_tests.test_session_auth_hash_fallbacks.SessionAuthHashFallbackTests.test_session_auth_hash_validated_against_fallbacks_and_upgraded)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/auth_tests/test_session_auth_hash_fallbacks.py", line 37, in test_session_auth_hash_validated_against_fallbacks_and_upgraded
    self.assertTrue(response.wsgi_request.user.is_authenticated)
AssertionError: False is not true
```

## Reproduction Steps
1. Checkout `django__django-16631` without this patch.
2. Apply `tests/auth_tests/test_session_auth_hash_fallbacks.py` from this branch.
3. Run `PYTHONPATH=$PWD .venv/bin/python tests/runtests.py auth_tests.test_session_auth_hash_fallbacks --parallel=1`.

## Fix Summary
- Iterate session auth hash validation across `SECRET_KEY` and `SECRET_KEY_FALLBACKS` when using the default `AbstractBaseUser.get_session_auth_hash` implementation.
- Transparently upgrade sessions issued under a fallback secret by cycling the key and re-seeding `_auth_user_hash` under the active secret.
- Consolidate the session hash key salt in `SESSION_AUTH_HASH_KEY_SALT` for reuse across fallback validation.
- Add regression coverage for fallback validation, upgrade behavior, mismatch handling, missing fallbacks, and custom hash overrides.

## Testing
- `PYTHONPATH=$PWD .venv/bin/python tests/runtests.py auth_tests --parallel=1`
- `.venv/bin/flake8 django/contrib/auth/__init__.py django/contrib/auth/base_user.py tests/auth_tests/test_session_auth_hash_fallbacks.py`

## CI
- Not run (per instructions).