### PR TITLE
swev-id: django__django-16877 Add escapeseq template filter

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -498,6 +498,14 @@ def safeseq(value):
     return [mark_safe(obj) for obj in value]
 
 
+@register.filter(is_safe=True, needs_autoescape=True)
+def escapeseq(value, autoescape=True):
+    """Escape each element in a sequence and return a list."""
+    if autoescape:
+        return [conditional_escape(obj) for obj in value]
+    return [escape(obj) for obj in value]
+
+
 @register.filter(is_safe=True)
 @stringfilter
 def striptags(value):

--- a/docs/ref/templates/builtins.txt
+++ b/docs/ref/templates/builtins.txt
@@ -2375,6 +2375,30 @@ You couldn't use the :tfilter:`safe` filter directly in this case, as it would
 first convert the variable into a string, rather than working with the
 individual elements of the sequence.
 
+.. templatefilter:: escapeseq
+
+``escapeseq``
+-------------
+
+Escapes each item in a sequence and returns a list. This filter is the
+counterpart to :tfilter:`safeseq` and is useful when chaining with
+:tfilter:`join` or other sequence filters.
+
+When auto-escaping is on, the filter uses :func:`~django.utils.html.conditional_escape`
+so that values already marked safe remain unchanged while other values are
+escaped. When auto-escaping is off, each item is escaped explicitly which
+prevents raw HTML from appearing in the output.
+
+.. code-block:: html+django
+
+    {% autoescape off %}
+        {{ some_list|join:", " }}
+        {{ some_list|escapeseq|join:", " }}
+    {% endautoescape %}
+
+This results in the first ``join`` rendering the items without escaping, while
+the ``escapeseq`` call ensures the joined output is HTML-escaped.
+
 .. templatefilter:: slice
 
 ``slice``

--- a/tests/template_tests/filter_tests/test_escapeseq.py
+++ b/tests/template_tests/filter_tests/test_escapeseq.py
@@ -1,0 +1,76 @@
+from django.test import SimpleTestCase
+from django.utils.html import mark_safe
+
+from ..utils import setup
+
+
+class EscapeseqTests(SimpleTestCase):
+    @setup({"escapeseq01": '{{ values|escapeseq|join:", " }}'})
+    def test_autoescape_on(self):
+        output = self.engine.render_to_string(
+            "escapeseq01", {"values": ["&", "<"]}
+        )
+        self.assertEqual(output, "&amp;, &lt;")
+
+    @setup(
+        {
+            "escapeseq02": (
+                '{% autoescape off %}{{ values|join:", " }} -- '
+                '{{ values|escapeseq|join:", " }}{% endautoescape %}'
+            )
+        }
+    )
+    def test_autoescape_off(self):
+        output = self.engine.render_to_string(
+            "escapeseq02", {"values": ["&", "<"]}
+        )
+        self.assertEqual(output, "&, < -- &amp;, &lt;")
+
+    @setup({"escapeseq03": '{{ values|escapeseq|join:", " }}'})
+    def test_safe_items_preserved_with_autoescape(self):
+        safe_value = mark_safe("<em>safe</em>")
+        output = self.engine.render_to_string(
+            "escapeseq03", {"values": [safe_value, "<"]}
+        )
+        self.assertEqual(output, "<em>safe</em>, &lt;")
+
+    @setup(
+        {
+            "escapeseq04": (
+                '{% autoescape off %}{{ values|escapeseq|join:", " }}'
+                '{% endautoescape %}'
+            )
+        }
+    )
+    def test_safe_items_escaped_with_autoescape_off(self):
+        safe_value = mark_safe("<em>safe</em>")
+        output = self.engine.render_to_string(
+            "escapeseq04", {"values": [safe_value, "<"]}
+        )
+        self.assertEqual(output, "&lt;em&gt;safe&lt;/em&gt;, &lt;")
+
+    @setup({"escapeseq05": '{{ values|escapeseq|join:", " }}'})
+    def test_mixed_types_and_generator(self):
+        def value_stream():
+            yield "<tag>"
+            yield 7
+            yield None
+
+        output = self.engine.render_to_string(
+            "escapeseq05", {"values": value_stream()}
+        )
+        self.assertEqual(output, "&lt;tag&gt;, 7, None")
+
+    @setup(
+        {
+            "escapeseq06": (
+                '{% autoescape off %}{{ values|escapeseq|join:sep }}'
+                '{% endautoescape %}'
+            )
+        }
+    )
+    def test_separator_not_escaped_with_autoescape_off(self):
+        output = self.engine.render_to_string(
+            "escapeseq06", {"values": ["&", "<"], "sep": "<hr>"}
+        )
+        self.assertEqual(output, "&amp;<hr>&lt;")


### PR DESCRIPTION
Closes #525

## Summary
- add the `escapeseq` template filter alongside `safeseq`
- document the filter usage and autoescape behavior in `docs/ref/templates/builtins.txt`
- cover autoescape on/off, safe values, generators, and separator handling in `test_escapeseq`

## Observed failure
Steps:
1. Checkout `django__django-16877`.
2. Run:
   ```bash
   PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py template_tests.filter_tests.test_escapeseq --parallel=1
   ```

Output:
```text
Testing against Django installed in '/workspace/django/django'
Found 6 test(s).
System check identified no issues (0 silenced).
EEEEEE
...
django.template.exceptions.TemplateSyntaxError: Invalid filter: 'escapeseq'
```

## Testing
- `PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py template_tests.filter_tests.test_escapeseq template_tests.filter_tests.test_safeseq --parallel=1`
- `flake8 django/template/defaultfilters.py tests/template_tests/filter_tests/test_escapeseq.py`
