### PR TITLE
swev-id: django__django-16938 - Clear select_related before serializer m2m iteration

### DIFF
--- a/django/core/serializers/python.py
+++ b/django/core/serializers/python.py
@@ -79,7 +79,13 @@ class Serializer(base.Serializer):
                     return self._value_from_field(value, value._meta.pk)
 
                 def queryset_iterator(obj, field):
-                    return getattr(obj, field.name).only("pk").iterator()
+                    return (
+                        getattr(obj, field.name)
+                        .select_related(None)
+                        .prefetch_related(None)
+                        .only("pk")
+                        .iterator()
+                    )
 
             m2m_iter = getattr(obj, "_prefetched_objects_cache", {}).get(
                 field.name,

--- a/django/core/serializers/xml_serializer.py
+++ b/django/core/serializers/xml_serializer.py
@@ -155,7 +155,13 @@ class Serializer(base.Serializer):
                     self.xml.addQuickElement("object", attrs={"pk": str(value.pk)})
 
                 def queryset_iterator(obj, field):
-                    return getattr(obj, field.name).only("pk").iterator()
+                    return (
+                        getattr(obj, field.name)
+                        .select_related(None)
+                        .prefetch_related(None)
+                        .only("pk")
+                        .iterator()
+                    )
 
             m2m_iter = getattr(obj, "_prefetched_objects_cache", {}).get(
                 field.name,

--- a/tests/serializers/test_json.py
+++ b/tests/serializers/test_json.py
@@ -6,7 +6,7 @@ import re
 from django.core import serializers
 from django.core.serializers.base import DeserializationError
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import models
+from django.db import connection, models
 from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.test.utils import isolate_apps
 from django.utils.translation import gettext_lazy, override
@@ -271,6 +271,58 @@ class JsonSerializerTestCase(SerializersTestBase, TestCase):
         expected = "(serializers.m2mdata:pk=1) field_value was 'None'"
         with self.assertRaisesMessage(DeserializationError, expected):
             next(serializers.deserialize("json", test_string, ignore=False))
+
+
+class JsonSerializerSelectRelatedTests(TransactionTestCase):
+    available_apps = ["serializers"]
+
+    @isolate_apps("serializers")
+    def test_m2m_related_manager_select_related(self):
+        class MemberManager(models.Manager):
+            def get_queryset(self):
+                return super().get_queryset().select_related("mentor")
+
+        class Member(models.Model):
+            name = models.CharField(max_length=50)
+            mentor = models.ForeignKey(
+                "self", null=True, blank=True, on_delete=models.CASCADE
+            )
+
+            objects = MemberManager()
+
+            class Meta:
+                db_table = "serializers_json_member"
+
+        class Club(models.Model):
+            name = models.CharField(max_length=50)
+            members = models.ManyToManyField(
+                Member, db_table="serializers_json_club_members"
+            )
+
+            class Meta:
+                db_table = "serializers_json_club"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Member)
+            editor.create_model(Club)
+
+        def teardown_models():
+            with connection.schema_editor() as editor:
+                editor.delete_model(Club)
+                editor.delete_model(Member)
+
+        self.addCleanup(teardown_models)
+
+        mentor = Member.objects.create(name="Mentor")
+        member = Member.objects.create(name="Member", mentor=mentor)
+        club = Club.objects.create(name="Club")
+        club.members.add(member)
+
+        with self.assertNumQueries(1):
+            payload = serializers.serialize("json", [club])
+
+        data = json.loads(payload)
+        self.assertEqual(data[0]["fields"]["members"], [member.pk])
 
 
 class JsonSerializerTransactionTestCase(

--- a/tests/serializers/test_xml.py
+++ b/tests/serializers/test_xml.py
@@ -2,7 +2,9 @@ from xml.dom import minidom
 
 from django.core import serializers
 from django.core.serializers.xml_serializer import DTDForbidden
+from django.db import connection, models
 from django.test import TestCase, TransactionTestCase
+from django.test.utils import isolate_apps
 
 from .tests import SerializersTestBase, SerializersTransactionTestBase
 
@@ -111,3 +113,62 @@ class XmlSerializerTransactionTestCase(
     <object pk="1" model="serializers.category">
         <field type="CharField" name="name">Reference</field></object>
 </django-objects>"""  # NOQA
+
+
+class XmlSerializerSelectRelatedTests(TransactionTestCase):
+    available_apps = ["serializers"]
+
+    @isolate_apps("serializers")
+    def test_m2m_related_manager_select_related(self):
+        class MemberManager(models.Manager):
+            def get_queryset(self):
+                return super().get_queryset().select_related("mentor")
+
+        class Member(models.Model):
+            name = models.CharField(max_length=50)
+            mentor = models.ForeignKey(
+                "self", null=True, blank=True, on_delete=models.CASCADE
+            )
+
+            objects = MemberManager()
+
+            class Meta:
+                db_table = "serializers_xml_member"
+
+        class Club(models.Model):
+            name = models.CharField(max_length=50)
+            members = models.ManyToManyField(
+                Member, db_table="serializers_xml_club_members"
+            )
+
+            class Meta:
+                db_table = "serializers_xml_club"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Member)
+            editor.create_model(Club)
+
+        def teardown_models():
+            with connection.schema_editor() as editor:
+                editor.delete_model(Club)
+                editor.delete_model(Member)
+
+        self.addCleanup(teardown_models)
+
+        mentor = Member.objects.create(name="Mentor")
+        member = Member.objects.create(name="Member", mentor=mentor)
+        club = Club.objects.create(name="Club")
+        club.members.add(member)
+
+        with self.assertNumQueries(1):
+            payload = serializers.serialize("xml", [club])
+
+        dom = minidom.parseString(payload)
+        member_field_nodes = [
+            node
+            for node in dom.getElementsByTagName("field")
+            if node.getAttribute("name") == "members"
+        ]
+        self.assertEqual(len(member_field_nodes), 1)
+        objects = member_field_nodes[0].getElementsByTagName("object")
+        self.assertEqual([obj.getAttribute("pk") for obj in objects], [str(member.pk)])


### PR DESCRIPTION
## Summary
- clear queryset select_related/prefetch_related before only('pk') when serializing M2M relations
- add regression coverage exercising JSON and XML serializers with related managers using select_related
- ensure serialization emits related PKs without FieldError (Fixes #532)

## Testing
- PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py serializers.test_json serializers.test_xml --parallel=1
- PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages flake8 django/core/serializers/python.py django/core/serializers/xml_serializer.py tests/serializers/test_json.py tests/serializers/test_xml.py