### PR TITLE
fix: wrap windowed aggregates (swev-id: django__django-17084)

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -403,6 +403,7 @@ class Query(BaseExpression):
         # Store annotation mask prior to temporarily adding aggregations for
         # resolving purpose to facilitate their subsequent removal.
         refs_subquery = False
+        refs_window = False
         replacements = {}
         annotation_select_mask = self.annotation_select_mask
         for alias, aggregate_expr in aggregate_exprs.items():
@@ -415,9 +416,14 @@ class Query(BaseExpression):
             # Temporarily add aggregate to annotations to allow remaining
             # members of `aggregates` to resolve against each others.
             self.append_annotation_mask([alias])
+            refs = aggregate.get_refs()
             refs_subquery |= any(
                 getattr(self.annotations[ref], "subquery", False)
-                for ref in aggregate.get_refs()
+                for ref in refs
+            )
+            refs_window |= any(
+                getattr(self.annotations[ref], "contains_over_clause", False)
+                for ref in refs
             )
             aggregate = aggregate.replace_expressions(replacements)
             self.annotations[alias] = aggregate
@@ -451,6 +457,7 @@ class Query(BaseExpression):
             or self.is_sliced
             or has_existing_aggregation
             or refs_subquery
+            or refs_window
             or qualify
             or self.distinct
             or self.combinator

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -27,6 +27,7 @@ from django.db.models import (
     TimeField,
     Value,
     Variance,
+    Window,
     When,
 )
 from django.db.models.expressions import Func, RawSQL
@@ -39,6 +40,7 @@ from django.db.models.functions import (
     Mod,
     Now,
     Pi,
+    RowNumber,
     TruncDate,
     TruncHour,
 )
@@ -2114,6 +2116,26 @@ class AggregateTestCase(TestCase):
                 "coalesced_total_books": 10,
             },
         )
+
+    @skipUnlessDBFeature("supports_over_clause")
+    def test_aggregate_over_window_annotation(self):
+        total_books = Book.objects.count()
+        queryset = Book.objects.annotate(
+            row_number=Window(
+                expression=RowNumber(),
+                order_by=[F("pk").asc()],
+            )
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            result = queryset.aggregate(total=Sum("row_number"))
+        self.assertEqual(
+            result,
+            {"total": sum(range(1, total_books + 1))},
+        )
+        self.assertEqual(len(ctx.captured_queries), 1)
+        sql = ctx.captured_queries[0]["sql"].lower()
+        self.assertEqual(sql.count("select"), 2, "Subquery wrapping required")
+        self.assertIn("from (select", sql)
 
 
 class AggregateAnnotationPruningTests(TestCase):


### PR DESCRIPTION
## Summary
- detect when aggregates reference window annotations and force subquery wrapping
- add regression coverage ensuring the ORM emits a wrapped query for window aggregates
- confirm aggregation over window annotations now succeeds on backends with OVER support

## Observed failure
`psycopg2.errors.GroupingError: aggregate function calls cannot contain window function calls`

## Stack trace
```
psycopg2.errors.GroupingError: aggregate function calls cannot contain window function calls
  File "django/db/backends/utils.py", line XXX, in _execute
    return self.cursor.execute(sql, params)
  File "django/db/models/sql/compiler.py", line XXX, in execute_sql
    cursor.execute(sql, params)
  File "django/db/models/query.py", line XXX, in aggregate
    return query.chain().get_aggregation(self.db, kwargs)
  ...
```

## Reproduction steps
1. Annotate a queryset with a window expression, e.g. `Window(Sum("value"), order_by=F("date").asc())`.
2. Aggregate over both the original value and the window annotation.
3. Run the query on PostgreSQL.
4. Observe Django emits `SUM(Window(...))` in a single SELECT and PostgreSQL raises `psycopg2.errors.GroupingError`.

## Fix
- track whether aggregates reference annotations whose expressions contain an OVER clause during resolution
- include this flag when deciding whether to wrap the base query in an aggregate subquery
- add a regression test confirming the ORM generates a subquery and the aggregate succeeds

## Testing
- `PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite $HOME/.nix-profile/bin/python3.11 tests/runtests.py aggregation --parallel=1`
- `$HOME/.nix-profile/bin/python3.11 -m flake8 django/db/models/sql/query.py tests/aggregation/tests.py`

Fixes #537