### PR TITLE
swev-id: django__django-16819 Optimize migration index reductions

### DIFF
--- a/django/db/migrations/operations/models.py
+++ b/django/db/migrations/operations/models.py
@@ -861,6 +861,21 @@ class AddIndex(IndexOperation):
     def migration_name_fragment(self):
         return "%s_%s" % (self.model_name_lower, self.index.name.lower())
 
+    def reduce(self, operation, app_label):
+        if (
+            isinstance(operation, RemoveIndex)
+            and self.model_name_lower == operation.model_name_lower
+            and self.index.name.lower() == operation.name.lower()
+        ):
+            return []
+        if (
+            isinstance(operation, AddIndex)
+            and self.model_name_lower == operation.model_name_lower
+            and self.index.name.lower() == operation.index.name.lower()
+        ):
+            return [operation]
+        return super().reduce(operation, app_label)
+
 
 class RemoveIndex(IndexOperation):
     """Remove an index from a model."""
@@ -903,6 +918,15 @@ class RemoveIndex(IndexOperation):
     @property
     def migration_name_fragment(self):
         return "remove_%s_%s" % (self.model_name_lower, self.name.lower())
+
+    def reduce(self, operation, app_label):
+        if (
+            isinstance(operation, RemoveIndex)
+            and self.model_name_lower == operation.model_name_lower
+            and self.name.lower() == operation.name.lower()
+        ):
+            return [self]
+        return super().reduce(operation, app_label)
 
 
 class RenameIndex(IndexOperation):

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -1,8 +1,14 @@
 from django.db import migrations, models
+from django.db.models import Q
 from django.db.migrations import operations
 from django.db.migrations.optimizer import MigrationOptimizer
 from django.db.migrations.serializer import serializer_factory
 from django.test import SimpleTestCase
+
+try:
+    from django.contrib.postgres.indexes import GinIndex
+except ImportError:
+    GinIndex = None
 
 from .models import EmptyManager, UnicodeModel
 
@@ -1119,6 +1125,69 @@ class OptimizerTests(SimpleTestCase):
                     "Phou", [("name", models.CharField(max_length=255))]
                 ),
             ],
+        )
+
+    def test_add_index_remove_index(self):
+        index = models.Index(
+            name="PONY_IDX",
+            fields=["pink"],
+            condition=Q(pink=True),
+            include=["weight"],
+            opclasses=["varchar_pattern_ops"],
+        )
+        self.assertOptimizesTo(
+            [
+                migrations.AddIndex("Pony", index),
+                migrations.RemoveIndex("Pony", "pony_idx"),
+            ],
+            [],
+        )
+
+    def test_add_index_replaced_by_later_add_index(self):
+        first_index = models.Index(name="pony_idx", fields=["weight"])
+        second_index = (
+            GinIndex(name="pony_idx", fields=["weight"])
+            if GinIndex is not None
+            else models.Index(
+                name="pony_idx",
+                fields=["weight"],
+                condition=Q(weight__gt=0),
+            )
+        )
+        self.assertOptimizesTo(
+            [
+                migrations.AddIndex("Pony", first_index),
+                migrations.AddIndex("Pony", second_index),
+            ],
+            [migrations.AddIndex("Pony", second_index)],
+        )
+
+    def test_remove_index_remove_index(self):
+        self.assertOptimizesTo(
+            [
+                migrations.RemoveIndex("Pony", "PONY_IDX"),
+                migrations.RemoveIndex("Pony", "pony_idx"),
+            ],
+            [migrations.RemoveIndex("Pony", "PONY_IDX")],
+        )
+
+    def test_index_operations_do_not_cross_rename_boundaries(self):
+        index = models.Index(name="pony_idx", fields=["weight"])
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddIndex("Pony", index),
+                migrations.RenameModel("Pony", "Horse"),
+                migrations.RemoveIndex("Horse", "pony_idx"),
+            ]
+        )
+        self.assertDoesNotOptimize(
+            [
+                migrations.AddIndex(
+                    "Pony", models.Index(name="pony_idx", fields=["weight"])
+                ),
+                migrations.RenameField("Pony", "weight", "mass"),
+                migrations.RemoveIndex("Pony", "pony_idx"),
+            ]
         )
 
     def test_rename_index(self):


### PR DESCRIPTION
## Summary
- add migration optimizer reductions collapsing redundant AddIndex/RemoveIndex pairs
- ensure repeated RemoveIndex operations keep the leading removal
- extend optimizer tests to cover index cancellation, replacement, and rename boundaries

Resolves #522.

## Reproduction Steps
```bash
PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages \
DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py migrations --parallel=1
```

## Observed Failure
```text
======================================================================
FAIL: test_add_index_remove_index (migrations.test_optimizer.OptimizerTests.test_add_index_remove_index)
AssertionError: Lists differ: [] != ["migrations.AddIndex(\n    model_name='Pony',\n    index=models.Index(condition=models.Q(('pink', True)), fields=['pink'], include=('weight',), name='PONY_IDX', opclasses=['varchar_pattern_ops']),\n)"]

======================================================================
FAIL: test_add_index_replaced_by_later_add_index (migrations.test_optimizer.OptimizerTests.test_add_index_replaced_by_later_add_index)
AssertionError: Lists differ: ["migr...GinIndex(fields=['weight'], name='pony_idx'),\n)"] != ["migr...Index(fields=['weight'], name='pony_idx'),\n)"]

======================================================================
FAIL: test_remove_index_remove_index (migrations.test_optimizer.OptimizerTests.test_remove_index_remove_index)
AssertionError: Lists differ: ["migr... name='PONY_IDX',\n)"] != ["migr... name='PONY_IDX',\n)", "migr... name='pony_idx',\n)"]
```

## Fix Summary
- short-circuit AddIndex.reduce to drop matching RemoveIndex and defer to the latest AddIndex
- short-circuit RemoveIndex.reduce to retain only the leading removal for identical targets
- add optimizer coverage to ensure name-based comparisons work across index variants and renames

## Testing
```bash
PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages \
DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py migrations --parallel=1
```