### PR TITLE
swev-id: django__django-17029 - Clear get_swappable_settings_name cache in Apps.clear_cache() [skip ci]

### DIFF
--- a/django/apps/registry.py
+++ b/django/apps/registry.py
@@ -376,6 +376,7 @@ class Apps:
         # Call expire cache on each model. This will purge
         # the relation tree and the fields cache.
         self.get_models.cache_clear()
+        self.get_swappable_settings_name.cache_clear()
         if self.ready:
             # Circumvent self.get_models() to prevent that the cache is refilled.
             # This particularly prevents that an empty value is cached while cloning.

--- a/tests/apps/tests.py
+++ b/tests/apps/tests.py
@@ -166,6 +166,22 @@ class AppsTests(SimpleTestCase):
         with self.assertRaisesMessage(LookupError, msg):
             apps.get_app_config("django.contrib.auth")
 
+    def test_clear_cache_clears_swappable_settings_cache(self):
+        with override_settings(
+            INSTALLED_APPS=[
+                "django.contrib.contenttypes",
+                "django.contrib.auth",
+            ]
+        ):
+            self.assertEqual(
+                apps.get_swappable_settings_name("auth.User"),
+                "AUTH_USER_MODEL",
+            )
+            with override_settings(INSTALLED_APPS=["django.contrib.contenttypes"]):
+                self.assertIsNone(
+                    apps.get_swappable_settings_name("auth.User")
+                )
+
     @override_settings(INSTALLED_APPS=SOME_INSTALLED_APPS)
     def test_is_installed(self):
         """


### PR DESCRIPTION
Resolves #535

## Summary
- clear `Apps.get_swappable_settings_name` when purging registry caches
- add a regression test ensuring the swappable settings cache is purged when INSTALLED_APPS changes

## Reproduction
Run the minimal script from the issue on the base branch:

```bash
PYTHONPATH=/workspace/django source .venv/bin/activate
PYTHONPATH=/workspace/django python - <<'PY'
import django
from django.conf import settings
from django.apps import apps
from django.test.utils import override_settings

settings.configure(
    INSTALLED_APPS=['django.contrib.contenttypes', 'django.contrib.auth'],
    SECRET_KEY='test',
)
django.setup()

first = apps.get_swappable_settings_name('auth.User')
assert first == 'AUTH_USER_MODEL'

with override_settings(INSTALLED_APPS=['django.contrib.contenttypes']):
    second = apps.get_swappable_settings_name('auth.User')
    assert second is None
PY
```

Observed failure before the fix:

```
first: AUTH_USER_MODEL
second: AUTH_USER_MODEL
Traceback (most recent call last):
  File "<stdin>", line 19, in <module>
AssertionError
```

## Testing
- `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py apps.tests.AppsTests.test_clear_cache_clears_swappable_settings_cache --parallel=1`
- `PYTHONPATH=/workspace/django DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py apps --parallel=1`

Local tests pass after the fix.