### PR TITLE
fix: swev-id: django__django-14007 apply returning converters

### DIFF
--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -6,7 +6,8 @@ from itertools import chain
 from django.core.exceptions import EmptyResultSet, FieldError
 from django.db import DatabaseError, NotSupportedError
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import F, OrderBy, RawSQL, Ref, Value
+from django.db.models.expressions import Col, F, OrderBy, RawSQL, Ref, Value
+from django.db.models.fields import Field
 from django.db.models.functions import Cast, Random
 from django.db.models.query_utils import Q, select_related_descend
 from django.db.models.sql.constants import (
@@ -1101,6 +1102,8 @@ class SQLCompiler:
         converters = {}
         for i, expression in enumerate(expressions):
             if expression:
+                if isinstance(expression, Field):
+                    expression = Col(None, expression)
                 backend_converters = self.connection.ops.get_db_converters(expression)
                 field_converters = expression.get_db_converters(self.connection)
                 if backend_converters or field_converters:
@@ -1412,13 +1415,18 @@ class SQLInsertCompiler(SQLCompiler):
             if not self.returning_fields:
                 return []
             if self.connection.features.can_return_rows_from_bulk_insert and len(self.query.objs) > 1:
-                return self.connection.ops.fetch_returned_insert_rows(cursor)
-            if self.connection.features.can_return_columns_from_insert:
+                rows = list(self.connection.ops.fetch_returned_insert_rows(cursor))
+            elif self.connection.features.can_return_columns_from_insert:
                 assert len(self.query.objs) == 1
-                return [self.connection.ops.fetch_returned_insert_columns(cursor, self.returning_params)]
-            return [(self.connection.ops.last_insert_id(
-                cursor, self.query.get_meta().db_table, self.query.get_meta().pk.column
-            ),)]
+                rows = [self.connection.ops.fetch_returned_insert_columns(cursor, self.returning_params)]
+            else:
+                rows = [(self.connection.ops.last_insert_id(
+                    cursor, self.query.get_meta().db_table, self.query.get_meta().pk.column
+                ),)]
+            converters = self.get_converters(self.returning_fields)
+            if converters:
+                rows = [tuple(row) for row in self.apply_converters(rows, converters)]
+            return rows
 
 
 class SQLDeleteCompiler(SQLCompiler):

--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -735,12 +735,41 @@ class CreatedField(models.DateTimeField):
         super().__init__(*args, **kwargs)
 
 
+class WrappedId(int):
+    pass
+
+
+class WrappedBigAutoField(models.BigAutoField):
+
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return value
+        return WrappedId(value)
+
+    def to_python(self, value):
+        if value is None or isinstance(value, WrappedId):
+            return value
+        value = super().to_python(value)
+        if value is None:
+            return value
+        return WrappedId(value)
+
+    def get_prep_value(self, value):
+        if isinstance(value, WrappedId):
+            value = int(value)
+        return super().get_prep_value(value)
+
+
 class ReturningModel(models.Model):
     created = CreatedField(editable=False)
 
 
 class NonIntegerPKReturningModel(models.Model):
     created = CreatedField(editable=False, primary_key=True)
+
+
+class ConvertedPKReturningModel(models.Model):
+    id = WrappedBigAutoField(primary_key=True)
 
 
 class JSONFieldNullable(models.Model):

--- a/tests/queries/test_db_returning.py
+++ b/tests/queries/test_db_returning.py
@@ -1,10 +1,16 @@
 import datetime
 
 from django.db import connection
-from django.test import TestCase, skipUnlessDBFeature
+from django.test import TestCase, skipIfDBFeature, skipUnlessDBFeature
 from django.test.utils import CaptureQueriesContext
 
-from .models import DumbCategory, NonIntegerPKReturningModel, ReturningModel
+from .models import (
+    ConvertedPKReturningModel,
+    DumbCategory,
+    NonIntegerPKReturningModel,
+    ReturningModel,
+    WrappedId,
+)
 
 
 @skipUnlessDBFeature('can_return_columns_from_insert')
@@ -41,6 +47,10 @@ class ReturningValuesTests(TestCase):
         self.assertTrue(obj.pk)
         self.assertIsInstance(obj.created, datetime.datetime)
 
+    def test_insert_returning_runs_field_converters(self):
+        obj = ConvertedPKReturningModel.objects.create()
+        self.assertIsInstance(obj.id, WrappedId)
+
     @skipUnlessDBFeature('can_return_rows_from_bulk_insert')
     def test_bulk_insert(self):
         objs = [ReturningModel(), ReturningModel(pk=2 ** 11), ReturningModel()]
@@ -49,3 +59,19 @@ class ReturningValuesTests(TestCase):
             with self.subTest(obj=obj):
                 self.assertTrue(obj.pk)
                 self.assertIsInstance(obj.created, datetime.datetime)
+
+    @skipUnlessDBFeature('can_return_rows_from_bulk_insert')
+    def test_bulk_insert_runs_field_converters(self):
+        objs = [ConvertedPKReturningModel(), ConvertedPKReturningModel()]
+        ConvertedPKReturningModel.objects.bulk_create(objs)
+        for obj in objs:
+            with self.subTest(obj=obj):
+                self.assertIsInstance(obj.id, WrappedId)
+
+
+@skipIfDBFeature('can_return_columns_from_insert')
+class ReturningLastInsertIdTests(TestCase):
+
+    def test_insert_uses_field_converters(self):
+        obj = ConvertedPKReturningModel.objects.create()
+        self.assertIsInstance(obj.id, WrappedId)


### PR DESCRIPTION
## Summary
- add regression coverage to assert Field.from_db_value is applied to INSERT-returned primary keys, bulk results, and last_insert_id backends
- ensure SQLInsertCompiler runs field/backend converters for returned rows/columns and adapts plain Fields via Col wrappers

Fixes #553

## Reproduction
1. Install test dependencies (e.g., via `nix profile add nixpkgs#python311{,Packages.{asgiref,sqlparse,pytz,tzdata,flake8}}`).
2. Run:
   ```bash
   PYTHONPATH="$PWD:$PWD/tests:/nix/store/hcm7w4jsaxwwdvhvyld5z1y2wzj0hri6-python3.11-asgiref-3.9.1/lib/python3.11/site-packages:/nix/store/lc0y6krlvr0qsppynhrk7zqamw63fbi0-python3.11-sqlparse-0.5.3/lib/python3.11/site-packages:/nix/store/k3azcgrqbl88l2rpw69ygmj3n2kymmzq-python3.11-pytz-2025.2/lib/python3.11/site-packages:/nix/store/g5psb5hhzazxnsz465bfgiwmlhz9b1n7-python3.11-tzdata-2025.2/lib/python3.11/site-packages" \
   DJANGO_SETTINGS_MODULE=tests.test_sqlite \
   python3 tests/runtests.py queries.test_db_returning --parallel=1
   ```
3. Observe the failure prior to this fix:
   ```
   FAIL: test_insert_uses_field_converters (queries.test_db_returning.ReturningLastInsertIdTests.test_insert_uses_field_converters)
   AssertionError: 1 is not an instance of <class 'queries.models.WrappedId'>
   ```

## Testing
- [x] PYTHONPATH="$PWD:$PWD/tests:/nix/store/hcm7w4jsaxwwdvhvyld5z1y2wzj0hri6-python3.11-asgiref-3.9.1/lib/python3.11/site-packages:/nix/store/lc0y6krlvr0qsppynhrk7zqamw63fbi0-python3.11-sqlparse-0.5.3/lib/python3.11/site-packages:/nix/store/k3azcgrqbl88l2rpw69ygmj3n2kymmzq-python3.11-pytz-2025.2/lib/python3.11/site-packages:/nix/store/g5psb5hhzazxnsz465bfgiwmlhz9b1n7-python3.11-tzdata-2025.2/lib/python3.11/site-packages" DJANGO_SETTINGS_MODULE=tests.test_sqlite python3 tests/runtests.py queries.test_db_returning --parallel=1
- [x] flake8 django/db/models/sql/compiler.py tests/queries/test_db_returning.py tests/queries/models.py