### PR TITLE
swev-id: django__django-16642 Fix FileResponse content encoding

### DIFF
--- a/django/http/response.py
+++ b/django/http/response.py
@@ -604,20 +604,17 @@ class FileResponse(StreamingHttpResponse):
 
         filename = os.path.basename(self.filename or filename)
         if self._no_explicit_content_type:
+            content_type = None
+            encoding = None
             if filename:
                 content_type, encoding = mimetypes.guess_type(filename)
-                # Encoding isn't set to prevent browsers from automatically
-                # uncompressing files.
-                content_type = {
-                    "bzip2": "application/x-bzip",
-                    "gzip": "application/gzip",
-                    "xz": "application/x-xz",
-                }.get(encoding, content_type)
-                self.headers["Content-Type"] = (
-                    content_type or "application/octet-stream"
-                )
-            else:
-                self.headers["Content-Type"] = "application/octet-stream"
+            self.headers["Content-Type"] = content_type or "application/octet-stream"
+            if filename:
+                lower_filename = filename.lower()
+                if encoding is None and lower_filename.endswith(".br"):
+                    encoding = "br"
+                if encoding in {"gzip", "compress", "bzip2", "xz", "br"}:
+                    self.headers["Content-Encoding"] = encoding
 
         if content_disposition := content_disposition_header(
             self.as_attachment, filename

--- a/tests/responses/test_fileresponse.py
+++ b/tests/responses/test_fileresponse.py
@@ -247,21 +247,38 @@ class FileResponseTests(SimpleTestCase):
 
     def test_compressed_response(self):
         """
-        If compressed responses are served with the uncompressed Content-Type
-        and a compression Content-Encoding, browsers might automatically
-        uncompress the file, which is most probably not wanted.
+        FileResponse infers the underlying Content-Type and sets
+        Content-Encoding for known compressed suffixes.
         """
         test_tuples = (
-            (".tar.gz", "application/gzip"),
-            (".tar.bz2", "application/x-bzip"),
-            (".tar.xz", "application/x-xz"),
+            (".tar.gz", "application/x-tar", "gzip"),
+            (".tar.bz2", "application/x-tar", "bzip2"),
+            (".tar.xz", "application/x-tar", "xz"),
         )
-        for extension, mimetype in test_tuples:
+        for extension, mimetype, encoding in test_tuples:
             with self.subTest(ext=extension):
                 with tempfile.NamedTemporaryFile(suffix=extension) as tmp:
                     response = FileResponse(tmp)
                 self.assertEqual(response.headers["Content-Type"], mimetype)
-                self.assertFalse(response.has_header("Content-Encoding"))
+                self.assertEqual(response.headers["Content-Encoding"], encoding)
+
+    def test_content_encoding_Z_suffix(self):
+        with tempfile.NamedTemporaryFile(suffix=".html.Z") as tmp:
+            response = FileResponse(tmp)
+        self.assertEqual(response.headers["Content-Type"], "text/html")
+        self.assertEqual(response.headers["Content-Encoding"], "compress")
+
+    def test_content_encoding_br_suffix(self):
+        with tempfile.NamedTemporaryFile(suffix=".html.br") as tmp:
+            response = FileResponse(tmp)
+        self.assertEqual(response.headers["Content-Type"], "text/html")
+        self.assertEqual(response.headers["Content-Encoding"], "br")
+
+    def test_explicit_content_type_disables_encoding_inference(self):
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp:
+            response = FileResponse(tmp, content_type="application/gzip")
+        self.assertEqual(response.headers["Content-Type"], "application/gzip")
+        self.assertFalse(response.has_header("Content-Encoding"))
 
     def test_unicode_attachment(self):
         response = FileResponse(


### PR DESCRIPTION
## Summary
- set FileResponse Content-Type from the underlying resource while inferring Content-Encoding for known compression suffixes (.Z, .gz, .bz2, .xz, .br)
- keep explicit content_type untouched and expand regression coverage for the new encoding rules
- align the response headers with HTTP semantics by separating representation metadata from transfer codings

## Reproduction
```python
from django.http import FileResponse

FileResponse(open("test.html.br", "rb"))
FileResponse(open("test.html.Z", "rb"))
```

```bash
PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages \
DJANGO_SETTINGS_MODULE=tests.test_sqlite \
python3.11 tests/runtests.py responses --parallel=1
```

### Observed failure
```
Testing against Django installed in '/workspace/django/django'
Found 56 test(s).
System check identified no issues (0 silenced).
.................FFF.....EE...............................
======================================================================
ERROR: test_content_encoding_Z_suffix (responses.test_fileresponse.FileResponseTests.test_content_encoding_Z_suffix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/responses/test_fileresponse.py", line 269, in test_content_encoding_Z_suffix
    self.assertEqual(response.headers["Content-Encoding"], "compress")
                     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/utils/datastructures.py", line 308, in __getitem__
    return self._store[key.lower()][1]
           ~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'content-encoding'

======================================================================
ERROR: test_content_encoding_br_suffix (responses.test_fileresponse.FileResponseTests.test_content_encoding_br_suffix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/responses/test_fileresponse.py", line 275, in test_content_encoding_br_suffix
    self.assertEqual(response.headers["Content-Encoding"], "br")
                     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/workspace/django/django/utils/datastructures.py", line 308, in __getitem__
    return self._store[key.lower()][1]
           ~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'content-encoding'

======================================================================
FAIL: test_compressed_response (responses.test_fileresponse.FileResponseTests.test_compressed_response) (ext='.tar.gz')
FileResponse infers the underlying Content-Type and sets
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/responses/test_fileresponse.py", line 262, in test_compressed_response
    self.assertEqual(response.headers["Content-Type"], mimetype)
AssertionError: 'application/gzip' != 'application/x-tar'
- application/gzip
+ application/x-tar


======================================================================
FAIL: test_compressed_response (responses.test_fileresponse.FileResponseTests.test_compressed_response) (ext='.tar.bz2')
FileResponse infers the underlying Content-Type and sets
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/responses/test_fileresponse.py", line 262, in test_compressed_response
    self.assertEqual(response.headers["Content-Type"], mimetype)
AssertionError: 'application/x-bzip' != 'application/x-tar'
- application/x-bzip
?               ^^^^
+ application/x-tar
?               ^^^


======================================================================
FAIL: test_compressed_response (responses.test_fileresponse.FileResponseTests.test_compressed_response) (ext='.tar.xz')
FileResponse infers the underlying Content-Type and sets
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/django/tests/responses/test_fileresponse.py", line 262, in test_compressed_response
    self.assertEqual(response.headers["Content-Type"], mimetype)
AssertionError: 'application/x-xz' != 'application/x-tar'
- application/x-xz
?               ^^
+ application/x-tar
?               ^^^


----------------------------------------------------------------------
Ran 56 tests in 0.011s

FAILED (failures=3, errors=2)
```

## Testing
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3.11 tests/runtests.py responses --parallel=1`

Fixes #512