### PR TITLE
fix: swev-id: django__django-17087 use qualname for nested defaults

### DIFF
--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -168,7 +168,7 @@ class FunctionTypeSerializer(BaseSerializer):
         ):
             klass = self.value.__self__
             module = klass.__module__
-            return "%s.%s.%s" % (module, klass.__name__, self.value.__name__), {
+            return "%s.%s.%s" % (module, klass.__qualname__, self.value.__name__), {
                 "import %s" % module
             }
         # Further error checking

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -211,6 +211,14 @@ class WriterTests(SimpleTestCase):
         X = "X", "X value"
         Y = "Y", "Y value"
 
+    class NestedChoicesWithDefault(models.TextChoices):
+        A = "A", "A value"
+        B = "B", "B value"
+
+        @classmethod
+        def default(cls):
+            return cls.A
+
     def safe_exec(self, string, value=None):
         d = {}
         try:
@@ -467,6 +475,23 @@ class WriterTests(SimpleTestCase):
                         {"import migrations.test_writer"},
                     ),
                 )
+
+    def test_serialize_nested_class_method_default(self):
+        field = models.CharField(
+            choices=WriterTests.NestedChoicesWithDefault,
+            default=WriterTests.NestedChoicesWithDefault.default,
+            max_length=1,
+        )
+        string = MigrationWriter.serialize(field)[0]
+        self.assertEqual(
+            string,
+            (
+                "models.CharField(choices=[('A', 'A value'), ('B', 'B value')], "
+                "default=migrations.test_writer.WriterTests."
+                "NestedChoicesWithDefault.default, "
+                "max_length=1)"
+            ),
+        )
 
     def test_serialize_uuid(self):
         self.assertSerializedEqual(uuid.uuid1())


### PR DESCRIPTION
## Summary
- use klass.__qualname__ when serializing bound class methods so nested classes resolve correctly
- add regression coverage for a nested TextChoices default on WriterTests

## Testing
- PYTHONPATH=$PWD/tests:$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py migrations.test_writer.WriterTests.test_serialize_nested_class_method_default --parallel=1
- .venv/bin/flake8 django/db/migrations/serializer.py tests/migrations/test_writer.py

## Reproduction Steps
1. On django__django-17087, run:
   ```
   PYTHONPATH=$PWD/tests:$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite python tests/runtests.py migrations.test_writer.WriterTests.test_serialize_nested_class_method_default --parallel=1
   ```
2. Observed failure:
   ```
   AssertionError: "models.CharField(choices=[('A', 'A value'), ('B', 'B value')], default=migrations.test_writer.NestedChoicesWithDefault.default, max_length=1)" != "models.CharField(choices=[('A', 'A value'), ('B', 'B value')], default=migrations.test_writer.WriterTests.NestedChoicesWithDefault.default, max_length=1)"
   ```

Fixes #536}