### PR TITLE
Fix: get_format accepts lazy format strings (date filter regression) [swev-id: django__django-15741]

### DIFF
--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -7,6 +7,7 @@ from importlib import import_module
 
 from django.conf import settings
 from django.utils import dateformat, numberformat
+from django.utils.encoding import force_str
 from django.utils.functional import lazy
 from django.utils.translation import check_for_language, get_language, to_locale
 
@@ -106,6 +107,8 @@ def get_format(format_type, lang=None, use_l10n=None):
     If use_l10n is provided and is not None, it forces the value to
     be localized (or not), overriding the value of settings.USE_L10N.
     """
+    if not isinstance(format_type, str):
+        format_type = force_str(format_type)
     if use_l10n is None:
         try:
             use_l10n = settings._USE_L10N_INTERNAL

--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -108,7 +108,7 @@ def get_format(format_type, lang=None, use_l10n=None):
     be localized (or not), overriding the value of settings.USE_L10N.
     """
     if not isinstance(format_type, str):
-        format_type = force_str(format_type)
+        format_type = force_str(format_type, strings_only=True)
     if use_l10n is None:
         try:
             use_l10n = settings._USE_L10N_INTERNAL

--- a/tests/template_tests/filter_tests/test_date.py
+++ b/tests/template_tests/filter_tests/test_date.py
@@ -3,12 +3,21 @@ from datetime import datetime, time
 from django.template.defaultfilters import date
 from django.test import SimpleTestCase
 from django.utils import timezone, translation
+from django.utils.translation import gettext_lazy
 
 from ..utils import setup
 from .timezone_utils import TimezoneTestCase
 
 
 class DateTests(TimezoneTestCase):
+    @setup({"date_lazy_format": "{{ d|date:fmt }}"})
+    def test_lazy_format_string(self):
+        output = self.engine.render_to_string(
+            "date_lazy_format",
+            {"d": datetime(2020, 1, 1), "fmt": gettext_lazy("Y-m-d")},
+        )
+        self.assertEqual(output, "2020-01-01")
+
     @setup({"date01": '{{ d|date:"m" }}'})
     def test_date01(self):
         output = self.engine.render_to_string("date01", {"d": datetime(2008, 1, 1)})

--- a/tests/utils_tests/test_formats_get_format.py
+++ b/tests/utils_tests/test_formats_get_format.py
@@ -25,3 +25,6 @@ class GetFormatTests(SimpleTestCase):
 
     def test_safe_string_literal(self):
         self.assertEqual(formats.get_format(mark_safe("Y-m-d")), "Y-m-d")
+
+    def test_protected_type_preserved(self):
+        self.assertIsNone(formats.get_format(None, use_l10n=False))

--- a/tests/utils_tests/test_formats_get_format.py
+++ b/tests/utils_tests/test_formats_get_format.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase
+from django.utils import formats
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy
+
+
+class GetFormatTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        formats.reset_format_cache()
+        self.addCleanup(formats.reset_format_cache)
+
+    def test_lazy_literal_format(self):
+        self.assertEqual(formats.get_format(gettext_lazy("Y-m-d")), "Y-m-d")
+
+    def test_lazy_setting_lookup(self):
+        value = formats.get_format(gettext_lazy("DATE_FORMAT"))
+        self.assertIsInstance(value, str)
+
+    def test_bytes_input(self):
+        self.assertEqual(formats.get_format(b"Y-m-d"), "Y-m-d")
+
+    def test_non_ascii_literal(self):
+        self.assertEqual(formats.get_format("Y年m月d日"), "Y年m月d日")
+
+    def test_safe_string_literal(self):
+        self.assertEqual(formats.get_format(mark_safe("Y-m-d")), "Y-m-d")


### PR DESCRIPTION
This PR fixes a regression where lazy format strings passed via the date template filter cause:

`TypeError: getattr(): attribute name must be string` in `django.utils.formats.get_format`.

- Implements coercion of non-`str` inputs (lazy gettext `Promise`, `bytes`) to native `str` via `force_str` at the top of `get_format`.
- Adds tests covering template date filter with a lazy format and direct `get_format` cases (lazy, bytes, non-ASCII, SafeString).

Linked Issue: #547

Reproduction steps:
```python
import datetime
from django.conf import settings
settings.configure(USE_L10N=True, USE_I18N=True, LANGUAGE_CODE='en', INSTALLED_APPS=[], TIME_ZONE='UTC')
import django; django.setup()
from django.utils.translation import gettext_lazy as _
from django.utils import formats
d = datetime.date(2020,1,1)
formats.date_format(d, _('Y-m-d'))
```

Observed stack trace excerpt:
```
TypeError: getattr(): attribute name must be string
  File "django/utils/formats.py", line 158, in date_format
    value, get_format(format or "DATE_FORMAT", use_l10n=use_l10n)
  File "django/utils/formats.py", line 128, in get_format
    val = getattr(module, format_type, None)
```

Notes:
- Base branch: django__django-15741
- CI is intentionally not run per project instructions.
