### PR TITLE
swev-id: django__django-15741 fix get_format lazy literal

### DIFF
--- a/django/utils/formats.py
+++ b/django/utils/formats.py
@@ -7,6 +7,7 @@ from importlib import import_module
 
 from django.conf import settings
 from django.utils import dateformat, numberformat
+from django.utils.encoding import force_str
 from django.utils.functional import lazy
 from django.utils.translation import check_for_language, get_language, to_locale
 
@@ -113,6 +114,9 @@ def get_format(format_type, lang=None, use_l10n=None):
             use_l10n = settings.USE_L10N
     if use_l10n and lang is None:
         lang = get_language()
+    format_type = force_str(format_type)
+    if format_type not in FORMAT_SETTINGS and not format_type.isidentifier():
+        return format_type
     cache_key = (format_type, lang)
     try:
         return _format_cache[cache_key]

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -1652,6 +1652,23 @@ class FormattingTests(SimpleTestCase):
     def test_format_arbitrary_settings(self):
         self.assertEqual(get_format("DEBUG"), "DEBUG")
 
+    def test_get_format_lazy_literal(self):
+        reset_format_cache()
+        lazy_format = gettext_lazy("Y-m-d")
+        result = get_format(lazy_format)
+        self.assertEqual(result, "Y-m-d")
+        self.assertIsInstance(result, str)
+
+    def test_get_format_lazy_setting_name(self):
+        reset_format_cache()
+        with translation.override("en", deactivate=True):
+            expected = get_format("DATE_FORMAT")
+        reset_format_cache()
+        with translation.override("en", deactivate=True):
+            lazy_format = gettext_lazy("DATE_FORMAT")
+            result = get_format(lazy_format)
+        self.assertEqual(result, expected)
+
     def test_get_custom_format(self):
         reset_format_cache()
         with self.settings(FORMAT_MODULE_PATH="i18n.other.locale"):

--- a/tests/template_tests/filter_tests/test_date.py
+++ b/tests/template_tests/filter_tests/test_date.py
@@ -3,6 +3,7 @@ from datetime import datetime, time
 from django.template.defaultfilters import date
 from django.test import SimpleTestCase
 from django.utils import timezone, translation
+from django.utils.translation import gettext_lazy
 
 from ..utils import setup
 from .timezone_utils import TimezoneTestCase
@@ -27,6 +28,15 @@ class DateTests(TimezoneTestCase):
                 "date02_l10n", {"d": datetime(2008, 1, 1)}
             )
         self.assertEqual(output, "1 janvier 2008")
+
+    @setup({"date_lazy_literal": "{{ d|date:fmt }}"})
+    def test_date_lazy_literal_format(self):
+        lazy_format = gettext_lazy("Y-m-d")
+        output = self.engine.render_to_string(
+            "date_lazy_literal",
+            {"d": datetime(2008, 1, 1), "fmt": lazy_format},
+        )
+        self.assertEqual(output, "2008-01-01")
 
     @setup({"date03": '{{ d|date:"m" }}'})
     def test_date03(self):


### PR DESCRIPTION
## Summary
- normalize \`format_type\` via \`force_str\` and treat non-identifier literals as direct values
- preserve localization module lookups for named keys, including lazy names
- add regression coverage for lazy literals in \`get_format\` and the date filter

## Testing
- \`PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py i18n --parallel=1\`
- \`PYTHONPATH=$PWD:$PWD/tests:$HOME/.nix-profile/lib/python3.11/site-packages DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py template_tests.filter_tests.test_date --parallel=1\`
- \`/root/.local/bin/flake8 django/utils/formats.py tests/i18n/tests.py tests/template_tests/filter_tests/test_date.py\`

## Reproduction
1. Install deps: \`pip3 install --user --break-system-packages asgiref sqlparse pytz\`
2. Set \`PYTHONPATH=/workspace/django\`
3. Run the script from #551 (see description) rendering `{{ d|date:_('Y-m-d') }}`

### Observed failure (before fix)
```
Traceback (most recent call last):
  File "reproduce_lazy_date.py", line 22, in <module>
    print(tmpl.render(ctx))
  File "django/template/defaultfilters.py", line 764, in date
    return formats.date_format(value, arg)
  File "django/utils/formats.py", line 128, in get_format
    val = getattr(module, format_type, None)
TypeError: attribute name must be string, not '__proxy__'
```

Fixes #551