### PR TITLE
swev-id: django__django-16661 fix lookup_allowed relational pk

### DIFF
--- a/django/contrib/admin/options.py
+++ b/django/contrib/admin/options.py
@@ -464,10 +464,17 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
             # It is allowed to filter on values that would be found from local
             # model anyways. For example, if you filter on employee__department__id,
             # then the id value would be found already from employee__department_id.
-            if not prev_field or (
-                prev_field.is_relation
-                and field not in prev_field.path_infos[-1].target_fields
-            ):
+            append_part = True
+            if prev_field and prev_field.is_relation:
+                target_fields = prev_field.path_infos[-1].target_fields
+                if field in target_fields:
+                    skip_for_target = not field.is_relation
+                    if field.is_relation:
+                        skip_for_target = getattr(
+                            field.remote_field, "parent_link", False
+                        )
+                    append_part = not skip_for_target
+            if append_part:
                 relation_parts.append(part)
             if not getattr(field, "path_infos", None):
                 # This is not a relational field, so further parts

--- a/tests/modeladmin/tests.py
+++ b/tests/modeladmin/tests.py
@@ -154,6 +154,71 @@ class ModelAdminTests(TestCase):
             ma.lookup_allowed("employee__department__code", "test_value"), True
         )
 
+    @isolate_apps("modeladmin")
+    def test_lookup_allowed_foreign_primary(self):
+        class Country(models.Model):
+            name = models.CharField(max_length=32)
+
+        class Place(models.Model):
+            name = models.CharField(max_length=32)
+            country = models.ForeignKey(Country, models.CASCADE)
+
+        class Restaurant(models.Model):
+            place = models.OneToOneField(Place, models.CASCADE, primary_key=True)
+
+        class Waiter(models.Model):
+            restaurant = models.ForeignKey(Restaurant, models.CASCADE)
+
+        class WaiterAdmin(ModelAdmin):
+            list_filter = ["restaurant__place__country"]
+
+        ma = WaiterAdmin(Waiter, self.site)
+        self.assertIs(
+            ma.lookup_allowed("restaurant__place__country", "test_value"), True
+        )
+
+    @isolate_apps("modeladmin")
+    def test_lookup_allowed_foreign_primary_with_transform(self):
+        class Country(models.Model):
+            name = models.CharField(max_length=32)
+
+        class Place(models.Model):
+            name = models.CharField(max_length=32)
+            country = models.ForeignKey(Country, models.CASCADE)
+
+        class Restaurant(models.Model):
+            place = models.OneToOneField(Place, models.CASCADE, primary_key=True)
+
+        class Waiter(models.Model):
+            restaurant = models.ForeignKey(Restaurant, models.CASCADE)
+
+        class WaiterAdmin(ModelAdmin):
+            list_filter = ["restaurant__place__country__name"]
+
+        ma = WaiterAdmin(Waiter, self.site)
+        self.assertIs(
+            ma.lookup_allowed("restaurant__place__country__name", "test_value"), True
+        )
+
+    @isolate_apps("modeladmin")
+    def test_lookup_allowed_parent_link(self):
+        class Place(models.Model):
+            name = models.CharField(max_length=32)
+
+        class Restaurant(Place):
+            pass
+
+        class Waiter(models.Model):
+            restaurant = models.ForeignKey(Restaurant, models.CASCADE)
+
+        class WaiterAdmin(ModelAdmin):
+            list_filter = ["restaurant__name"]
+
+        ma = WaiterAdmin(Waiter, self.site)
+        self.assertIs(
+            ma.lookup_allowed("restaurant__name", "test_value"), True
+        )
+
     def test_field_arguments(self):
         # If fields is specified, fieldsets_add and fieldsets_change should
         # just stick the fields into a formsets structure and return it.


### PR DESCRIPTION
## Summary
- Fixes #513 by keeping OneToOne primary key hops in `ModelAdmin.lookup_allowed` when `parent_link` is False.
- Preserve MTI parent link collapsing so `restaurant__name` style lookups stay allowed.
- Add regression coverage for relational primary keys and a transform hop.

## Reproduction
1. `PYTHONPATH=$PWD ./tests/runtests.py modeladmin --verbosity 2`
2. `PYTHONPATH=$PWD ./tests/runtests.py modeladmin.tests.ModelAdminTests.test_lookup_allowed_foreign_primary --verbosity 2`

### Observed Failure (before fix)
```
FAIL: test_lookup_allowed_foreign_primary (modeladmin.tests.ModelAdminTests.test_lookup_allowed_foreign_primary)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/django/test/utils.py", line 443, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/tests/modeladmin/tests.py", line 176, in test_lookup_allowed_foreign_primary
    self.assertIs(
AssertionError: False is not True

----------------------------------------------------------------------
Ran 1 test in 0.003s

FAILED (failures=1)
```

## Testing
- `PYTHONPATH=$PWD ./tests/runtests.py modeladmin --verbosity 2`
- `flake8 django/contrib/admin/options.py tests/modeladmin/tests.py`

_No CI runs were triggered; local testing only._