### PR TITLE
swev-id: django__django-15741 - Coerce get_format lazy inputs

### DIFF
--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -7,6 +7,7 @@ from importlib import import_module
 
 from django.conf import settings
 from django.utils import dateformat, numberformat
+from django.utils.encoding import force_str
 from django.utils.functional import lazy
 from django.utils.translation import check_for_language, get_language, to_locale
 
@@ -106,6 +107,8 @@ def get_format(format_type, lang=None, use_l10n=None):
     If use_l10n is provided and is not None, it forces the value to
     be localized (or not), overriding the value of settings.USE_L10N.
     """
+    format_type = force_str(format_type)
+
     if use_l10n is None:
         try:
             use_l10n = settings._USE_L10N_INTERNAL

--- a/tests/template_tests/filter_tests/test_date.py
+++ b/tests/template_tests/filter_tests/test_date.py
@@ -1,8 +1,10 @@
 from datetime import datetime, time
 
+from django.conf import settings
 from django.template.defaultfilters import date
 from django.test import SimpleTestCase
-from django.utils import timezone, translation
+from django.utils import formats, timezone, translation
+from django.utils.translation import gettext_lazy
 
 from ..utils import setup
 from .timezone_utils import TimezoneTestCase
@@ -83,3 +85,25 @@ class FunctionTests(SimpleTestCase):
 
     def test_escape_characters(self):
         self.assertEqual(date(datetime(2005, 12, 29), r"jS \o\f F"), "29th of December")
+
+    def test_lazy_format_string(self):
+        lazy_format = gettext_lazy("Y-m-d")
+        with translation.override("en"):
+            self.assertEqual(date(datetime(2024, 1, 2), lazy_format), "2024-01-02")
+
+    def test_get_format_with_lazy_string(self):
+        with translation.override("en"):
+            result = formats.get_format(gettext_lazy("Y-m-d"), use_l10n=True)
+        self.assertEqual(result, "Y-m-d")
+        self.assertIsInstance(result, str)
+
+    def test_get_format_named_setting(self):
+        with translation.override("en"):
+            result = formats.get_format("DATE_FORMAT", use_l10n=True)
+        self.assertEqual(result, settings.DATE_FORMAT)
+
+    def test_get_format_bytes_input(self):
+        with translation.override("en"):
+            result = formats.get_format(b"Y-m-d", use_l10n=True)
+        self.assertEqual(result, "Y-m-d")
+        self.assertIsInstance(result, str)


### PR DESCRIPTION
## Summary
- coerce format_type in django.utils.formats.get_format with force_str to normalize lazy inputs
- add template date filter regression tests covering lazy, named, and bytes formats

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=tests.test_sqlite .venv/bin/python tests/runtests.py template_tests.filter_tests.test_date --parallel=1
- .venv/bin/flake8 django/utils/formats.py tests/template_tests/filter_tests/test_date.py

Fixes #548