### PR TITLE
feat: swev-id: django__django-9296 make paginator iterable

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -106,6 +106,10 @@ class Paginator:
         """
         return range(1, self.num_pages + 1)
 
+    def __iter__(self):
+        for page_num in self.page_range:
+            yield self.page(page_num)
+
     def _check_object_list_is_ordered(self):
         """
         Warn if self.object_list is unordered (typically a QuerySet).

--- a/docs/topics/pagination.txt
+++ b/docs/topics/pagination.txt
@@ -33,6 +33,11 @@ accessing the items for each page::
     >>> p.page_range
     range(1, 3)
 
+    >>> for page in p:
+    ...     page
+    <Page 1 of 2>
+    <Page 2 of 2>
+
     >>> page1 = p.page(1)
     >>> page1
     <Page 1 of 2>
@@ -67,6 +72,10 @@ accessing the items for each page::
     Traceback (most recent call last):
     ...
     EmptyPage: That page contains no results
+
+``Paginator`` instances implement the iterator protocol, so you can loop over
+them to retrieve each page lazily. Iteration yields the same pages that are
+exposed through :attr:`~django.core.paginator.Paginator.page_range`.
 
 .. note::
 

--- a/tests/pagination/tests.py
+++ b/tests/pagination/tests.py
@@ -2,7 +2,7 @@ import warnings
 from datetime import datetime
 
 from django.core.paginator import (
-    EmptyPage, InvalidPage, PageNotAnInteger, Paginator,
+    EmptyPage, InvalidPage, Page, PageNotAnInteger, Paginator,
     UnorderedObjectListWarning,
 )
 from django.test import SimpleTestCase, TestCase
@@ -149,6 +149,69 @@ class PaginationTests(SimpleTestCase):
         self.assertEqual(42, paginator.count)
         self.assertEqual(5, paginator.num_pages)
         self.assertEqual([1, 2, 3, 4, 5], list(paginator.page_range))
+
+    def test_iteration_yields_pages(self):
+        paginator = Paginator(range(1, 8), 3)
+        pages = list(paginator)
+        self.assertTrue(pages)
+        self.assertTrue(all(isinstance(page, Page) for page in pages))
+        self.assertEqual([1, 2, 3], [page.number for page in pages])
+
+    def test_iteration_edge_cases(self):
+        cases = (
+            ([], 5, 0, True, [1]),
+            ([], 5, 0, False, []),
+            ([1], 5, 0, True, [1]),
+            (list(range(11)), 10, 1, True, [1]),
+            (list(range(12)), 10, 1, True, [1, 2]),
+        )
+        for object_list, per_page, orphans, allow_empty, expected in cases:
+            with self.subTest(
+                object_list=object_list,
+                per_page=per_page,
+                orphans=orphans,
+                allow_empty=allow_empty,
+            ):
+                paginator = Paginator(
+                    object_list, per_page, orphans=orphans,
+                    allow_empty_first_page=allow_empty,
+                )
+                pages = list(paginator)
+                self.assertEqual(expected, [page.number for page in pages])
+                self.assertTrue(all(isinstance(page, Page) for page in pages))
+
+    def test_iteration_is_lazy(self):
+        class RecordingPaginator(Paginator):
+            def __init__(self, *args, **kwargs):
+                self.page_calls = []
+                super().__init__(*args, **kwargs)
+
+            def page(self, number):
+                self.page_calls.append(number)
+                return super().page(number)
+
+        paginator = RecordingPaginator(range(6), 2)
+        iterator = iter(paginator)
+        self.assertEqual([], paginator.page_calls)
+
+        first = next(iterator)
+        self.assertEqual([1], paginator.page_calls)
+        self.assertEqual(1, first.number)
+
+        second = next(iterator)
+        self.assertEqual([1, 2], paginator.page_calls)
+        self.assertEqual(2, second.number)
+
+        third = next(iterator)
+        self.assertEqual([1, 2, 3], paginator.page_calls)
+        self.assertEqual(3, third.number)
+
+        with self.assertRaises(StopIteration):
+            next(iterator)
+
+        empty = RecordingPaginator([], 2, allow_empty_first_page=False)
+        self.assertEqual([], list(empty))
+        self.assertEqual([], empty.page_calls)
 
     def test_count_does_not_silence_attribute_error(self):
         class AttributeErrorContainer:


### PR DESCRIPTION
## Summary
- implement Paginator.__iter__ to iterate over page_range
- add iteration tests covering edge cases and laziness
- document Paginator iterability in pagination topic docs

## Testing
- PYTHONPATH=/workspace/django:/root/.nix-profile/lib/python3.11/site-packages:/nix/store/kbyysxq0ry8vqbpkdwld118fi92wvqsf-python3-3.11.14/lib/python3.11/site-packages /root/.nix-profile/bin/python3 tests/runtests.py pagination --parallel=1
- /root/.nix-profile/bin/flake8 django/core/paginator.py tests/pagination/tests.py

References #542