### PR TITLE
swev-id: django__django-16899 include offending readonly field name

### DIFF
--- a/django/contrib/admin/checks.py
+++ b/django/contrib/admin/checks.py
@@ -771,10 +771,11 @@ class BaseModelAdminChecks:
             except FieldDoesNotExist:
                 return [
                     checks.Error(
-                        "The value of '%s' is not a callable, an attribute of "
-                        "'%s', or an attribute of '%s'."
+                        "The value of '%s' refers to '%s', which is not a callable, "
+                        "an attribute of '%s', or an attribute of '%s'."
                         % (
                             label,
+                            field_name,
                             obj.__class__.__name__,
                             obj.model._meta.label,
                         ),

--- a/docs/ref/checks.txt
+++ b/docs/ref/checks.txt
@@ -675,8 +675,9 @@ with the admin site:
 * **admin.E033**: The value of ``ordering`` refers to ``<field name>``, which
   is not a field of ``<model>``.
 * **admin.E034**: The value of ``readonly_fields`` must be a list or tuple.
-* **admin.E035**: The value of ``readonly_fields[n]`` is not a callable, an
-  attribute of ``<ModelAdmin class>``, or an attribute of ``<model>``.
+* **admin.E035**: The value of ``readonly_fields[n]`` refers to
+  ``<field name>``, which is not a callable, an attribute of
+  ``<ModelAdmin class>``, or an attribute of ``<model>``.
 * **admin.E036**: The value of ``autocomplete_fields`` must be a list or tuple.
 * **admin.E037**: The value of ``autocomplete_fields[n]`` refers to
   ``<field name>``, which is not a field of ``<model>``.

--- a/tests/admin_checks/tests.py
+++ b/tests/admin_checks/tests.py
@@ -798,8 +798,9 @@ class SystemChecksTestCase(SimpleTestCase):
         errors = SongAdmin(Song, AdminSite()).check()
         expected = [
             checks.Error(
-                "The value of 'readonly_fields[1]' is not a callable, an attribute "
-                "of 'SongAdmin', or an attribute of 'admin_checks.Song'.",
+                "The value of 'readonly_fields[1]' refers to 'nonexistent', which is "
+                "not a callable, an attribute of 'SongAdmin', or an attribute of "
+                "'admin_checks.Song'.",
                 obj=SongAdmin,
                 id="admin.E035",
             )
@@ -814,8 +815,9 @@ class SystemChecksTestCase(SimpleTestCase):
         errors = CityInline(State, AdminSite()).check()
         expected = [
             checks.Error(
-                "The value of 'readonly_fields[0]' is not a callable, an attribute "
-                "of 'CityInline', or an attribute of 'admin_checks.City'.",
+                "The value of 'readonly_fields[0]' refers to 'i_dont_exist', which is "
+                "not a callable, an attribute of 'CityInline', or an attribute of "
+                "'admin_checks.City'.",
                 obj=CityInline,
                 id="admin.E035",
             )


### PR DESCRIPTION
## Summary
- include the offending readonly field name in the admin.E035 message
- align admin readonly field checks tests with the new wording
- document the revised admin.E035 text in the checks reference

Fixes #524.

## Reproduction Steps
1. Create a helper settings module (e.g. `/tmp/django_pytest_settings.py`) with:
   ```python
   from tests.test_sqlite import *  # noqa

   INSTALLED_APPS = [
       "django.contrib.contenttypes",
       "django.contrib.auth",
       "django.contrib.sites",
       "django.contrib.sessions",
       "django.contrib.messages",
       "django.contrib.admin.apps.SimpleAdminConfig",
       "django.contrib.staticfiles",
       "admin_checks",
   ]

   MIDDLEWARE = [
       "django.contrib.sessions.middleware.SessionMiddleware",
       "django.middleware.common.CommonMiddleware",
       "django.middleware.csrf.CsrfViewMiddleware",
       "django.contrib.auth.middleware.AuthenticationMiddleware",
       "django.contrib.messages.middleware.MessageMiddleware",
   ]

   ROOT_URLCONF = "tests.urls"
   SITE_ID = 1
   TEMPLATES = [
       {
           "BACKEND": "django.template.backends.django.DjangoTemplates",
           "DIRS": [],
           "APP_DIRS": True,
           "OPTIONS": {
               "context_processors": [
                   "django.template.context_processors.debug",
                   "django.template.context_processors.request",
                   "django.contrib.auth.context_processors.auth",
                   "django.contrib.messages.context_processors.messages",
               ],
           },
       }
   ]

   STATIC_URL = "static/"
   DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
   ```
2. Run the targeted tests after exporting the environment variables:
   ```
   export PYTHONPATH=/tmp:/workspace/django/tests:/workspace/django
   export DJANGO_SETTINGS_MODULE=django_pytest_settings
   .venv/bin/python -m pytest tests/admin_checks/tests.py::SystemChecksTestCase::test_nonexistent_field -q
   .venv/bin/python -m pytest tests/admin_checks/tests.py::SystemChecksTestCase::test_nonexistent_field_on_inline -q
   ```

## Observed Failure Output
```text
=================================== FAILURES ===================================
_________________ SystemChecksTestCase.test_nonexistent_field __________________

self = <admin_checks.tests.SystemChecksTestCase testMethod=test_nonexistent_field>

    def test_nonexistent_field(self):
        class SongAdmin(admin.ModelAdmin):
            readonly_fields = ("title", "nonexistent")
    
        errors = SongAdmin(Song, AdminSite()).check()
        expected = [
            checks.Error(
                "The value of 'readonly_fields[1]' refers to 'nonexistent', which is "
                "not a callable, an attribute of 'SongAdmin', or an attribute of "
                "'admin_checks.Song'.",
                obj=SongAdmin,
                id="admin.E035",
            )
        ]
>       self.assertEqual(errors, expected)
E       AssertionError: Lists differ: [<Err[48 chars][1]' is not a callable, an attribute of 'SongA[169 chars]35'>] != [<Err[48 chars][1]' refers to 'nonexistent', which is not a c[200 chars]35'>]
E       
E       First differing element 0:
E       <Erro[47 chars][1]' is not a callable, an attribute of 'SongA[168 chars]035'>
E       <Erro[47 chars][1]' refers to 'nonexistent', which is not a c[199 chars]035'>
E       
E       Diff is 754 characters long. Set self.maxDiff to None to see it.

tests/admin_checks/tests.py:808: AssertionError
=========================== short test summary info ============================
FAILED tests/admin_checks/tests.py::SystemChecksTestCase::test_nonexistent_field
1 failed in 0.08s
```
```text
=================================== FAILURES ===================================
____________ SystemChecksTestCase.test_nonexistent_field_on_inline _____________

self = <admin_checks.tests.SystemChecksTestCase testMethod=test_nonexistent_field_on_inline>

    def test_nonexistent_field_on_inline(self):
        class CityInline(admin.TabularInline):
            model = City
            readonly_fields = ["i_dont_exist"]  # Missing attribute
    
        errors = CityInline(State, AdminSite()).check()
        expected = [
            checks.Error(
                "The value of 'readonly_fields[0]' refers to 'i_dont_exist', which is "
                "not a callable, an attribute of 'CityInline', or an attribute of "
                "'admin_checks.City'.",
                obj=CityInline,
                id="admin.E035",
            )
        ]
>       self.assertEqual(errors, expected)
E       AssertionError: Lists differ: [<Err[48 chars][0]' is not a callable, an attribute of 'CityI[181 chars]35'>] != [<Err[48 chars][0]' refers to 'i_dont_exist', which is not a [213 chars]35'>]
E       
E       First differing element 0:
E       <Erro[47 chars][0]' is not a callable, an attribute of 'CityI[180 chars]035'>
E       <Erro[47 chars][0]' refers to 'i_dont_exist', which is not a [212 chars]035'>
E       
E       Diff is 780 characters long. Set self.maxDiff to None to see it.

tests/admin_checks/tests.py:825: AssertionError
=========================== short test summary info ============================
FAILED tests/admin_checks/tests.py::SystemChecksTestCase::test_nonexistent_field_on_inline
1 failed in 0.07s
```

## Fix
- include the offending value in `BaseModelAdminChecks._check_readonly_fields_item()` so `admin.E035` names the attribute that failed resolution
- update the admin checks tests to assert the new wording
- refresh the admin checks documentation entry for `admin.E035`

## Testing
- `PYTHONPATH=/tmp:/workspace/django/tests:/workspace/django DJANGO_SETTINGS_MODULE=django_pytest_settings .venv/bin/python -m pytest tests/admin_checks/tests.py::SystemChecksTestCase::test_nonexistent_field -q`
- `PYTHONPATH=/tmp:/workspace/django/tests:/workspace/django DJANGO_SETTINGS_MODULE=django_pytest_settings .venv/bin/python -m pytest tests/admin_checks/tests.py::SystemChecksTestCase::test_nonexistent_field_on_inline -q`
- `PYTHONPATH=/tmp:/workspace/django/tests:/workspace/django DJANGO_SETTINGS_MODULE=django_pytest_settings .venv/bin/python -m pytest tests/admin_checks/tests.py -q`
