### PR TITLE
Fix XOR fallback to use parity semantics for chained Q() (odd-truth) [swev-id: django__django-16901]

### DIFF
--- a/django/db/models/sql/where.py
+++ b/django/db/models/sql/where.py
@@ -128,15 +128,17 @@ class WhereNode(tree.Node):
         if self.connector == XOR and not connection.features.supports_logical_xor:
             # Convert if the database doesn't support XOR:
             #   a XOR b XOR c XOR ...
-            # to:
-            #   (a OR b OR c OR ...) AND (a + b + c + ...) == 1
-            lhs = self.__class__(self.children, OR)
+            # to parity semantics (true iff an odd number of arguments are true):
+            #   (a + b + c + ...) % 2 == 1
+            # Represent each condition as 1 when true, 0 otherwise, sum them,
+            # then compare the modulo of 2 to 1.
             rhs_sum = reduce(
                 operator.add,
                 (Case(When(c, then=1), default=0) for c in self.children),
             )
-            rhs = Exact(1, rhs_sum)
-            return self.__class__([lhs, rhs], AND, self.negated).as_sql(
+            rhs_mod2 = rhs_sum % 2
+            rhs = Exact(1, rhs_mod2)
+            return self.__class__([rhs], AND, self.negated).as_sql(
                 compiler, connection
             )
 

--- a/tests/xor_lookups/tests.py
+++ b/tests/xor_lookups/tests.py
@@ -65,3 +65,14 @@ class XorLookupsTests(TestCase):
             Number.objects.filter(Q(pk__in=[]) ^ Q(num__gte=5)),
             self.numbers[5:],
         )
+
+    def test_xor_parity_multiple_arguments_with_duplicates(self):
+        # On backends without native XOR, ensure parity (odd number of truths)
+        # semantics for chained XOR with duplicate conditions.
+        target = self.numbers[3]
+        q = Q(pk=target.pk)
+        self.assertCountEqual(Number.objects.filter(q), [target])
+        self.assertCountEqual(Number.objects.filter(q ^ q), [])
+        self.assertCountEqual(Number.objects.filter(q ^ q ^ q), [target])
+        self.assertCountEqual(Number.objects.filter(q ^ q ^ q ^ q), [])
+        self.assertCountEqual(Number.objects.filter(q ^ q ^ q ^ q ^ q), [target])


### PR DESCRIPTION
Summary

On DBs without native logical XOR (e.g., PostgreSQL), Django's WhereNode fallback for chained XOR (Q(...) ^ Q(...) ^ ...) incorrectly enforced 'exactly one' semantics. Correct XOR semantics are parity: true iff an odd number of operands are true. This PR updates the fallback to compute parity via modulo of the sum of CASE WHEN predicates.

Linked Issue: #528
Task reference: swev-id: django__django-16901

Change details

- django/db/models/sql/where.py: Replace fallback transformation from
  (a OR b OR c ...) AND (a + b + c + ...) == 1
  to
  (a + b + c + ...) % 2 == 1
  using Django's expression system (CASE + modulo operator). This ensures associative/parity semantics for any number of XOR operands.
- tests/xor_lookups/tests.py: Add coverage for chained XOR over duplicate conditions to ensure odd/even parity behavior: q ^ q -> empty, q ^ q ^ q -> one match, etc.

Reproduction steps

Using the existing xor_lookups test app (SQLite backend exercises the fallback path as supports_logical_xor=False for non-MySQL):

1) Create and select a single target Number:

    target = Number.objects.create(num=3)
    q = Q(pk=target.pk)

2) Evaluate chained XORs:

    Number.objects.filter(q).count()            # 1
    Number.objects.filter(q ^ q).count()        # 0
    Number.objects.filter(q ^ q ^ q).count()    # Expected 1 (odd parity)
    Number.objects.filter(q ^ q ^ q ^ q).count()# Expected 0
    Number.objects.filter(q ^ q ^ q ^ q ^ q).count() # Expected 1

Observed failure (before this fix)

Running the new test against the previous fallback yields the following failure:

    FAIL: test_xor_parity_multiple_arguments_with_duplicates (xor_lookups.tests.XorLookupsTests.test_xor_parity_multiple_arguments_with_duplicates)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/workspace/django/tests/xor_lookups/tests.py", line 76, in test_xor_parity_multiple_arguments_with_duplicates
        self.assertCountEqual(Number.objects.filter(q ^ q ^ q), [target])
        ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AssertionError: Element counts were not equal:
    First has 0, Second has 1:  <Number: 3>

This demonstrates the incorrect 'exactly one' fallback for 3 operands; parity should return one match.

After fix (local validation)

    $ python tests/runtests.py xor_lookups --parallel 1 -v 2
    ...
    Ran 7 tests in 0.007s
    OK

Notes

- This change only affects the fallback path used when connection.features.supports_logical_xor is False.
- MySQL (supports_logical_xor=True) continues to use native XOR handling unchanged.
- No CI was run as per task constraints; local tests focused on the xor_lookups app.