### PR TITLE
swev-id: django__django-16950 Prevent clearing non-PK to_field (UUID) defaults during Inline formset add

### DIFF
--- a/django/forms/models.py
+++ b/django/forms/models.py
@@ -1172,11 +1172,8 @@ class BaseInlineFormSet(BaseModelFormSet):
 
         # If we're adding a new object, ignore a parent's auto-generated key
         # as it will be regenerated on the save request.
-        if self.instance._state.adding:
-            if kwargs.get("to_field") is not None:
-                to_field = self.instance._meta.get_field(kwargs["to_field"])
-            else:
-                to_field = self.instance._meta.pk
+        if self.instance._state.adding and kwargs.get("to_field") is None:
+            to_field = self.instance._meta.pk
             if to_field.has_default():
                 setattr(self.instance, to_field.attname, None)
 

--- a/tests/admin_views/admin.py
+++ b/tests/admin_views/admin.py
@@ -18,6 +18,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.views.decorators.common import no_append_slash
 
+from . import models as admin_views_models
 from .forms import MediaActionForm
 from .models import (
     Actor,
@@ -311,6 +312,16 @@ class CustomArticleAdmin(admin.ModelAdmin):
 
 class ThingAdmin(admin.ModelAdmin):
     list_filter = ("color", "color__warm", "color__value", "pub_date")
+
+
+class SubThingUUIDFKInline(admin.TabularInline):
+    model = admin_views_models.SubThingUUIDFK
+
+
+class ThingWithUUIDAdmin(admin.ModelAdmin):
+    inlines = [SubThingUUIDFKInline]
+    list_display = ("uuid", "name")
+    readonly_fields = ("uuid",)
 
 
 class InquisitionAdmin(admin.ModelAdmin):
@@ -1189,6 +1200,7 @@ site.register(
 site.register(ModelWithStringPrimaryKey)
 site.register(Color)
 site.register(Thing, ThingAdmin)
+site.register(admin_views_models.ThingWithUUID, ThingWithUUIDAdmin)
 site.register(Actor)
 site.register(Inquisition, InquisitionAdmin)
 site.register(Sketch, SketchAdmin)

--- a/tests/admin_views/models.py
+++ b/tests/admin_views/models.py
@@ -159,6 +159,21 @@ class Thing(models.Model):
         return self.title
 
 
+class ThingWithUUID(models.Model):
+    uuid = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
+    name = models.CharField(max_length=20, blank=True)
+
+
+class SubThingUUIDFK(models.Model):
+    thing = models.ForeignKey(
+        ThingWithUUID,
+        models.CASCADE,
+        to_field="uuid",
+        related_name="subthings",
+    )
+    name = models.CharField(max_length=20)
+
+
 class Actor(models.Model):
     name = models.CharField(max_length=50)
     age = models.IntegerField()

--- a/tests/admin_views/test_admin_inline_fk_to_uuid.py
+++ b/tests/admin_views/test_admin_inline_fk_to_uuid.py
@@ -1,0 +1,56 @@
+import uuid
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from .models import SubThingUUIDFK, ThingWithUUID
+
+
+@override_settings(ROOT_URLCONF="admin_views.urls")
+class InlineUUIDToFieldTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="super", password="secret", email="super@example.com"
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_inline_fk_to_uuid_uses_parent_default(self):
+        constant_uuid = uuid.UUID("00000000-0000-0000-0000-000000000001")
+        uuid_field = ThingWithUUID._meta.get_field("uuid")
+        original_default = uuid_field.default
+        uuid_field.default = lambda: constant_uuid
+        self.addCleanup(setattr, uuid_field, "default", original_default)
+
+        add_url = reverse("admin:admin_views_thingwithuuid_add")
+        response = self.client.get(add_url)
+        self.assertEqual(response.status_code, 200)
+
+        inline_formset = response.context["inline_admin_formsets"][0].formset
+        management_data = {
+            f"{inline_formset.prefix}-{key}": str(value)
+            for key, value in inline_formset.management_form.initial.items()
+        }
+        management_data[f"{inline_formset.prefix}-TOTAL_FORMS"] = "1"
+        management_data[f"{inline_formset.prefix}-INITIAL_FORMS"] = "0"
+
+        post_data = {
+            "name": "Parent",
+            f"{inline_formset.prefix}-0-id": "",
+            f"{inline_formset.prefix}-0-thing": str(constant_uuid),
+            f"{inline_formset.prefix}-0-name": "Child",
+            "_save": "Save",
+        }
+        post_data.update(management_data)
+
+        response = self.client.post(add_url, post_data)
+        self.assertEqual(response.status_code, 302)
+
+        parent = ThingWithUUID.objects.get()
+        child = SubThingUUIDFK.objects.get()
+        self.assertIsNotNone(parent.uuid)
+        self.assertEqual(parent.uuid, constant_uuid)
+        self.assertEqual(child.thing_id, constant_uuid)


### PR DESCRIPTION
## Summary
- keep BaseInlineFormSet from clearing parent defaults when FK targets a non-PK to_field
- add ThingWithUUID/SubThingUUIDFK fixtures and inline admin registration for coverage
- verify admin add flow preserves UUID defaults via regression test

## Testing
- PYTHONPATH=$PWD:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py admin_views --parallel=1

## Reproduction
1. Create ThingWithUUID with SubThingUUIDFK inline pointing to `to_field='uuid'`.
2. Open the admin add view and submit a child inline row.
3. Observe inline validation failing because the parent UUID default is cleared to `None`.

Closes #534