### PR TITLE
fix(imagefield): skip post_init without dimensions (swev-id: django__django-16801)

### DIFF
--- a/django/db/models/fields/files.py
+++ b/django/db/models/fields/files.py
@@ -441,7 +441,7 @@ class ImageField(FileField):
         # after their corresponding image field don't stay cleared by
         # Model.__init__, see bug #11196.
         # Only run post-initialization dimension update on non-abstract models
-        if not cls._meta.abstract:
+        if not cls._meta.abstract and (self.width_field or self.height_field):
             signals.post_init.connect(self.update_dimension_fields, sender=cls)
 
     def update_dimension_fields(self, instance, force=False, *args, **kwargs):

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -5,6 +5,7 @@ from unittest import skipIf
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.core.files.images import ImageFile
+from django.db.models import signals
 from django.test import TestCase
 from django.test.testcases import SerializeMixin
 
@@ -443,21 +444,56 @@ class TwoImageFieldTests(ImageFieldTestMixin, TestCase):
         # have been opened.
         self.assertIs(p.mugshot.was_opened, True)
         self.assertIs(p.headshot.was_opened, True)
-        # Dimensions should now be cached, and if we reset was_opened and
-        # check dimensions again, the file should not have opened.
-        p.mugshot.was_opened = False
-        p.headshot.was_opened = False
-        self.check_dimensions(p, 4, 8, "mugshot")
-        self.check_dimensions(p, 8, 4, "headshot")
-        self.assertIs(p.mugshot.was_opened, False)
-        self.assertIs(p.headshot.was_opened, False)
 
-        # If we assign a new image to the instance, the dimensions should
-        # update.
-        p.mugshot = self.file2
-        p.headshot = self.file1
-        self.check_dimensions(p, 8, 4, "mugshot")
-        self.check_dimensions(p, 4, 8, "headshot")
-        # Dimensions were recalculated, and hence file should have opened.
-        self.assertIs(p.mugshot.was_opened, True)
-        self.assertIs(p.headshot.was_opened, True)
+
+@skipIf(Image is None, "Pillow is required to test ImageField")
+class ImageFieldSignalRegistrationTests(TestCase):
+    def _is_update_dimension_receiver(self, receiver):
+        names = [
+            getattr(receiver, "__name__", ""),
+            getattr(receiver, "__qualname__", ""),
+        ]
+        if any(
+            name.split(".")[-1] == "update_dimension_fields"
+            for name in names
+            if name
+        ):
+            return True
+
+        bound = getattr(receiver, "__func__", None)
+        if bound and self._is_update_dimension_receiver(bound):
+            return True
+
+        func = getattr(receiver, "func", None)
+        if func and self._is_update_dimension_receiver(func):
+            return True
+
+        return False
+
+    def _count_dimension_receivers(self, model):
+        sync_receivers, async_receivers = signals.post_init._live_receivers(model)
+        all_receivers = [*sync_receivers, *async_receivers]
+        return sum(
+            1
+            for receiver in all_receivers
+            if self._is_update_dimension_receiver(receiver)
+        )
+
+    def test_no_listener_without_dimension_fields(self):
+        self.assertEqual(self._count_dimension_receivers(Person), 0)
+
+    def test_listener_connected_with_dimension_fields(self):
+        self.assertEqual(
+            self._count_dimension_receivers(PersonWithHeight),
+            1,
+        )
+        self.assertEqual(
+            self._count_dimension_receivers(PersonWithHeightAndWidth),
+            1,
+        )
+
+    def test_multiple_listeners_with_multiple_image_fields(self):
+        self.assertEqual(
+            self._count_dimension_receivers(PersonTwoImages),
+            2,
+        )

--- a/tests/model_fields/test_imagefield.py
+++ b/tests/model_fields/test_imagefield.py
@@ -444,6 +444,23 @@ class TwoImageFieldTests(ImageFieldTestMixin, TestCase):
         # have been opened.
         self.assertIs(p.mugshot.was_opened, True)
         self.assertIs(p.headshot.was_opened, True)
+        # Dimensions should now be cached, and if we reset was_opened and
+        # check dimensions again, the files should not open.
+        p.mugshot.was_opened = False
+        p.headshot.was_opened = False
+        self.check_dimensions(p, 4, 8, "mugshot")
+        self.check_dimensions(p, 8, 4, "headshot")
+        self.assertIs(p.mugshot.was_opened, False)
+        self.assertIs(p.headshot.was_opened, False)
+
+        # If we assign new images to the instance, the dimensions should
+        # update and the files should reopen.
+        p.mugshot = self.file2
+        p.headshot = self.file1
+        self.check_dimensions(p, 8, 4, "mugshot")
+        self.check_dimensions(p, 4, 8, "headshot")
+        self.assertIs(p.mugshot.was_opened, True)
+        self.assertIs(p.headshot.was_opened, True)
 
 
 @skipIf(Image is None, "Pillow is required to test ImageField")


### PR DESCRIPTION
## Summary
- skip wiring ImageField.update_dimension_fields when no width/height fields are configured
- add regression tests exercising post_init receiver counts for different ImageField setups

## Observed problem
Every ImageField currently connects its post_init handler even when the model does not declare dimension fields. That extra receiver forces unnecessary signal dispatch overhead during model initialization.

## Reproduction
A shell snippet that shows the excess receiver prior to this fix:

```shell
PYTHONPATH=/workspace/django/tests:/workspace/django python - <<'PY'
from django.conf import settings

settings.configure(
    INSTALLED_APPS=[
        "django.contrib.auth",
        "django.contrib.contenttypes",
        "model_fields",
    ],
    DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3"}},
    SECRET_KEY="tests",
    USE_TZ=False,
)

import django

django.setup()

from django.db.models import signals
from model_fields import models

print("Person:", signals.post_init._live_receivers(models.Person)[0])
print("PersonWithHeight:", signals.post_init._live_receivers(models.PersonWithHeight)[0])
print("PersonTwoImages:", signals.post_init._live_receivers(models.PersonTwoImages)[0])
PY
```

Before this change the "Person" line contained a single `update_dimension_fields` receiver even though the model has no dimension fields. After the fix the same command prints an empty list for `Person` while models with dimension fields still report their listeners.

## Testing
- `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py model_fields.test_imagefield --parallel=1`
- `flake8 django/db/models/fields/files.py tests/model_fields/test_imagefield.py`

Fixes #521
